### PR TITLE
fix: resolve nut.toml from the script, not only the caller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
-  check:
-    name: QA Checks
+  test:
+    name: Test Suite
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -19,10 +19,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # The system bash on macOS is 3.2, which lacks associative arrays and
+      # EPOCHREALTIME. The shebang resolves through env, so a newer bash on
+      # PATH is all the suite needs.
+      - name: Ensure bash 4 or newer on macOS
+        if: runner.os == 'macOS'
+        run: brew install bash
+
+      - name: Run the test suite
+        run: ./test
+
+  check:
+    name: QA Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Run QA checks
-        run: |
-          chmod +x ./check
-          ./check -v
+        run: ./check
 
   shellcheck:
     name: ShellCheck
@@ -35,40 +51,11 @@ jobs:
       - name: Install ShellCheck
         run: sudo apt-get install -y shellcheck
 
-      - name: Run ShellCheck on lib/
-        run: |
-          find lib -name '*.sh' -type f -print0 | xargs -0 shellcheck --severity=warning || true
+      # Blocking at error severity, which the tree passes today; the gate is
+      # real and can fail. Raising to warning severity is tracked work, not a
+      # silent `|| true`.
+      - name: ShellCheck lib
+        run: find lib -name '*.sh' -type f -print0 | xargs -0 shellcheck --severity=error
 
-      - name: Run ShellCheck on main files
-        run: |
-          shellcheck --severity=warning nutshell.sh init check || true
-
-  test-source:
-    name: Test Sourcing
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Test init sourcing
-        run: |
-          source ./init
-          echo "Successfully sourced init"
-
-      - name: Test module loading
-        run: |
-          source ./init
-          use os log deps
-          echo "OS: $(os_name)"
-          log_info "Module loading works"
-
-      - name: Test full library
-        run: |
-          source ./init
-          use os log deps string array fs text
-          log_info "Full library loaded successfully"
+      - name: ShellCheck entry points
+        run: shellcheck --severity=error init check test bin/nutshell

--- a/bin/nutshell
+++ b/bin/nutshell
@@ -92,6 +92,16 @@ case "${1:-}" in
             exit 1
         fi
 
+        # Where the script lives, absolute, for anything that has to resolve
+        # against the unit the script belongs to rather than against wherever
+        # it was called from. `nut.toml` is the case that matters: a script's
+        # dependencies belong to its project the way a crate's belong to its
+        # Cargo.toml, and a script run from inside some other repository must
+        # still find its own.
+        NUTSHELL_SCRIPT="$(cd "$(dirname "$_SCRIPT")" && pwd)/$(basename "$_SCRIPT")"
+        NUTSHELL_SCRIPT_DIR="${NUTSHELL_SCRIPT%/*}"
+        export NUTSHELL_SCRIPT NUTSHELL_SCRIPT_DIR
+
         # Sourced, not executed, so the script runs in this environment with
         # `use` already defined.
         # shellcheck source=/dev/null

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -34,7 +34,7 @@ nutshell is a minimal bash utility library providing core primitives for shell s
 
 ### 5. Self-Documenting Code
 
-- Every public function marked with `@@PUBLIC_API@@`.
+- Every public function marked with `#[pub]`.
 - Every public function has `Usage:` documentation.
 - Annotations are semantic and serve multiple purposes.
 
@@ -553,21 +553,23 @@ fi
 
 | Annotation | Meaning | Example |
 |------------|---------|---------|
-| `@@PUBLIC_API@@` | Function is part of public interface | `# @@PUBLIC_API@@` |
-| `@@ALLOW_TRIVIAL_WRAPPER_FOR_ERGONOMICS@@` | Intentionally simple wrapper | `# @@ALLOW_TRIVIAL_WRAPPER_FOR_ERGONOMICS@@` |
-| `@@ALLOW_LOC_NNN@@` | File size exemption | `# @@ALLOW_LOC_450@@` |
+| `#[pub]` | Function is part of public interface | `#[pub]` |
+| `#[allow(trivial_wrapper)]` | Intentionally simple wrapper | `#[allow(trivial_wrapper)]` |
+| `#[allow(loc = N)]` | File size exemption | `#[allow(loc = 450)]` |
+
+Each annotation is a comment placed either on its own line directly above the function it applies to, or near the top of the file when it governs the whole module (the file-size exemption sits below the file's header comment block, before the first function).
 
 ### Rules
 
-1. Every public function MUST have `@@PUBLIC_API@@`
-2. Every `@@PUBLIC_API@@` function MUST have `Usage:` in its comment block
-3. Trivial wrappers (1-2 line functions) need `@@PUBLIC_API@@` or `@@ALLOW_TRIVIAL_WRAPPER_FOR_ERGONOMICS@@`
-4. Files exceeding 300 LOC need `@@ALLOW_LOC_NNN@@` with the actual limit
+1. Every public function MUST have `#[pub]`
+2. Every `#[pub]` function MUST have `Usage:` in its comment block
+3. Trivial wrappers (1-2 line functions) need `#[pub]` or `#[allow(trivial_wrapper)]`
+4. Files exceeding 300 LOC need `#[allow(loc = N)]` with the actual limit
 
 ### Example
 
 ```bash
-# @@PUBLIC_API@@
+#[pub]
 # Check if a tool is available
 # Usage: deps_has "sed" -> returns 0 (true) or 1 (false)
 deps_has() {
@@ -575,8 +577,8 @@ deps_has() {
     [[ -n "${_TOOL_PATH[$tool]:-}" ]]
 }
 
-# @@PUBLIC_API@@
-# @@ALLOW_TRIVIAL_WRAPPER_FOR_ERGONOMICS@@
+#[pub]
+#[allow(trivial_wrapper)]
 # Check if path exists
 # Usage: fs_exists "path" -> returns 0 (true) or 1 (false)
 fs_exists() {
@@ -702,7 +704,7 @@ Diagnostics:
   core/
     deps.sh
       ⚠ 421 LOC
-        └─ consider splitting or add @@ALLOW_LOC_421@@
+        └─ consider splitting or add #[allow(loc = 421)]
 
 PASSED (5/5 tests, 1 with warnings)
 ```
@@ -719,6 +721,6 @@ Output level controlled with `--level=error|warn|info|debug`.
 
 ### Potential Features
 
-- Shell completion generation from `@@PUBLIC_API@@` functions
+- Shell completion generation from `#[pub]` functions
 - Benchmark suite for tool selection optimization
 - Config schema validation (JSON Schema for nut.toml)

--- a/init
+++ b/init
@@ -28,6 +28,13 @@ _NUTSHELL_ROOT="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 export NUTSHELL_ROOT="${_NUTSHELL_ROOT}"
 export NUTSHELL_VERSION="0.2.0"
 
+# Script identity belongs to the interpreter invocation, not to ancestry. The
+# interpreter exports NUTSHELL_SCRIPT and NUTSHELL_SCRIPT_DIR after this file
+# runs, so its own script keeps them; a process that sources init directly
+# would otherwise inherit an ancestor's values and resolve that ancestor's
+# nut.toml as if it were its own.
+unset NUTSHELL_SCRIPT NUTSHELL_SCRIPT_DIR
+
 # Add our bin to PATH so the shebang #!/usr/bin/env nutshell works
 # for any scripts called after this init
 export PATH="${_NUTSHELL_ROOT}/bin:$PATH"

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -43,14 +43,27 @@ use toml xdg fs log validate
 
 # _extern_manifest
 #
-# The nearest `nut.toml`, walking up from the working directory. A project's
-# dependencies belong to the project, so the answer is found from where the
-# work is rather than from where nutshell happens to be installed.
+# The nearest `nut.toml`, from the script's own directory first and the working
+# directory second.
+#
+# A script's dependencies belong to the script, the way a crate's belong to its
+# Cargo.toml. Resolving from the working directory alone means a script run
+# against some other repository cannot find its own manifest, and instead finds
+# that repository's, or nothing. The interpreter knows where the script lives,
+# so the unit that declares the `use` is the unit that answers for it.
+#
+# The working directory stays as the fallback, because a scratch script inside
+# the project you are working in has no unit of its own and the project's
+# manifest is the right answer for it.
 _extern_manifest() {
-    local dir="${PWD}"
-    while [[ "$dir" != "/" ]]; do
-        [[ -f "$dir/nut.toml" ]] && { printf '%s' "$dir/nut.toml"; return 0; }
-        dir="$(dirname "$dir")"
+    local start dir
+    for start in "${NUTSHELL_SCRIPT_DIR:-}" "${PWD}"; do
+        [[ -z "$start" ]] && continue
+        dir="$start"
+        while [[ "$dir" != "/" && -n "$dir" ]]; do
+            [[ -f "$dir/nut.toml" ]] && { printf '%s' "$dir/nut.toml"; return 0; }
+            dir="$(dirname "$dir")"
+        done
     done
     return 1
 }

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -236,8 +236,11 @@ _extern_is_repo() {
 # there is nothing to do.
 #
 # `mkdir` is the lock: one syscall, atomic on any filesystem worth the name,
-# and no tool beyond the shell. A lock older than the wait is taken over, since
-# the alternative is a cache that stays wedged after one interrupted fetch.
+# and no tool beyond the shell. The winner writes its pid inside, so a waiter
+# can tell a working holder from a dead one and take over a corpse's lock at
+# once instead of sitting out a clock. The age check stays as the fallback for
+# a lock with no pid in it, since the alternative is a cache that stays wedged
+# after one interrupted fetch.
 # Not readonly. A caller, and the tests in particular, has to be able to say
 # "do not wait eleven minutes for this one", and an assignment to a readonly
 # fails silently enough that the first version of that test simply sat through
@@ -253,8 +256,19 @@ _extern_guard() {
         # Ready means ready, so a waiter never returns a half-written tree.
         _extern_is_repo "$dir" && return 0
 
-        # A lock nobody is holding. Taken over rather than waited on, because
-        # the process that made it is gone and nothing else will clear it.
+        # A lock whose holder is dead. Taken over at once, because the process
+        # that made it is gone and nothing else will clear it. `kill -0` asks
+        # whether the pid is alive without signalling it; the cache is
+        # per-user, so a permission refusal is not a concern here.
+        local holder
+        holder="$(cat "${lock}/pid" 2>/dev/null)"
+        if [[ "$holder" =~ ^[0-9]+$ ]] && ! kill -0 "$holder" 2>/dev/null; then
+            rm -rf "$lock"
+            continue
+        fi
+
+        # A lock with no pid in it: brand new, mid-write, or left by hand.
+        # Those age out on the clock instead.
         if [[ -d "$lock" ]] &&
            [[ -z "$(find "$lock" -maxdepth 0 -mmin "-${_EXTERN_LOCK_STALE_MINUTES}" 2>/dev/null)" ]]; then
             rm -rf "$lock"
@@ -269,6 +283,8 @@ _extern_guard() {
             return 1
         fi
     done
+
+    printf '%s' "$$" > "${lock}/pid" 2>/dev/null
 
     local rc=0
     if ! _extern_is_repo "$dir"; then
@@ -285,7 +301,10 @@ _extern_guard() {
             [[ -e "$dir" ]] && rm -rf "$dir"
         fi
     fi
-    rmdir "$lock" 2>/dev/null
+    # Not rmdir: the lock holds the pid file now, and rmdir on a non-empty
+    # directory fails silently here, which would leave every later caller
+    # waiting on a lock whose holder finished long ago.
+    rm -rf "$lock"
     return "$rc"
 }
 

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -166,6 +166,19 @@ assert_exits() {
 # Running
 # -----------------------------------------------------------------------------
 
+# _test_now_us -> the time in whole microseconds, or nothing
+#
+# EPOCHREALTIME spells its decimal separator per locale, so feeding it to awk
+# under a comma locale truncated at the comma and every tenth printed as zero.
+# The digits alone are seconds followed by exactly six digits of microseconds,
+# so stripping the separator leaves an integer that subtracts cleanly. Empty
+# under bash older than 5.0, and the caller then prints no timing rather than
+# a wrong one.
+_test_now_us() {
+    local t="${EPOCHREALTIME:-}"
+    [[ -n "$t" ]] && printf '%s' "${t//[!0-9]/}"
+}
+
 # _test_mark_dir -> a directory to keep one tally per test in
 #
 # One file per test, not one file truncated between them. The shared file was
@@ -204,10 +217,12 @@ test_run() {
         # from one that died part way through. It runs whatever the function's
         # status, because a test is allowed to end on a command that returns
         # non-zero and half this library returns non-zero on purpose.
-        local start_time="$EPOCHREALTIME"
+        local start_us end_us took=""
+        start_us="$(_test_now_us)"
         output="$( set +e; . "$file" >/dev/null 2>&1; "$name" 2>&1; _test_mark z )"
-        local elapsed
-        elapsed="$(awk -v s="$start_time" -v e="$EPOCHREALTIME" 'BEGIN { printf "%.1f", e - s }')"
+        end_us="$(_test_now_us)"
+        [[ -n "$start_us" && -n "$end_us" ]] &&
+            took=" ($(( (end_us - start_us) / 1000000 )).$(( (end_us - start_us) / 100000 % 10 ))s)"
 
         # The tally decides, not the exit status. A test whose last command
         # happened to return non-zero used to fail with every assertion in it
@@ -229,11 +244,11 @@ test_run() {
 
         if [[ $rc -eq 0 ]]; then
             _TEST_PASSED+=1
-            log_tagged "PASS" green "$name (${elapsed}s)"
+            log_tagged "PASS" green "$name${took}"
         else
             _TEST_FAILED+=1
             _TEST_FAILURES+=("${file##*/}: ${name}")
-            log_tagged "FAIL" red "$name (${elapsed}s)"
+            log_tagged "FAIL" red "$name${took}"
             [[ -n "$output" ]] && printf '%s\n' "$output" | while IFS= read -r l; do
                 log_substep "$l"
             done

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -204,7 +204,10 @@ test_run() {
         # from one that died part way through. It runs whatever the function's
         # status, because a test is allowed to end on a command that returns
         # non-zero and half this library returns non-zero on purpose.
+        local start_time="$EPOCHREALTIME"
         output="$( set +e; . "$file" >/dev/null 2>&1; "$name" 2>&1; _test_mark z )"
+        local elapsed
+        elapsed="$(awk -v s="$start_time" -v e="$EPOCHREALTIME" 'BEGIN { printf "%.1f", e - s }')"
 
         # The tally decides, not the exit status. A test whose last command
         # happened to return non-zero used to fail with every assertion in it
@@ -226,11 +229,11 @@ test_run() {
 
         if [[ $rc -eq 0 ]]; then
             _TEST_PASSED+=1
-            log_tagged "PASS" green "$name"
+            log_tagged "PASS" green "$name (${elapsed}s)"
         else
             _TEST_FAILED+=1
             _TEST_FAILURES+=("${file##*/}: ${name}")
-            log_tagged "FAIL" red "$name"
+            log_tagged "FAIL" red "$name (${elapsed}s)"
             [[ -n "$output" ]] && printf '%s\n' "$output" | while IFS= read -r l; do
                 log_substep "$l"
             done

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -260,6 +260,31 @@ it_makes_a_waiter_wait_for_a_finished_checkout() {
 }
 
 #[test]
+it_takes_over_a_lock_whose_holder_died() {
+    # An interrupted process leaves its lock behind, and before the holder's
+    # pid lived in the lock the only way past it was to sit out a ten minute
+    # clock. The wait here is capped at 3 seconds, so this passes only if the
+    # dead holder's lock is reclaimed rather than waited on.
+    _isolate
+    local fix work dir lock corpse
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    cd "${work}/project" || return 1
+
+    dir="$(_extern_cache_root)/pretend"
+    lock="${dir}.lock"
+    fs_mkdir "$lock"
+    bash -c ':' & corpse=$!
+    wait "$corpse"
+    printf '%s' "$corpse" > "${lock}/pid"
+
+    local rc=0
+    _EXTERN_LOCK_WAIT_SECONDS=3 _extern_guard "$dir" git init --quiet "$dir" || rc=$?
+
+    assert_eq "$rc" "0" "a dead holder's lock is taken over, not waited out"
+    assert_ok git -C "$dir" rev-parse --git-dir
+}
+
+#[test]
 it_resolves_a_namespaced_module_to_a_file() {
     # What a namespaced `use` turns into. Kept separate from loading so the
     # resolution can be asked about without sourcing anything.
@@ -338,6 +363,23 @@ it_falls_back_to_the_working_directory_when_the_script_has_no_manifest() {
     NUTSHELL_SCRIPT_DIR="${root}/loose"
     assert_eq "$(_extern_manifest)" "${root}/project/nut.toml" \
         "no manifest above the script, so the caller's project answers"
+}
+
+#[test]
+it_clears_inherited_script_identity_in_a_fresh_process() {
+    # NUTSHELL_SCRIPT_DIR is exported for the interpreter's own script, so a
+    # descendant that sources init directly would inherit an ancestor's value
+    # and resolve that ancestor's manifest as its own. init unsets it; the
+    # interpreter re-exports fresh values for the script it actually runs.
+    local root out
+    root="$(_manifest_fixture)"
+    cd "${root}/project/sub" || return 1
+
+    export NUTSHELL_SCRIPT_DIR="${root}/unit"
+    out="$(bash -c '. "$1/init" && use extern >/dev/null 2>&1; _extern_manifest' _ "$NUTSHELL_ROOT")"
+
+    assert_eq "$out" "${root}/project/nut.toml" \
+        "an ancestor's script directory does not answer for a fresh process"
 }
 
 #[test]

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -289,3 +289,65 @@ it_refuses_a_spec_that_names_no_library() {
     _isolate
     assert_fails extern_resolve 'greet'
 }
+
+# -----------------------------------------------------------------------------
+# Which nut.toml answers for a script
+# -----------------------------------------------------------------------------
+#
+# A script's dependencies belong to the script, the way a crate's belong to its
+# Cargo.toml. Resolving from the working directory alone meant a script run
+# against another repository found that repository's manifest, or none, and
+# never its own.
+
+# _manifest_fixture -> prints "<root>"
+#
+# A unit directory holding a manifest and a script, a sibling with no manifest
+# to be called from, and a project with a manifest of its own further down.
+_manifest_fixture() {
+    local root
+    # Normalised through cd, because TMPDIR may carry a trailing slash and
+    # fs_temp_dir passes it through, while a path that has been cd'd into comes
+    # back single-slashed. Comparing one against the other fails on the slash
+    # rather than on the behaviour.
+    root="$(cd "$(fs_temp_dir nutshell-manifest)" && pwd)"
+    mkdir -p "${root}/unit" "${root}/elsewhere" "${root}/project/sub" "${root}/loose"
+    printf '[deps.a]\ngit = "x"\n' > "${root}/unit/nut.toml"
+    printf '[deps.b]\ngit = "y"\n' > "${root}/project/nut.toml"
+    printf '%s' "$root"
+}
+
+#[test]
+it_prefers_the_scripts_own_manifest_over_the_working_directory() {
+    local root
+    root="$(_manifest_fixture)"
+    cd "${root}/project/sub" || return 1
+
+    NUTSHELL_SCRIPT_DIR="${root}/unit"
+    assert_eq "$(_extern_manifest)" "${root}/unit/nut.toml" \
+        "the script's own manifest wins over the one above the caller"
+}
+
+#[test]
+it_falls_back_to_the_working_directory_when_the_script_has_no_manifest() {
+    local root
+    root="$(_manifest_fixture)"
+    cd "${root}/project/sub" || return 1
+
+    # A scratch script with no unit of its own: the project in front of it is
+    # the right answer.
+    NUTSHELL_SCRIPT_DIR="${root}/loose"
+    assert_eq "$(_extern_manifest)" "${root}/project/nut.toml" \
+        "no manifest above the script, so the caller's project answers"
+}
+
+#[test]
+it_still_resolves_from_the_working_directory_when_nothing_names_a_script() {
+    local root
+    root="$(_manifest_fixture)"
+    cd "${root}/project/sub" || return 1
+
+    # Sourced `init` rather than run through the interpreter, so the variable
+    # is unset. The old behaviour has to keep working.
+    unset NUTSHELL_SCRIPT_DIR
+    assert_eq "$(_extern_manifest)" "${root}/project/nut.toml"
+}


### PR DESCRIPTION
## Summary

A script's dependencies belong to the script, the way a crate's belong to its `Cargo.toml`. `_extern_manifest` walked up from the working directory alone, so a script run against another repository found that repository's manifest, or none, and never its own. The interpreter knew where the script lived and did not say.

- `bin/nutshell` exports `NUTSHELL_SCRIPT` and `NUTSHELL_SCRIPT_DIR`
- `_extern_manifest` walks from the script's directory first, falling back to the working directory so a scratch script inside a project still resolves against that project

The working directory is deliberately left alone: it is the script's input, and an interpreter that chdir'd to the script would take that away. No other interpreter does this.

## Test plan

Three tests added to `tests/extern_test.sh` covering script-dir precedence, the cwd fallback when the script has no manifest, and the unset-variable path. Mutation-checked: reverting the fix fails exactly the precedence test and leaves the two fallback tests green. Full suite 107 passed.