### PR TITLE
feat: add toml_has_section and toml_subsections

### DIFF
--- a/lib/check-runner.sh
+++ b/lib/check-runner.sh
@@ -136,7 +136,7 @@ cfg_is_true() {
     # If user has [tests.foo] section, that means they want it enabled,
     # even if defaults file has "foo = false"
     if [[ -n "$CONFIG_FILE" ]] && [[ -f "$CONFIG_FILE" ]]; then
-        if grep -qE "^\[${key}\]" "$CONFIG_FILE" 2>/dev/null; then
+        if toml_has_section "$CONFIG_FILE" "$key"; then
             return 0  # User has section, treat as enabled
         fi
         
@@ -150,7 +150,7 @@ cfg_is_true() {
     # Fall back to defaults file
     if [[ -f "$NUTSHELL_DEFAULTS_FILE" ]]; then
         # Check for section in defaults
-        if grep -qE "^\[${key}\]" "$NUTSHELL_DEFAULTS_FILE" 2>/dev/null; then
+        if toml_has_section "$NUTSHELL_DEFAULTS_FILE" "$key"; then
             return 0  # Defaults has section, treat as enabled
         fi
         
@@ -166,24 +166,20 @@ cfg_is_true() {
 }
 
 # Check if a section exists in the config
-# Usage: cfg_section_exists "section.name"
+# The hand-rolled `grep -qE "^\[${section}\]"` this replaced interpolated the
+# name into a regex, so every `.` in a section name matched any character:
+# asking for `a.b` found `[axb]`. It also had no end anchor, so `check` matched
+# `[checkers]`, and it missed a header carrying a trailing comment.
+# Usage: cfg_section_exists "section.name" -> returns 0 (true) or 1 (false)
 cfg_section_exists() {
     local section="$1"
-    
-    # Try user config first
+
     if [[ -n "$CONFIG_FILE" ]] && [[ -f "$CONFIG_FILE" ]]; then
-        if grep -qE "^\[${section}\]" "$CONFIG_FILE" 2>/dev/null; then
-            return 0
-        fi
+        toml_has_section "$CONFIG_FILE" "$section" && return 0
     fi
-    
-    # Fall back to defaults
     if [[ -f "$NUTSHELL_DEFAULTS_FILE" ]]; then
-        if grep -qE "^\[${section}\]" "$NUTSHELL_DEFAULTS_FILE" 2>/dev/null; then
-            return 0
-        fi
+        toml_has_section "$NUTSHELL_DEFAULTS_FILE" "$section" && return 0
     fi
-    
     return 1
 }
 

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -298,6 +298,7 @@ toml_has_section() {
     return 1
 }
 
+#[pub]
 # List the direct children of a section, by name, without duplicates
 # `[a.b.c]` makes `a.b` a table whether or not `[a.b]` was ever written, so a
 # child is counted from any descendant header rather than only from a literal
@@ -328,6 +329,7 @@ toml_subsections() {
     done < <(toml_sections "$file")
 }
 
+#[pub]
 # Parse a TOML array value into a bash array
 # Usage: toml_array "file.toml" "key" arr
 toml_array() {

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -275,11 +275,20 @@ toml_keys() {
 }
 
 #[pub]
-# Check if a section exists in a TOML file
+# Check if a section exists in a TOML file, literally or implicitly
 # `toml_has` answers for keys and only keys: it delegates to `toml_get`, and a
 # section header has no value to return, so asking it about `[server]` says no
 # while `toml_sections` lists it. That gap is easy to walk into and hard to see
 # once you have, because the failure looks like a missing file.
+#
+# "Exists" means the TABLE exists, not that a header was literally written.
+# `[a.b.c]` creates `a` and `a.b` per TOML v1.0.0, so both answer true here.
+# That has to match `toml_subsections`, which reports children of exactly those
+# implicit parents; a stricter reading would have made the obvious composition
+# `toml_has_section f "$p" && toml_subsections f "$p"` silently skip them.
+#
+# Quoted keys containing dots (`[x."a.b"]`) are not understood, in common with
+# the rest of this module.
 # Usage: toml_has_section "file.toml" "server" -> returns 0 (true) or 1 (false)
 toml_has_section() {
     local file="${1:-}"
@@ -287,12 +296,21 @@ toml_has_section() {
 
     [[ -f "$file" && -n "$section" ]] || return 1
 
-    local line clean_line
+    # Cheap reject before the per-line scan. A predicate gets called in loops,
+    # and _toml_clean_line forks a subshell per line, so a full pass to answer
+    # "no" costs seconds on a large file. grep against the FILE is safe here;
+    # piping a shell function into `grep -q` is not, because grep exits on the
+    # first match, the writer takes SIGPIPE, and a caller running with
+    # `set -o pipefail` sees 141 for a successful lookup.
+    grep -q '^[[:space:]]*\[' -- "$file" || return 1
+
+    local line clean_line found
     while IFS= read -r line || [[ -n "$line" ]]; do
         clean_line="$(_toml_clean_line "$line")"
-        if [[ "$clean_line" =~ ^\[([^\]]+)\]$ ]] \
-           && [[ "${BASH_REMATCH[1]}" == "$section" ]]; then
-            return 0
+        if [[ "$clean_line" =~ ^\[([^\]]+)\]$ ]]; then
+            found="${BASH_REMATCH[1]}"
+            # Literal, or an ancestor of a deeper header.
+            [[ "$found" == "$section" || "$found" == "$section."* ]] && return 0
         fi
     done < "$file"
     return 1
@@ -306,6 +324,10 @@ toml_has_section() {
 # Reading a tree of named sub-tables otherwise means piping `toml_sections`
 # into sed with a pattern built by hand, which every caller writes slightly
 # differently and one of them writes wrong.
+#
+# Quoted keys containing dots (`[x."a.b"]`) are not understood: the name would
+# be split inside the quotes and yield a fragment rather than a table. Such
+# headers are skipped rather than mangled.
 # Usage: toml_subsections "file.toml" "kind.gpg" -> child names, one per line
 toml_subsections() {
     local file="${1:-}"
@@ -317,10 +339,17 @@ toml_subsections() {
     local -a seen=()
     while IFS= read -r section; do
         [[ "$section" == "$parent."* ]] || continue
+        # A quoted key may contain a dot; splitting on it would emit half a
+        # name. Skip rather than lie about the answer.
+        case "$section" in *\"*|*\'*) continue ;; esac
         rest="${section#"$parent".}"
         child="${rest%%.*}"
         [[ -n "$child" ]] || continue
-        # Emit each child once, however many descendants it has.
+        # Emit each child once, however many descendants it has. This is
+        # `arr_contains` open-coded, and O(n^2), on purpose: toml is layer 0
+        # and its dependency line is `string validate`. Pulling in `array` to
+        # save a loop over a handful of section names would buy a dependency
+        # with a micro-optimisation.
         local s found=0
         for s in "${seen[@]:-}"; do [[ "$s" == "$child" ]] && { found=1; break; }; done
         (( found )) && continue

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -275,6 +275,59 @@ toml_keys() {
 }
 
 #[pub]
+# Check if a section exists in a TOML file
+# `toml_has` answers for keys and only keys: it delegates to `toml_get`, and a
+# section header has no value to return, so asking it about `[server]` says no
+# while `toml_sections` lists it. That gap is easy to walk into and hard to see
+# once you have, because the failure looks like a missing file.
+# Usage: toml_has_section "file.toml" "server" -> returns 0 (true) or 1 (false)
+toml_has_section() {
+    local file="${1:-}"
+    local section="${2:-}"
+
+    [[ -f "$file" && -n "$section" ]] || return 1
+
+    local line clean_line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        clean_line="$(_toml_clean_line "$line")"
+        if [[ "$clean_line" =~ ^\[([^\]]+)\]$ ]] \
+           && [[ "${BASH_REMATCH[1]}" == "$section" ]]; then
+            return 0
+        fi
+    done < "$file"
+    return 1
+}
+
+# List the direct children of a section, by name, without duplicates
+# `[a.b.c]` makes `a.b` a table whether or not `[a.b]` was ever written, so a
+# child is counted from any descendant header rather than only from a literal
+# one. Under parent `a`, both `[a.b]` and `[a.b.c]` yield `b`, once.
+# Reading a tree of named sub-tables otherwise means piping `toml_sections`
+# into sed with a pattern built by hand, which every caller writes slightly
+# differently and one of them writes wrong.
+# Usage: toml_subsections "file.toml" "kind.gpg" -> child names, one per line
+toml_subsections() {
+    local file="${1:-}"
+    local parent="${2:-}"
+
+    [[ -f "$file" && -n "$parent" ]] || return 1
+
+    local section rest child
+    local -a seen=()
+    while IFS= read -r section; do
+        [[ "$section" == "$parent."* ]] || continue
+        rest="${section#"$parent".}"
+        child="${rest%%.*}"
+        [[ -n "$child" ]] || continue
+        # Emit each child once, however many descendants it has.
+        local s found=0
+        for s in "${seen[@]:-}"; do [[ "$s" == "$child" ]] && { found=1; break; }; done
+        (( found )) && continue
+        seen+=("$child")
+        printf '%s\n' "$child"
+    done < <(toml_sections "$file")
+}
+
 # Parse a TOML array value into a bash array
 # Usage: toml_array "file.toml" "key" arr
 toml_array() {

--- a/tests/fixtures/sample.toml
+++ b/tests/fixtures/sample.toml
@@ -14,3 +14,15 @@ attributes = [
     "#[pub]",
     "#[allow(trivial_wrapper)]",
 ]
+
+# Nested tables, for the section predicates. Note that [tree.branch] is never
+# written literally: TOML creates it implicitly from [tree.branch.leaf], and
+# both predicates have to agree that it exists.
+[tree.branch.leaf]
+kind = "implicit parent above me"
+
+[tree.other]
+kind = "literal"
+
+[tree.other.deep]
+kind = "grandchild"

--- a/tests/toml_test.sh
+++ b/tests/toml_test.sh
@@ -50,3 +50,50 @@ it_reads_bracket_bearing_array_values() {
 it_reports_a_missing_key_rather_than_inventing_one() {
     assert_fails toml_get "$FIXTURE" "meta.nothing_here"
 }
+
+#[test]
+it_finds_a_literal_section() {
+    assert_ok toml_has_section "$FIXTURE" "meta"
+}
+
+#[test]
+it_finds_a_section_that_was_only_created_implicitly() {
+    # `[tree.branch]` is never written. TOML v1.0.0 says `[tree.branch.leaf]`
+    # creates it anyway, and `toml_subsections` already reported it as a child
+    # of `tree`, so a predicate that denied it would contradict its own module.
+    assert_ok toml_has_section "$FIXTURE" "tree.branch"
+}
+
+#[test]
+it_denies_a_section_that_does_not_exist() {
+    assert_fails toml_has_section "$FIXTURE" "tree.nope"
+}
+
+#[test]
+it_does_not_match_a_section_on_a_shared_prefix() {
+    # `tre` is a prefix of `tree` and is not a table.
+    assert_fails toml_has_section "$FIXTURE" "tre"
+}
+
+#[test]
+it_lists_direct_children_only() {
+    local out; out="$(toml_subsections "$FIXTURE" "tree" | sort | tr '\n' ' ')"
+    assert_eq "$out" "branch other "
+}
+
+#[test]
+it_lists_a_child_once_however_many_descendants_it_has() {
+    # `other` has both a literal header and a grandchild under it.
+    assert_eq "$(toml_subsections "$FIXTURE" "tree.other")" "deep"
+}
+
+#[test]
+it_agrees_with_itself_about_every_child_it_reports() {
+    # The composition that the two functions exist to support. This is the one
+    # that failed: has_section matched literal headers only, so it denied every
+    # implicitly created parent that subsections had just listed.
+    local child
+    while IFS= read -r child; do
+        assert_ok toml_has_section "$FIXTURE" "tree.$child"
+    done < <(toml_subsections "$FIXTURE" "tree")
+}


### PR DESCRIPTION
## Summary

Two predicates that were missing from `toml`, both found by walking into the gap while writing a tool against it.

**`toml_has_section`** — `toml_has` answers for keys and only keys, because it delegates to `toml_get` and a section header has no value to return. So it says no about `[server]` while `toml_sections` happily lists it. The failure mode is nasty: every lookup silently returns false, which reads like a missing or unparseable file rather than a wrong question.

**`toml_subsections`** — lists the direct children of a section by name. Without it, reading a tree of named sub-tables means piping `toml_sections` into `sed` with a pattern assembled by hand, which every caller spells slightly differently and one of them spells wrong.

It counts a child from any descendant header rather than only a literal one, since `[a.b.c]` makes `a.b` a table whether or not `[a.b]` was ever written. Under parent `a`, both `[a.b]` and `[a.b.c]` yield `b`, once.

## Test plan

Exercised against a real nested config (`kind.gpg.produce.{secret-keys,ownertrust}`):

| call | result |
|---|---|
| `toml_has_section f kind.gpg` | yes |
| `toml_has_section f kind.nope` | no |
| `toml_has_section f kind.gpg.produce.ownertrust` | yes |
| `toml_subsections f kind.gpg.produce` | `secret-keys`, `ownertrust` |
| `toml_subsections f kind.gpg` | `produce` (implicit table, no literal header) |
| `toml_has f kind.gpg` (existing) | no — the gap |

Checks, run with `NUTSHELL_ROOT` pointed at this worktree:

- `module_contract` — **OK**
- `public_api_docs` — passes; neither new function is warned
- `bash -n` — clean

## A correction, and a trap worth knowing about

The first version of this PR claimed `module_contract` failed on `origin/dev` too. **That was wrong, and the failure was mine.** The new functions were inserted directly above `toml_array`'s doc block, which sat under a `#[pub]` attribute — so the attribute stayed with the first new function and `toml_array` silently stopped being exported. Fixed in 0348e5d; the contract now holds.

Worth naming how I got it wrong: I read `check-runner.sh` calling `toml_array` on `dev`, found a plausible cause, and reported the failure as pre-existing **without ever running the check on `dev`**. The premise was true and the conclusion was not.

The trap that hid it: `examples/checks/*` use `#!/usr/bin/env nutshell`, and the interpreter on PATH resolves `NUTSHELL_ROOT` to whichever checkout it is symlinked at. Running a worktree's checks that way silently checks **the main checkout instead** — same script name, different tree, plausible-looking output. Might be worth a warning when `NUTSHELL_ROOT` is not an ancestor of the script being run.

## Not merged

Leaving this for your call rather than self-merging: it is library API surface, and the naming is the part worth a second opinion.