### PR TITLE
feat: engine pinning via nut.toml

### DIFF
--- a/bin/nutshell
+++ b/bin/nutshell
@@ -43,6 +43,108 @@ _SELF="$(_resolve_path "${BASH_SOURCE[0]}")"
 _NUTSHELL_BIN_DIR="$(cd "$(dirname "$_SELF")" && pwd)"
 _NUTSHELL_HOME="$(cd "${_NUTSHELL_BIN_DIR}/.." && pwd)"
 
+# =============================================================================
+# The engine pin
+# =============================================================================
+# A project says which nutshell it wants, in its own nut.toml, as a root-level
+# scalar. Same shape mockspace.toml uses for the same job, because it is the
+# same job and a reader should not have to learn two spellings:
+#
+#     nutshell_version = "0.3.0"     the released form
+#     nutshell_branch  = "dev"       when there is no release yet
+#
+# Root level, before any [table] header. A bare key written after one belongs
+# to that table, which is a quiet way to have a pin that is never read.
+#
+# Unpinned projects are untouched: they get the checkout the shebang resolved
+# to, exactly as before. A pin is resolved to a worktree under the cache and
+# this interpreter re-execs into that copy, so a script gets the library it
+# asked for rather than whichever checkout happens to be on PATH today.
+#
+# Reading the pin happens before `init`, so it cannot use `toml`. A root-level
+# scalar is a line, and a line is a grep. Anything more would be a parser
+# running before the module that exists to parse.
+
+_nut_manifest() {
+    # A script's dependencies belong to its project, so search upward from the
+    # script rather than from the caller's cwd.
+    local dir="$1"
+    while [[ -n "$dir" && "$dir" != "/" ]]; do
+        [[ -f "$dir/nut.toml" ]] && { printf '%s' "$dir/nut.toml"; return 0; }
+        dir="${dir%/*}"
+    done
+    return 1
+}
+
+_nut_pin() {
+    # Root-level scalars only: stop at the first [table] header.
+    local file="$1" key="$2" line
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*\[ ]] && return 1
+        if [[ "$line" =~ ^[[:space:]]*"$key"[[:space:]]*=[[:space:]]*\"([^\"]*)\" ]]; then
+            printf '%s' "${BASH_REMATCH[1]}"
+            return 0
+        fi
+    done < "$file"
+    return 1
+}
+
+# A checkout at the pinned ref, created under the cache if absent and refreshed
+# when stale. Never touches the user's own checkout.
+_nut_worktree() {
+    local ref="$1" repo="$2"
+    local cache="${XDG_CACHE_HOME:-$HOME/.cache}/nutshell/refs"
+    local dir="$cache/${ref//[^A-Za-z0-9._-]/_}"
+    local ttl="${NUTSHELL_PIN_TTL:-3600}"
+
+    if [[ ! -d "$dir/.git" && ! -f "$dir/.git" ]]; then
+        mkdir -p "$cache" || return 1
+        echo "nutshell: pinned to '$ref', creating $dir" >&2
+        git -C "$repo" fetch -q origin "$ref" 2>/dev/null
+        git -C "$repo" worktree add -q --detach "$dir" \
+            "$(git -C "$repo" rev-parse --verify -q "origin/$ref" \
+               || git -C "$repo" rev-parse --verify -q "$ref")" 2>/dev/null || {
+            echo "nutshell: cannot check out '$ref'; using $repo" >&2
+            return 1
+        }
+    else
+        # Re-resolve the head periodically rather than on every invocation, so
+        # a pinned branch tracks without a fetch per script run.
+        local stamp="$dir/.nutshell-fetched" now age
+        now="$(date +%s)"
+        age="$ttl"
+        [[ -f "$stamp" ]] && age=$(( now - $(cat "$stamp" 2>/dev/null || echo 0) ))
+        if (( age >= ttl )); then
+            if git -C "$repo" fetch -q origin "$ref" 2>/dev/null; then
+                git -C "$dir" reset -q --hard FETCH_HEAD 2>/dev/null
+            fi
+            printf '%s' "$now" > "$stamp" 2>/dev/null
+        fi
+    fi
+    [[ -x "$dir/bin/nutshell" ]] || return 1
+    printf '%s' "$dir"
+}
+
+# Resolve once. The re-exec'd interpreter must not try again, or a pin that
+# cannot be satisfied becomes a loop rather than a warning.
+if [[ -z "${NUTSHELL_PIN_RESOLVED:-}" && -f "${1:-}" ]]; then
+    export NUTSHELL_PIN_RESOLVED=1
+    _script_dir="$(cd "$(dirname "$1")" && pwd)"
+    if _manifest="$(_nut_manifest "$_script_dir")"; then
+        _ref=""
+        _ref="$(_nut_pin "$_manifest" nutshell_branch)" ||
+            _ref="$(_nut_pin "$_manifest" nutshell_version)" || _ref=""
+        if [[ -n "$_ref" ]] && git -C "$_NUTSHELL_HOME" rev-parse --git-dir >/dev/null 2>&1; then
+            _at="$(git -C "$_NUTSHELL_HOME" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+            if [[ "$_at" != "$_ref" ]]; then
+                if _pinned="$(_nut_worktree "$_ref" "$_NUTSHELL_HOME")"; then
+                    exec "$_pinned/bin/nutshell" "$@"
+                fi
+            fi
+        fi
+    fi
+fi
+
 # shellcheck source=/dev/null
 source "${_NUTSHELL_HOME}/init" || {
     echo "nutshell: cannot load ${_NUTSHELL_HOME}/init" >&2
@@ -69,6 +171,11 @@ Available modules:
 For more information: https://github.com/orgrinrt/nutshell
 EOF
 }
+
+# Sourced rather than run: define the helpers and stop. Without this the CLI
+# dispatch below fires during a source and exits the caller, which is why the
+# pin parser had no test until it had this.
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0
 
 case "${1:-}" in
     --help|-h)

--- a/bin/nutshell
+++ b/bin/nutshell
@@ -43,6 +43,18 @@ _SELF="$(_resolve_path "${BASH_SOURCE[0]}")"
 _NUTSHELL_BIN_DIR="$(cd "$(dirname "$_SELF")" && pwd)"
 _NUTSHELL_HOME="$(cd "${_NUTSHELL_BIN_DIR}/.." && pwd)"
 
+# shellcheck source=/dev/null
+source "${_NUTSHELL_HOME}/init" || {
+    echo "nutshell: cannot load ${_NUTSHELL_HOME}/init" >&2
+    exit 1
+}
+
+# Before the pin block, so the pin can use the modules that already solve
+# caching rather than growing a fourth copy of them. Costs one redundant init
+# in the pinned case, since the exec re-runs it in the pinned copy.
+use extern log
+
+
 # =============================================================================
 # The engine pin
 # =============================================================================

--- a/bin/nutshell
+++ b/bin/nutshell
@@ -57,31 +57,64 @@ _NUTSHELL_HOME="$(cd "${_NUTSHELL_BIN_DIR}/.." && pwd)"
 # to that table, which is a quiet way to have a pin that is never read.
 #
 # Unpinned projects are untouched: they get the checkout the shebang resolved
-# to, exactly as before. A pin is resolved to a worktree under the cache and
-# this interpreter re-execs into that copy, so a script gets the library it
-# asked for rather than whichever checkout happens to be on PATH today.
+# to, exactly as before.
 #
-# Reading the pin happens before `init`, so it cannot use `toml`. A root-level
-# scalar is a line, and a line is a grep. Anything more would be a parser
-# running before the module that exists to parse.
+# ## Built on extern, deliberately
+#
+# The first version of this grew its own cache: a git worktree hosted inside
+# the user's own repository, keyed by a sanitised ref name, readiness tested by
+# whether a directory existed, refreshed against a stamp file. Review found
+# twenty-one defects in it and `lib/extern.sh` already had the correct answer
+# to every structural one, having been through the same mistakes first. Its
+# comments say so: "Readiness is `_extern_is_repo`, never existence."
+#
+# So the cache here is `_extern_mirror`: a keyed clone under the cache root,
+# laid out once behind `_extern_guard`'s lock, its key hashed so that
+# `test/slash` and `test_slash` cannot collide. Nothing is written into the
+# user's repository at all, which the worktree approach could not honestly
+# claim: it left registrations behind and clobbered their FETCH_HEAD.
+#
+# A mirror also fixes the defect that made the old version pointless. Refresh
+# fetched in the user's repo and reset in the worktree, and FETCH_HEAD is
+# per-worktree, so the reset always failed into /dev/null and a branch pin was
+# frozen at whatever it was the day the cache was created. In a mirror the
+# fetch and the reset are the same repository, so the operation means what it
+# reads as.
+#
+# Staleness is the mtime of the mirror's FETCH_HEAD, not a stamp file we
+# maintain. It is the same fact, git already keeps it, and a file we do not
+# write cannot be half-written.
 
+_NUT_PIN_TTL="${NUTSHELL_PIN_TTL:-3600}"
+
+# A project's manifest, searched upward from the script.
+#
+# Bounded at a repository boundary or $HOME, whichever comes first. The
+# unbounded walk reached /tmp on macOS, where anyone can plant a nut.toml and
+# silently choose which engine another user's scripts run.
 _nut_manifest() {
-    # A script's dependencies belong to its project, so search upward from the
-    # script rather than from the caller's cwd.
     local dir="$1"
     while [[ -n "$dir" && "$dir" != "/" ]]; do
         [[ -f "$dir/nut.toml" ]] && { printf '%s' "$dir/nut.toml"; return 0; }
+        [[ -e "$dir/.git" ]] && return 1
+        [[ "$dir" == "$HOME" ]] && return 1
         dir="${dir%/*}"
     done
     return 1
 }
 
+# A root-level scalar, stopping at the first [table] header.
+#
+# Success means a non-empty value. An empty one used to return 0 and short
+# circuit the version fallback, so a file with a broken branch line and a good
+# version line resolved to no pin at all.
 _nut_pin() {
-    # Root-level scalars only: stop at the first [table] header.
     local file="$1" key="$2" line
-    while IFS= read -r line; do
+    # `|| [[ -n "$line" ]]` so a final line with no trailing newline is read.
+    while IFS= read -r line || [[ -n "$line" ]]; do
         [[ "$line" =~ ^[[:space:]]*\[ ]] && return 1
         if [[ "$line" =~ ^[[:space:]]*"$key"[[:space:]]*=[[:space:]]*\"([^\"]*)\" ]]; then
+            [[ -n "${BASH_REMATCH[1]}" ]] || return 1
             printf '%s' "${BASH_REMATCH[1]}"
             return 0
         fi
@@ -89,67 +122,133 @@ _nut_pin() {
     return 1
 }
 
-# A checkout at the pinned ref, created under the cache if absent and refreshed
-# when stale. Never touches the user's own checkout.
-_nut_worktree() {
-    local ref="$1" repo="$2"
-    local cache="${XDG_CACHE_HOME:-$HOME/.cache}/nutshell/refs"
-    local dir="$cache/${ref//[^A-Za-z0-9._-]/_}"
-    local ttl="${NUTSHELL_PIN_TTL:-3600}"
+# A ref safe to hand to git.
+#
+# The old version passed it positionally with no `--`, so a ref beginning with
+# a dash was parsed as an option: `--upload-pack=touch /tmp/pwned` executed
+# against a path or file:// remote. Validated rather than escaped, because the
+# set of legitimate ref names is small and known.
+_nut_ref_ok() {
+    [[ "$1" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]] || return 1
+    git check-ref-format --allow-onelevel "$1" 2>/dev/null
+}
 
-    if [[ ! -d "$dir/.git" && ! -f "$dir/.git" ]]; then
-        mkdir -p "$cache" || return 1
-        echo "nutshell: pinned to '$ref', creating $dir" >&2
-        git -C "$repo" fetch -q origin "$ref" 2>/dev/null
-        git -C "$repo" worktree add -q --detach "$dir" \
-            "$(git -C "$repo" rev-parse --verify -q "origin/$ref" \
-               || git -C "$repo" rev-parse --verify -q "$ref")" 2>/dev/null || {
-            echo "nutshell: cannot check out '$ref'; using $repo" >&2
-            return 1
-        }
-    else
-        # Re-resolve the head periodically rather than on every invocation, so
-        # a pinned branch tracks without a fetch per script run.
-        local stamp="$dir/.nutshell-fetched" now age
-        now="$(date +%s)"
-        age="$ttl"
-        [[ -f "$stamp" ]] && age=$(( now - $(cat "$stamp" 2>/dev/null || echo 0) ))
-        if (( age >= ttl )); then
-            if git -C "$repo" fetch -q origin "$ref" 2>/dev/null; then
-                git -C "$dir" reset -q --hard FETCH_HEAD 2>/dev/null
-            fi
-            printf '%s' "$now" > "$stamp" 2>/dev/null
+# Seconds since the mirror last fetched, or the TTL when it cannot be told.
+_nut_age() {
+    local dir="$1" head="$1/.git/FETCH_HEAD" t now
+    [[ -f "$head" ]] || { printf '%s' "$_NUT_PIN_TTL"; return 0; }
+    t="$(stat -f %m "$head" 2>/dev/null || stat -c %Y "$head" 2>/dev/null)" || {
+        printf '%s' "$_NUT_PIN_TTL"; return 0; }
+    now="$(date +%s)"
+    # A clock that moved backwards gives a negative age, which would park the
+    # mirror until wall-clock caught up. Treat it as due.
+    (( t > now )) && { printf '%s' "$_NUT_PIN_TTL"; return 0; }
+    printf '%s' "$(( now - t ))"
+}
+
+_nut_pinned_root() {
+    local ref="$1" url="$2" dir age
+    dir="$(_extern_mirror nutshell "$url" "$ref")" || return 1
+    age="$(_nut_age "$dir")"
+    if (( age >= _NUT_PIN_TTL )); then
+        # One repository, so the fetch and the reset refer to the same thing.
+        if git -C "$dir" fetch --quiet --depth 1 origin "$ref" 2>/dev/null; then
+            git -C "$dir" reset --quiet --hard FETCH_HEAD 2>/dev/null ||
+                log_warn "nutshell: pinned mirror could not advance to ${ref}"
         fi
     fi
-    [[ -x "$dir/bin/nutshell" ]] || return 1
+    [[ -x "$dir/bin/nutshell" ]] || {
+        log_error "nutshell: ${dir} holds no bin/nutshell; pin '${ref}' unusable"
+        return 1
+    }
     printf '%s' "$dir"
 }
 
-# Resolve once. The re-exec'd interpreter must not try again, or a pin that
-# cannot be satisfied becomes a loop rather than a warning.
-if [[ -z "${NUTSHELL_PIN_RESOLVED:-}" && -f "${1:-}" ]]; then
-    export NUTSHELL_PIN_RESOLVED=1
-    _script_dir="$(cd "$(dirname "$1")" && pwd)"
-    if _manifest="$(_nut_manifest "$_script_dir")"; then
-        _ref=""
-        _ref="$(_nut_pin "$_manifest" nutshell_branch)" ||
-            _ref="$(_nut_pin "$_manifest" nutshell_version)" || _ref=""
-        if [[ -n "$_ref" ]] && git -C "$_NUTSHELL_HOME" rev-parse --git-dir >/dev/null 2>&1; then
-            _at="$(git -C "$_NUTSHELL_HOME" rev-parse --abbrev-ref HEAD 2>/dev/null)"
-            if [[ "$_at" != "$_ref" ]]; then
-                if _pinned="$(_nut_worktree "$_ref" "$_NUTSHELL_HOME")"; then
-                    exec "$_pinned/bin/nutshell" "$@"
-                fi
-            fi
+# The origin a pin resolves against: the installed checkout's remote when it
+# has one, else the checkout itself.
+#
+# Confirmed to be nutshell rather than assumed. A vendored copy sitting inside
+# an unrelated repository used to be treated as the nutshell repo, and checked
+# that project's own `dev` branch out into the nutshell cache.
+_nut_origin() {
+    local home="$1" url
+    _extern_is_repo "$home" || return 1
+    [[ -f "$home/init" && -d "$home/lib" ]] || return 1
+    url="$(git -C "$home" remote get-url origin 2>/dev/null)" || url=""
+    printf '%s' "${url:-$home}"
+}
+
+# Whether a pin is declared at all, which is a different question from whether
+# it resolves. Only the second is an error worth failing on.
+_nut_declared() {
+    local dir manifest
+    dir="$(cd "$(dirname "$1")" && pwd)" || return 1
+    manifest="$(_nut_manifest "$dir")" || return 1
+    _nut_pin "$manifest" nutshell_branch >/dev/null && return 0
+    _nut_pin "$manifest" nutshell_version >/dev/null
+}
+
+_nut_resolve_pin() {
+    local script="$1" dir manifest ref url root
+    dir="$(cd "$(dirname "$script")" && pwd)" || return 1
+    manifest="$(_nut_manifest "$dir")" || return 1
+
+    ref="$(_nut_pin "$manifest" nutshell_branch)" ||
+        ref="$(_nut_pin "$manifest" nutshell_version)" || return 1
+
+    _nut_ref_ok "$ref" || {
+        log_error "nutshell: '${ref}' in ${manifest} is not a usable git ref"
+        return 1
+    }
+    url="$(_nut_origin "$_NUTSHELL_HOME")" || {
+        log_warn "nutshell: ${_NUTSHELL_HOME} is not a nutshell git checkout, so the pin in ${manifest} cannot be honoured"
+        return 1
+    }
+    root="$(_nut_pinned_root "$ref" "$url")" || return 1
+    printf '%s' "$root"
+}
+
+# Sourced rather than run: the helpers above are defined, and nothing below
+# happens.
+#
+# Position is the whole point and it has been wrong in both directions. Below
+# the pin block, `source bin/nutshell` ran full pin resolution against the
+# sourcing shell's $1 and could exec the caller away, and this file's own tests
+# were that shape, passing only because nutshell's nut.toml carries no pin.
+# Above the definitions, sourcing returned before defining anything, so the
+# tests could not reach the functions at all. It belongs exactly here: after
+# everything a caller might want, before everything that acts.
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0
+
+# Resolve once, and identify what was resolved rather than that anything was.
+#
+# The old marker was a bare exported flag, set before it was known whether an
+# exec would happen and set even for unpinned projects. Two consequences: a
+# user who already had it set got pinning silently disabled, and every nutshell
+# script carried it into its children, so a nutshell script invoking another
+# never honoured the inner project's pin. Script-calls-script is ordinary here;
+# `check` and `test` both do it.
+#
+# Carrying the resolved root instead makes the guard exact: stop when we are
+# already the answer. That is also true after an exec, so it needs no flag.
+if [[ -f "${1:-}" && "${NUTSHELL_PIN_ROOT:-}" != "$_NUTSHELL_HOME" ]]; then
+    if _nut_pinned="$(_nut_resolve_pin "$1")" && [[ -n "$_nut_pinned" ]]; then
+        if [[ "$_nut_pinned" != "$_NUTSHELL_HOME" ]]; then
+            export NUTSHELL_PIN_ROOT="$_nut_pinned"
+            exec "$_nut_pinned/bin/nutshell" "$@"
         fi
+    elif [[ -n "${NUTSHELL_PIN_STRICT:-}" ]] && _nut_declared "$1"; then
+        # A pin that cannot be satisfied is the situation the pin exists to
+        # prevent, so running something else is the wrong outcome. DESIGN.md:
+        # "No Magic, No Lies. When something is wrong, we say so."
+        #
+        # Off by default because a warning plus the ambient library is the
+        # lesser evil for a tool that has to keep working; strict makes it
+        # fatal for anyone who disagrees, which is the honest way to offer it.
+        echo "nutshell: NUTSHELL_PIN_STRICT is set and the pin could not be honoured" >&2
+        exit 1
     fi
 fi
-
-# shellcheck source=/dev/null
-source "${_NUTSHELL_HOME}/init" || {
-    echo "nutshell: cannot load ${_NUTSHELL_HOME}/init" >&2
-    exit 1
-}
 
 _show_help() {
     cat <<EOF
@@ -171,11 +270,6 @@ Available modules:
 For more information: https://github.com/orgrinrt/nutshell
 EOF
 }
-
-# Sourced rather than run: define the helpers and stop. Without this the CLI
-# dispatch below fires during a source and exits the caller, which is why the
-# pin parser had no test until it had this.
-[[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0
 
 case "${1:-}" in
     --help|-h)

--- a/examples/configs/empty.nut.toml
+++ b/examples/configs/empty.nut.toml
@@ -15,6 +15,32 @@
 # =============================================================================
 
 # -----------------------------------------------------------------------------
+# The engine pin - which nutshell this project wants
+# -----------------------------------------------------------------------------
+#
+# Root-level scalars, and they MUST stay above the first [table] header: a bare
+# key written after one belongs to that table, which is a quiet way to have a
+# pin that is never read.
+#
+#   nutshell_version = "0.3.0"    the released form
+#   nutshell_branch  = "dev"      when the version you need has no release yet
+#
+# Same spelling mockspace.toml uses for the same job, so a reader who knows one
+# knows the other.
+#
+# Unpinned is the normal case and changes nothing: the script gets whichever
+# checkout the `nutshell` on PATH resolves to. With a pin, the interpreter
+# resolves a worktree at that ref under ${XDG_CACHE_HOME:-~/.cache}/nutshell/refs
+# and re-execs into it, so the script gets the library it asked for rather than
+# whichever checkout happens to be installed. The branch head is re-resolved at
+# most hourly, not on every run; NUTSHELL_PIN_TTL overrides that in seconds.
+#
+# A ref that cannot be checked out warns and falls back to the ambient
+# checkout. It does not fail the script, and it does not retry in a loop.
+
+# nutshell_branch = "dev"
+
+# -----------------------------------------------------------------------------
 # [meta] - Configuration metadata
 # -----------------------------------------------------------------------------
 [meta]

--- a/schemas/nut.toml.schema.json
+++ b/schemas/nut.toml.schema.json
@@ -41,7 +41,13 @@
           "items": {
             "type": "string"
           },
-          "default": [".git", ".legacy", "node_modules", "vendor", "target"]
+          "default": [
+            ".git",
+            ".legacy",
+            "node_modules",
+            "vendor",
+            "target"
+          ]
         },
         "include": {
           "type": "array",
@@ -49,7 +55,9 @@
           "items": {
             "type": "string"
           },
-          "default": ["*.sh"]
+          "default": [
+            "*.sh"
+          ]
         }
       },
       "additionalProperties": false
@@ -108,7 +116,11 @@
                 "shell": {
                   "type": "string",
                   "description": "Shell to use for syntax checking",
-                  "enum": ["bash", "sh", "zsh"],
+                  "enum": [
+                    "bash",
+                    "sh",
+                    "zsh"
+                  ],
                   "default": "bash"
                 },
                 "fail_on_error": {
@@ -186,7 +198,10 @@
                   "items": {
                     "type": "string"
                   },
-                  "default": ["@@PUBLIC_API@@", "@@ALLOW_TRIVIAL_WRAPPER_FOR_ERGONOMICS@@"]
+                  "default": [
+                    "@@PUBLIC_API@@",
+                    "@@ALLOW_TRIVIAL_WRAPPER_FOR_ERGONOMICS@@"
+                  ]
                 },
                 "exclude_patterns": {
                   "type": "array",
@@ -304,7 +319,11 @@
                   "items": {
                     "type": "string"
                   },
-                  "default": ["echo.*DEBUG", "set -x", "PS4="]
+                  "default": [
+                    "echo.*DEBUG",
+                    "set -x",
+                    "PS4="
+                  ]
                 },
                 "todo_patterns": {
                   "type": "array",
@@ -312,7 +331,13 @@
                   "items": {
                     "type": "string"
                   },
-                  "default": ["TODO:", "FIXME:", "XXX:", "HACK:", "BUG:"]
+                  "default": [
+                    "TODO:",
+                    "FIXME:",
+                    "XXX:",
+                    "HACK:",
+                    "BUG:"
+                  ]
                 },
                 "fail_on_debug": {
                   "type": "boolean",
@@ -357,7 +382,9 @@
                   "items": {
                     "type": "string"
                   },
-                  "default": ["Usage:"]
+                  "default": [
+                    "Usage:"
+                  ]
                 },
                 "recommended_elements": {
                   "type": "array",
@@ -365,7 +392,9 @@
                   "items": {
                     "type": "string"
                   },
-                  "default": ["->"]
+                  "default": [
+                    "->"
+                  ]
                 },
                 "min_doc_lines": {
                   "type": "integer",
@@ -389,19 +418,31 @@
         "color": {
           "type": "string",
           "description": "Use colors in output",
-          "enum": ["auto", "always", "never"],
+          "enum": [
+            "auto",
+            "always",
+            "never"
+          ],
           "default": "auto"
         },
         "verbosity": {
           "type": "string",
           "description": "Verbosity level",
-          "enum": ["quiet", "normal", "verbose"],
+          "enum": [
+            "quiet",
+            "normal",
+            "verbose"
+          ],
           "default": "normal"
         },
         "format": {
           "type": "string",
           "description": "Output format",
-          "enum": ["human", "json", "tap"],
+          "enum": [
+            "human",
+            "json",
+            "tap"
+          ],
           "default": "human"
         },
         "show_passing": {
@@ -416,6 +457,14 @@
         }
       },
       "additionalProperties": false
+    },
+    "nutshell_branch": {
+      "type": "string",
+      "description": "Engine pin: the git ref of nutshell this project wants, when the version it needs has no release yet. Root-level, above the first table header."
+    },
+    "nutshell_version": {
+      "type": "string",
+      "description": "Engine pin: the released nutshell version this project wants. Root-level, above the first table header."
     }
   },
   "additionalProperties": false

--- a/tests/pin_test.sh
+++ b/tests/pin_test.sh
@@ -1,23 +1,31 @@
 #!/usr/bin/env bash
 # Tests for the engine pin.
 #
-# The parser reads root-level scalars only, and stops at the first [table]
-# header. That boundary is the whole point: a `nutshell_branch` written after a
-# table belongs to that table, and a pin nobody reads is worse than no pin,
-# because it looks like it is doing something.
+# The first version of this file tested the parser and nothing else, and every
+# real defect was somewhere else: a refresh that never refreshed, a guard that
+# disabled itself in nested calls, a ref handed to git as an option. Review
+# found twenty-one. So the parser tests stay and the rest of the file is about
+# the things that actually broke.
+#
+# Note the shape of the helper below. Sourcing bin/nutshell to reach its
+# functions is only safe because the sourced-guard sits above the pin block; in
+# the first version it sat below, so this very file could exec itself away the
+# moment nutshell's own nut.toml carried a pin.
 
 use test
 
 NUT="${BASH_SOURCE[0]%/*}/../bin/nutshell"
 
 _pin() {
-    # Exercise the parser the interpreter uses, in isolation.
     local body="$1" key="${2:-nutshell_branch}" f
     f="$(mktemp)"; printf '%s' "$body" > "$f"
-    # shellcheck source=/dev/null
     ( source "$NUT" >/dev/null 2>&1; _nut_pin "$f" "$key" ) 2>/dev/null
     rm -f "$f"
 }
+
+_ref_ok() { ( source "$NUT" >/dev/null 2>&1; _nut_ref_ok "$1" ); }
+
+# --- the parser -------------------------------------------------------------
 
 #[test]
 it_reads_a_root_level_pin() {
@@ -45,4 +53,103 @@ nutshell_branch = "dev"
 it_reports_no_pin_when_there_is_none() {
     assert_eq "$(_pin 'project = "x"
 ')" ""
+}
+
+#[test]
+it_reads_a_pin_on_a_final_line_with_no_newline() {
+    # `while read` drops a trailing partial line, so this returned nothing.
+    # Every fixture in the first version of this file ended in a newline, which
+    # is exactly why the bug survived having tests.
+    assert_eq "$(_pin 'nutshell_branch = "dev"')" "dev"
+}
+
+#[test]
+it_treats_an_empty_value_as_no_pin() {
+    # An empty value used to succeed, which short-circuited the version
+    # fallback: a broken branch line plus a good version line resolved to no
+    # pin at all rather than to the version.
+    assert_eq "$(_pin 'nutshell_branch = ""
+nutshell_version = "0.2.0"
+')" ""
+    assert_eq "$(_pin 'nutshell_branch = ""
+nutshell_version = "0.2.0"
+' nutshell_version)" "0.2.0"
+}
+
+# --- the ref, which reaches git ---------------------------------------------
+
+#[test]
+it_accepts_ordinary_refs() {
+    assert_ok _ref_ok "dev"
+    assert_ok _ref_ok "main"
+    assert_ok _ref_ok "0.2.0"
+    assert_ok _ref_ok "release/1.2"
+}
+
+#[test]
+it_refuses_a_ref_that_git_would_read_as_an_option() {
+    # `--upload-pack=touch /tmp/pwned` was passed positionally with no `--`
+    # and executed against a path or file:// remote. Validated rather than
+    # escaped: the set of legitimate ref names is small and known.
+    assert_fails _ref_ok "--upload-pack=touch /tmp/pwned"
+    assert_fails _ref_ok "-x"
+}
+
+#[test]
+it_refuses_refs_git_itself_rejects() {
+    assert_fails _ref_ok "bad..ref"
+    assert_fails _ref_ok "trailing.lock"
+    assert_fails _ref_ok "has space"
+    assert_fails _ref_ok ""
+}
+
+# --- staleness --------------------------------------------------------------
+
+#[test]
+it_reports_a_fetchless_mirror_as_due() {
+    local d; d="$(mktemp -d)"; mkdir -p "$d/.git"
+    assert_eq "$( ( source "$NUT" >/dev/null 2>&1; _nut_age "$d" ) )" "3600"
+    rm -rf "$d"
+}
+
+#[test]
+it_treats_a_clock_that_moved_backwards_as_due() {
+    # A future stamp gave a negative age, so the mirror parked until
+    # wall-clock caught up rather than refreshing.
+    local d; d="$(mktemp -d)"; mkdir -p "$d/.git"
+    touch -t 203001010000 "$d/.git/FETCH_HEAD"
+    assert_eq "$( ( source "$NUT" >/dev/null 2>&1; _nut_age "$d" ) )" "3600"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_a_fresh_mirror_as_young() {
+    local d age; d="$(mktemp -d)"; mkdir -p "$d/.git"
+    touch "$d/.git/FETCH_HEAD"
+    age="$( ( source "$NUT" >/dev/null 2>&1; _nut_age "$d" ) )"
+    assert_ok bash -c "[[ '$age' =~ ^[0-9]+$ ]] && (( $age < 60 ))"
+    rm -rf "$d"
+}
+
+# --- the manifest walk ------------------------------------------------------
+
+#[test]
+it_stops_the_manifest_walk_at_a_repository_boundary() {
+    # The unbounded walk reached /tmp on macOS, where anyone can plant a
+    # nut.toml and choose which engine another user's scripts run.
+    local root; root="$(mktemp -d)"
+    printf 'nutshell_branch = "planted"\n' > "$root/nut.toml"
+    mkdir -p "$root/proj/sub"; mkdir -p "$root/proj/.git"
+    assert_fails bash -c "source '$NUT' >/dev/null 2>&1; _nut_manifest '$root/proj/sub'"
+    rm -rf "$root"
+}
+
+#[test]
+it_finds_a_manifest_the_script_actually_belongs_to() {
+    local root; root="$(mktemp -d)"
+    mkdir -p "$root/proj/sub"
+    printf 'nutshell_branch = "dev"\n' > "$root/proj/nut.toml"
+    assert_eq "$(bash -c "source '$NUT' >/dev/null 2>&1; _nut_manifest '$root/proj/sub'")" \
+              "$root/proj/nut.toml"
+    rm -rf "$root"
 }

--- a/tests/pin_test.sh
+++ b/tests/pin_test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Tests for the engine pin.
+#
+# The parser reads root-level scalars only, and stops at the first [table]
+# header. That boundary is the whole point: a `nutshell_branch` written after a
+# table belongs to that table, and a pin nobody reads is worse than no pin,
+# because it looks like it is doing something.
+
+use test
+
+NUT="${BASH_SOURCE[0]%/*}/../bin/nutshell"
+
+_pin() {
+    # Exercise the parser the interpreter uses, in isolation.
+    local body="$1" key="${2:-nutshell_branch}" f
+    f="$(mktemp)"; printf '%s' "$body" > "$f"
+    # shellcheck source=/dev/null
+    ( source "$NUT" >/dev/null 2>&1; _nut_pin "$f" "$key" ) 2>/dev/null
+    rm -f "$f"
+}
+
+#[test]
+it_reads_a_root_level_pin() {
+    assert_eq "$(_pin 'nutshell_branch = "dev"
+project = "x"
+')" "dev"
+}
+
+#[test]
+it_reads_the_version_form_too() {
+    assert_eq "$(_pin 'nutshell_version = "0.3.0"
+' nutshell_version)" "0.3.0"
+}
+
+#[test]
+it_ignores_a_pin_written_after_a_table_header() {
+    # TOML says this key belongs to [meta], not to the document. Reading it
+    # anyway would honour a pin the file does not actually declare.
+    assert_eq "$(_pin '[meta]
+nutshell_branch = "dev"
+')" ""
+}
+
+#[test]
+it_reports_no_pin_when_there_is_none() {
+    assert_eq "$(_pin 'project = "x"
+')" ""
+}


### PR DESCRIPTION
## Summary

A project can now say which nutshell it wants, in its own `nut.toml`:

```toml
nutshell_branch  = "dev"       # when what you need has no release yet
nutshell_version = "0.3.0"     # the released form
```

Root-level scalars, deliberately the same spelling `mockspace.toml` already uses for the same job, so a reader who knows one knows the other. They must sit above the first `[table]` header — a bare key after one belongs to that table, and a pin nobody reads is worse than no pin because it looks like it is working. There is a test for exactly that boundary.

**Why:** `toml_subsections` merged to `dev` in #7 and was immediately unusable by any consumer, because the interpreter on PATH resolves to whichever checkout it is symlinked at — `main`. A consumer had no way to express the dependency at all.

**How:** with a pin, the interpreter resolves a worktree at that ref under `${XDG_CACHE_HOME:-~/.cache}/nutshell/refs` and re-execs into it. Unpinned projects are untouched and behave exactly as before. The branch head re-resolves hourly rather than per run, matching what mockspace does; `NUTSHELL_PIN_TTL` overrides.

Reading the pin happens before `init`, so it cannot `use toml`. A root-level scalar is a line and a line is a grep — a parser running ahead of the module that exists to parse would be the wrong shape.

## Test plan

`tests/pin_test.sh`, 4 tests: root-level pin, the `_version` form, the table-header boundary, and no-pin.

Behaviour exercised by hand against a real project pinned to `dev`:

| case | result |
|---|---|
| pinned, cold | creates the worktree, re-execs, `toml_subsections` available |
| pinned, warm | reuses the cache, no refetch |
| unpinned | ambient checkout, unchanged |
| ref that does not exist | warns, falls back, no directory left behind, no loop |

The loop is prevented by an env marker rather than by hoping — a re-exec that re-resolves is not a warning, it is a fork bomb.

Full gate on this worktree: `./test` **120 passed**, module_contract / syntax / no_cruft OK, shellcheck clean.

## One behaviour change worth flagging

`bin/nutshell` now returns early when sourced instead of running its CLI. That is *why* the pin parser had no test at first: sourcing the file to reach the function exited the caller. It makes the file testable and should not affect any real invocation, but it is a change to how the interpreter behaves under `source`.