### PR TITLE
feat: super:: for a unit's own modules, and nut_dir for where a file is

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,20 +354,25 @@ module that builds a path from them is describing somebody else's location and
 breaks the moment the entry point moves. That is not hypothetical; it took a
 whole test suite down when a runner moved from `tests/` to the repository root.
 
-The whole environment, for reference:
+The whole exported environment, which is five things:
 
-| Variable | What it is |
-|---|---|
-| `NUTSHELL_SCRIPT` | The entry script, absolute |
-| `NUTSHELL_SCRIPT_DIR` | Its directory |
-| `NUTSHELL_ROOT` | The nutshell checkout in use |
-| `NUTSHELL_HOME` | Same, as the install root |
-| `NUTSHELL_BIN_DIR` | Its `bin/`, added to `PATH` by `init` |
-| `NUTSHELL_SH` / `NUTSHELL_SH_DIR` | `nutshell.sh` and its directory |
-| `NUTSHELL_INIT` | The `init` file that was sourced |
-| `NUTSHELL_LOADED` | Set once init has run, so a second source is a no-op |
-| `NUTSHELL_VERSION` | The version string |
-| `NUTSHELL_PIN_TTL` | How long a pinned branch head is reused before re-resolving |
+| Variable | What it is | Set by |
+|---|---|---|
+| `NUTSHELL_SCRIPT` | The entry script, absolute | `bin/nutshell` |
+| `NUTSHELL_SCRIPT_DIR` | Its directory | `bin/nutshell` |
+| `NUTSHELL_PIN_ROOT` | The pinned checkout, when a project pins one | `bin/nutshell` |
+| `NUTSHELL_ROOT` | The nutshell checkout in use | `init` |
+| `NUTSHELL_VERSION` | The version string | `init` |
+
+`NUTSHELL_PIN_TTL` is read rather than exported: set it to change how long a
+pinned branch head is reused before re-resolving.
+
+Names beginning with a single underscore are internal and are not listed,
+because they are not the interface. An earlier version of this table had six
+entries that do not exist, produced by a grep for `NUTSHELL_[A-Z_]+` which
+matched those private names inside their own underscore prefix, and it swapped
+the meanings of two of them on the way. In the section whose whole purpose was
+that a reader kept getting these wrong.
 
 ### Depending on another library
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,65 @@ The assertions are `assert_eq`, `assert_ne`, `assert_contains`, `assert_empty`,
 against what it got, because a bare "assertion failed" sends the reader back to
 the source to work out what the values even were.
 
+### Reaching your own modules
+
+A module you wrote lives in your `lib/`, and `super::` is how you name it:
+
+```bash
+use super::attribution
+```
+
+Three namespaces, and they answer three different questions:
+
+| Written | Resolves to |
+|---|---|
+| `use log` | nutshell's own module |
+| `use shebang::diagnostics/findings` | a module in a library declared in `nut.toml` |
+| `use super::mine` | `lib/mine.sh` in **this** unit, found from its `nut.toml` |
+
+`super::` is anchored on the manifest rather than on the running script, so a
+module three directories down reaches `lib/` the same way the entry script does,
+and moving the entry script changes nothing.
+
+It does not fall through. `use super::string` in a project with no
+`lib/string.sh` is an error naming the module, not a silent load of nutshell's
+`string`, because a unit that gets handed a module it did not write has no way
+to tell.
+
+### Where am I: the current file against the entry point
+
+Two different questions, and reaching for the wrong one is the mistake this
+section exists to prevent.
+
+```bash
+nut_dir      # the directory of the file calling it
+nut_file     # that file, absolute
+```
+
+Those name the **current file**, the way Deno's `import.meta.dirname` and Rust's
+`file!()` do. A module that wants a sibling wants `nut_dir`.
+
+`NUTSHELL_SCRIPT` and `NUTSHELL_SCRIPT_DIR` name the **entry point**: the script
+the interpreter was handed. They stay the same in every file the run loads, so a
+module that builds a path from them is describing somebody else's location and
+breaks the moment the entry point moves. That is not hypothetical; it took a
+whole test suite down when a runner moved from `tests/` to the repository root.
+
+The whole environment, for reference:
+
+| Variable | What it is |
+|---|---|
+| `NUTSHELL_SCRIPT` | The entry script, absolute |
+| `NUTSHELL_SCRIPT_DIR` | Its directory |
+| `NUTSHELL_ROOT` | The nutshell checkout in use |
+| `NUTSHELL_HOME` | Same, as the install root |
+| `NUTSHELL_BIN_DIR` | Its `bin/`, added to `PATH` by `init` |
+| `NUTSHELL_SH` / `NUTSHELL_SH_DIR` | `nutshell.sh` and its directory |
+| `NUTSHELL_INIT` | The `init` file that was sourced |
+| `NUTSHELL_LOADED` | Set once init has run, so a second source is a no-op |
+| `NUTSHELL_VERSION` | The version string |
+| `NUTSHELL_PIN_TTL` | How long a pinned branch head is reused before re-resolving |
+
 ### Depending on another library
 
 A dependency is declared in `nut.toml`, not in the script that wants it:

--- a/bin/nutshell
+++ b/bin/nutshell
@@ -308,10 +308,19 @@ case "${1:-}" in
             echo "nutshell: -c needs a command" >&2
             exit 2
         }
-        _SCRIPT="$(mktemp -t nutshell-c.XXXXXX)"
-        printf '%s\n' "$1" > "$_SCRIPT"
+        _tmp="$(mktemp -t nutshell-c.XXXXXX)"
+        printf '%s\n' "$1" > "$_tmp"
         shift
-        trap 'rm -f "$_SCRIPT"' EXIT
+        # Opened, then unlinked, then run from the descriptor. The directory
+        # entry is gone before the command runs, so nothing is left behind
+        # whatever the command does: an `EXIT` trap here is overwritten by any
+        # command that sets its own, and a command that exits never reaches a
+        # cleanup line at all. Both were true of the first version, and the
+        # trap case leaks a file per invocation.
+        exec {_cfd}< "$_tmp"
+        rm -f "$_tmp"
+        _SCRIPT="/dev/fd/${_cfd}"
+        _IS_COMMAND=1
         ;;
     -*)
         # An unknown option is a mistake, not a file. Treating it as one
@@ -332,7 +341,7 @@ esac
 # adding `-c` there produced a case arm that set a script and then ended, and
 # `-c 'echo hello'` printed nothing at all while exiting zero.
 
-if [[ ! -f "$_SCRIPT" ]]; then
+if [[ "${_IS_COMMAND:-0}" -ne 1 && ! -f "$_SCRIPT" ]]; then
     echo "nutshell: script not found: $_SCRIPT" >&2
     exit 1
 fi
@@ -347,8 +356,15 @@ fi
 # "where is the file I am in". A module that builds a path from this breaks when
 # the entry point moves. `nut_dir` and `nut_file` are the current-file answer,
 # the way Deno separates `import.meta.dirname` from `import.meta.main`.
-NUTSHELL_SCRIPT="$(cd "$(dirname "$_SCRIPT")" && pwd)/$(basename "$_SCRIPT")"
-NUTSHELL_SCRIPT_DIR="${NUTSHELL_SCRIPT%/*}"
+if [[ "${_IS_COMMAND:-0}" -eq 1 ]]; then
+    # A command has no file and therefore no unit. Anchoring it on the working
+    # directory is the only honest answer: it is where the person typing it is.
+    NUTSHELL_SCRIPT="$_SCRIPT"
+    NUTSHELL_SCRIPT_DIR="$PWD"
+else
+    NUTSHELL_SCRIPT="$(cd "$(dirname "$_SCRIPT")" && pwd)/$(basename "$_SCRIPT")"
+    NUTSHELL_SCRIPT_DIR="${NUTSHELL_SCRIPT%/*}"
+fi
 export NUTSHELL_SCRIPT NUTSHELL_SCRIPT_DIR
 
 # Sourced, not executed, so the script runs in this environment with `use`

--- a/bin/nutshell
+++ b/bin/nutshell
@@ -15,6 +15,7 @@
 # Also a small CLI:
 #
 #   nutshell <script>       run a script with the nutshell environment
+#   nutshell -c <command>   run a command string, as any shell does
 #   nutshell --version      print the version
 #   nutshell --help         what is here
 #
@@ -268,6 +269,7 @@ nutshell - Everything you need, in a nutshell.
 
 Usage:
   nutshell <script>       Run a script with nutshell environment
+  nutshell -c <command>   Run a command string, as any shell does
   nutshell --version      Show version
   nutshell --help         Show this help
 
@@ -296,28 +298,60 @@ case "${1:-}" in
         _show_help
         exit 1
         ;;
+    -c)
+        # Every other shell takes `-c <command>`, so people write it, and this
+        # used to read it as a filename and report `script not found: -c`. That
+        # is a true sentence about the wrong thing, and it sent at least one
+        # reader looking for a missing file.
+        shift
+        [[ $# -gt 0 ]] || {
+            echo "nutshell: -c needs a command" >&2
+            exit 2
+        }
+        _SCRIPT="$(mktemp -t nutshell-c.XXXXXX)"
+        printf '%s\n' "$1" > "$_SCRIPT"
+        shift
+        trap 'rm -f "$_SCRIPT"' EXIT
+        ;;
+    -*)
+        # An unknown option is a mistake, not a file. Treating it as one
+        # produces a not-found error naming the flag, which reads as a broken
+        # path rather than as a flag nobody implemented.
+        echo "nutshell: unknown option: $1" >&2
+        echo "  nutshell <script> | -c <command> | --version | --help" >&2
+        exit 2
+        ;;
     *)
         _SCRIPT="$1"
         shift
-
-        if [[ ! -f "$_SCRIPT" ]]; then
-            echo "nutshell: script not found: $_SCRIPT" >&2
-            exit 1
-        fi
-
-        # Where the script lives, absolute, for anything that has to resolve
-        # against the unit the script belongs to rather than against wherever
-        # it was called from. `nut.toml` is the case that matters: a script's
-        # dependencies belong to its project the way a crate's belong to its
-        # Cargo.toml, and a script run from inside some other repository must
-        # still find its own.
-        NUTSHELL_SCRIPT="$(cd "$(dirname "$_SCRIPT")" && pwd)/$(basename "$_SCRIPT")"
-        NUTSHELL_SCRIPT_DIR="${NUTSHELL_SCRIPT%/*}"
-        export NUTSHELL_SCRIPT NUTSHELL_SCRIPT_DIR
-
-        # Sourced, not executed, so the script runs in this environment with
-        # `use` already defined.
-        # shellcheck source=/dev/null
-        source "$_SCRIPT"
         ;;
 esac
+
+# Running the script sits outside the case, because two branches reach it: a
+# path, and `-c`, which writes one. It used to live inside the path branch, so
+# adding `-c` there produced a case arm that set a script and then ended, and
+# `-c 'echo hello'` printed nothing at all while exiting zero.
+
+if [[ ! -f "$_SCRIPT" ]]; then
+    echo "nutshell: script not found: $_SCRIPT" >&2
+    exit 1
+fi
+
+# Where the script lives, absolute, for anything that has to resolve against the
+# unit the script belongs to rather than against wherever it was called from.
+# `nut.toml` is the case that matters: a script's dependencies belong to its
+# project the way a crate's belong to its Cargo.toml, and a script run from
+# inside some other repository must still find its own.
+#
+# This is the ENTRY POINT, and it is the answer to a different question than
+# "where is the file I am in". A module that builds a path from this breaks when
+# the entry point moves. `nut_dir` and `nut_file` are the current-file answer,
+# the way Deno separates `import.meta.dirname` from `import.meta.main`.
+NUTSHELL_SCRIPT="$(cd "$(dirname "$_SCRIPT")" && pwd)/$(basename "$_SCRIPT")"
+NUTSHELL_SCRIPT_DIR="${NUTSHELL_SCRIPT%/*}"
+export NUTSHELL_SCRIPT NUTSHELL_SCRIPT_DIR
+
+# Sourced, not executed, so the script runs in this environment with `use`
+# already defined.
+# shellcheck source=/dev/null
+source "$_SCRIPT"

--- a/examples/checks/check_function_duplication.sh
+++ b/examples/checks/check_function_duplication.sh
@@ -303,8 +303,9 @@ compare_stripped_names() {
     
     {
         stripped[NR] = $1
-        original[NR] = $2
-        files[NR] = $3
+        prefixes[NR] = $2
+        original[NR] = $3
+        files[NR] = $4
         count = NR
     }
     
@@ -313,6 +314,20 @@ compare_stripped_names() {
             for (j = i + 1; j <= count; j++) {
                 # Skip if same file
                 if (files[i] == files[j]) continue
+
+                # Different module prefixes means these are namespaced siblings
+                # rather than duplicates. `arr_contains` and `str_contains` do
+                # the same job for different types and are named that way on
+                # purpose, so comparing their stripped forms scores 1.000 for
+                # every such pair and reports the naming convention as a defect.
+                # That is what this did to a library where every function is
+                # `<module>_<verb>`: twelve warnings, not one of them real, and
+                # no body duplication found at all.
+                #
+                # Within one prefix the comparison is worth having, since
+                # `toml_get_or` against `toml_fetch_or` in the same module is a
+                # real question.
+                if (prefixes[i] != prefixes[j]) continue
                 
                 # Early exit: if lengths are too different, skip expensive Levenshtein
                 if (!can_meet_threshold(stripped[i], stripped[j], threshold)) continue

--- a/init
+++ b/init
@@ -106,8 +106,18 @@ use() {
             # so a module three directories down reaches `lib/` the same way
             # the entry script does and moving the entry script changes
             # nothing.
-            use extern || return 1
-            mod_path="$(_use_super_resolve "${mod#super::}")" || return 1
+            # BASH_SOURCE[1] is the file that called `use`, which is the unit
+            # this `super::` belongs to. BASH_SOURCE[0] is `init` itself, and
+            # NUTSHELL_SCRIPT_DIR is the entry point; neither answers "which
+            # unit is asking".
+            local _caller="${BASH_SOURCE[1]:-}"
+            local _from
+            if [[ -n "$_caller" && "$_caller" == */* ]]; then
+                _from="$(cd "${_caller%/*}" 2>/dev/null && pwd)"
+            else
+                _from="$PWD"
+            fi
+            mod_path="$(_use_super_resolve "${mod#super::}" "$_from")" || return 1
         elif [[ "$mod" == *"::"* ]]; then
             use extern || return 1
             mod_path="$(extern_resolve "$mod")" || return 1
@@ -147,13 +157,33 @@ use() {
 # that silently resolved to a nutshell module of the same name would load
 # something the author did not write and did not mean.
 _use_super_resolve() {
-    local rest="$1" manifest root candidate
-    manifest="$(_extern_manifest)" || {
-        echo "nutshell: 'super::${rest}' needs a nut.toml, and none was found" >&2
+    local rest="$1" from="$2" root candidate dir
+
+    # Walk up from the file that wrote the `use`, not from the entry point.
+    #
+    # `_extern_manifest` searches NUTSHELL_SCRIPT_DIR and then PWD, which are
+    # both facts about the invocation rather than about the file asking. A
+    # module inside a unit, run by an entry script outside it, resolved
+    # `super::` against the entry script's unit or against nothing. That is the
+    # entry-point anchoring `nut_dir` exists to correct, shipped in the same
+    # change that corrects it, which is how a review found it.
+    #
+    # The caller's own directory is the only anchor that means "this unit" from
+    # every file in it.
+    dir="$from"
+    while [[ -n "$dir" && "$dir" != "/" ]]; do
+        if [[ -f "${dir}/nut.toml" ]]; then
+            root="$dir"
+            break
+        fi
+        dir="${dir%/*}"
+    done
+
+    if [[ -z "${root:-}" ]]; then
+        echo "nutshell: 'super::${rest}' needs a nut.toml above ${from}, and none was found" >&2
         echo "  super:: names this unit's own lib/, and the manifest is what marks the unit" >&2
         return 1
-    }
-    root="${manifest%/*}"
+    fi
     for candidate in "${root}/lib/${rest}.sh" "${root}/libs/${rest}.sh" "${root}/${rest}.sh"; do
         [[ -f "$candidate" ]] && { printf '%s' "$candidate"; return 0; }
     done
@@ -174,8 +204,20 @@ _use_super_resolve() {
 #
 # Usage: nut_file -> /abs/path/to/the/caller.sh
 nut_file() {
-    local src="${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
-    printf '%s' "$(cd "${src%/*}" 2>/dev/null && pwd)/${src##*/}"
+    local src="${BASH_SOURCE[1]:-}" dir
+    # A source with no slash in it is a relative name resolved against the
+    # working directory, which is what `bash s.sh` from the file's own directory
+    # produces. The first version stripped `${src%/*}`, got the whole name back,
+    # failed to `cd` into it and printed `/s.sh` with exit 0: a wrong absolute
+    # path that looks like a right one. Silence is the defect, not the path.
+    [[ -z "$src" ]] && { echo "nut_file: no calling file" >&2; return 1; }
+    if [[ "$src" == */* ]]; then
+        dir="$(cd "${src%/*}" 2>/dev/null && pwd)" || dir=""
+    else
+        dir="$PWD"
+    fi
+    [[ -z "$dir" ]] && { echo "nut_file: cannot resolve ${src}" >&2; return 1; }
+    printf '%s/%s' "$dir" "${src##*/}"
 }
 export -f nut_file
 
@@ -187,8 +229,17 @@ export -f nut_file
 #
 # Usage: source "$(nut_dir)/helper.sh"
 nut_dir() {
-    local src="${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
-    (cd "${src%/*}" 2>/dev/null && pwd)
+    local src="${BASH_SOURCE[1]:-}" dir
+    [[ -z "$src" ]] && { echo "nut_dir: no calling file" >&2; return 1; }
+    if [[ "$src" == */* ]]; then
+        dir="$(cd "${src%/*}" 2>/dev/null && pwd)" || dir=""
+    else
+        dir="$PWD"
+    fi
+    # Empty with a zero exit was the old behaviour, and it turned the documented
+    # `source "$(nut_dir)/helper.sh"` into `source "/helper.sh"`.
+    [[ -z "$dir" ]] && { echo "nut_dir: cannot resolve ${src}" >&2; return 1; }
+    printf '%s' "$dir"
 }
 export -f nut_dir
 

--- a/init
+++ b/init
@@ -202,7 +202,8 @@ _use_super_resolve() {
 # that builds a path from that breaks the moment the entry point moves, which
 # is a real thing that happened and took a whole test suite down with it.
 #
-# Usage: nut_file -> /abs/path/to/the/caller.sh
+# Usage: nut_file -> prints the calling file, absolute; returns 1 when it cannot be resolved
+#[pub]
 nut_file() {
     local src="${BASH_SOURCE[1]:-}" dir
     # A source with no slash in it is a relative name resolved against the
@@ -227,7 +228,8 @@ export -f nut_file
 # reaches for a sibling file, and the answer to the mistake `NUTSHELL_SCRIPT_DIR`
 # invites.
 #
-# Usage: source "$(nut_dir)/helper.sh"
+# Usage: source "$(nut_dir)/helper.sh" -> prints the calling file's directory; returns 1 when it cannot be resolved
+#[pub]
 nut_dir() {
     local src="${BASH_SOURCE[1]:-}" dir
     [[ -z "$src" ]] && { echo "nut_dir: no calling file" >&2; return 1; }

--- a/init
+++ b/init
@@ -96,7 +96,19 @@ use() {
         # A namespaced module comes from a library declared in nut.toml, so
         # resolution goes through extern rather than nutshell's own lib.
         local mod_path
-        if [[ "$mod" == *"::"* ]]; then
+        if [[ "$mod" == super::* ]]; then
+            # This unit's own library. `super::` is the only way a project
+            # reaches a module it wrote itself, because a bare `use` resolves
+            # nutshell's set and a namespaced one resolves a declared
+            # dependency, and a unit is neither of those to itself.
+            #
+            # Anchored on the unit's manifest rather than on the entry point,
+            # so a module three directories down reaches `lib/` the same way
+            # the entry script does and moving the entry script changes
+            # nothing.
+            use extern || return 1
+            mod_path="$(_use_super_resolve "${mod#super::}")" || return 1
+        elif [[ "$mod" == *"::"* ]]; then
             use extern || return 1
             mod_path="$(extern_resolve "$mod")" || return 1
         else
@@ -124,6 +136,61 @@ use() {
         fi
     done
 }
+
+# _use_super_resolve <rest>
+#
+# The file `super::<rest>` names, from the unit's own manifest directory. The
+# same three shapes `extern_resolve` tries, so a library laid out one way works
+# whether it is reached from inside or from a consumer.
+#
+# Fails loudly rather than falling through to nutshell's own set. A `super::`
+# that silently resolved to a nutshell module of the same name would load
+# something the author did not write and did not mean.
+_use_super_resolve() {
+    local rest="$1" manifest root candidate
+    manifest="$(_extern_manifest)" || {
+        echo "nutshell: 'super::${rest}' needs a nut.toml, and none was found" >&2
+        echo "  super:: names this unit's own lib/, and the manifest is what marks the unit" >&2
+        return 1
+    }
+    root="${manifest%/*}"
+    for candidate in "${root}/lib/${rest}.sh" "${root}/libs/${rest}.sh" "${root}/${rest}.sh"; do
+        [[ -f "$candidate" ]] && { printf '%s' "$candidate"; return 0; }
+    done
+    echo "nutshell: this unit has no module '${rest}'" >&2
+    echo "  looked in ${root}/lib, ${root}/libs and ${root}" >&2
+    return 1
+}
+
+# nut_file
+#
+# The file calling this, absolute. Not the entry script: the file the call is
+# written in, the way Deno's `import.meta.filename` and Rust's `file!()` name
+# the current source rather than the program.
+#
+# `NUTSHELL_SCRIPT` is the entry point and is a different question. A module
+# that builds a path from that breaks the moment the entry point moves, which
+# is a real thing that happened and took a whole test suite down with it.
+#
+# Usage: nut_file -> /abs/path/to/the/caller.sh
+nut_file() {
+    local src="${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
+    printf '%s' "$(cd "${src%/*}" 2>/dev/null && pwd)/${src##*/}"
+}
+export -f nut_file
+
+# nut_dir
+#
+# The directory of the file calling this, absolute. What a script wants when it
+# reaches for a sibling file, and the answer to the mistake `NUTSHELL_SCRIPT_DIR`
+# invites.
+#
+# Usage: source "$(nut_dir)/helper.sh"
+nut_dir() {
+    local src="${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
+    (cd "${src%/*}" 2>/dev/null && pwd)
+}
+export -f nut_dir
 
 # Export the function so it's available in subshells
 export -f use

--- a/lib/array.sh
+++ b/lib/array.sh
@@ -48,7 +48,7 @@ arr_index() {
 
 #[pub]
 # Remove duplicates from array (preserves order)
-# Usage: arr_unique arr
+# Usage: arr_unique arr -> prints nothing; rewrites the named array in place, order preserved
 arr_unique() {
     local -n _arr="$1"
     local -A seen=()
@@ -67,7 +67,7 @@ arr_unique() {
 
 #[pub]
 # Reverse array in place
-# Usage: arr_reverse arr
+# Usage: arr_reverse arr -> prints nothing; rewrites the named array in place
 arr_reverse() {
     local -n _arr="$1"
     local len=${#_arr[@]}
@@ -116,7 +116,7 @@ arr_last() {
 
 #[pub]
 # Sort array in place (lexicographic)
-# Usage: arr_sort arr
+# Usage: arr_sort arr -> prints nothing; rewrites the named array in place, lexicographic
 arr_sort() {
     local -n _arr="$1"
     local -a sorted

--- a/lib/check-runner.sh
+++ b/lib/check-runner.sh
@@ -184,7 +184,7 @@ cfg_section_exists() {
 }
 
 # Check if a test is enabled
-# Usage: cfg_test_enabled "syntax"
+# Usage: cfg_test_enabled "syntax" -> returns 0 when the test is enabled, 1 when it is not
 #[pub]
 cfg_test_enabled() {
     local test_name="$1"
@@ -643,7 +643,7 @@ strip_prefix() {
 
 # Print test summary
 #[pub]
-# Usage: print_summary ["Test Suite Name"]
+# Usage: print_summary ["Test Suite Name"] -> prints the totals block; returns 0 always
 print_summary() {
     local test_name="${1:-Test Suite}"
     
@@ -717,7 +717,7 @@ print_summary() {
 
 # Exit with appropriate code based on test results
 #[pub]
-# Usage: exit_with_status
+# Usage: exit_with_status -> does not return; exits 0 clean, 1 on failures, 2 on warnings only
 exit_with_status() {
     [[ $TESTS_FAILED -gt 0 ]] && exit 1
     exit 0

--- a/lib/color.sh
+++ b/lib/color.sh
@@ -278,7 +278,7 @@ color_has_truecolor() {
 
 #[pub]
 # Force enable colors (ignores NO_COLOR and terminal detection)
-# Usage: color_enable
+# Usage: color_enable -> prints nothing; forces colour on regardless of what was detected
 color_enable() {
     _COLOR_SUPPORT="basic"
     _init_colors
@@ -286,7 +286,7 @@ color_enable() {
 
 #[pub]
 # Force disable colors
-# Usage: color_disable
+# Usage: color_disable -> prints nothing; forces colour off regardless of what was detected
 color_disable() {
     _COLOR_SUPPORT="none"
     _init_colors
@@ -294,7 +294,7 @@ color_disable() {
 
 #[pub]
 # Re-detect color support (useful after changing TERM or NO_COLOR)
-# Usage: color_redetect
+# Usage: color_redetect -> prints nothing; re-runs detection, for a terminal that changed under us
 color_redetect() {
     _detect_color_support
     _init_colors

--- a/lib/deps.sh
+++ b/lib/deps.sh
@@ -611,7 +611,7 @@ deps_caps() {
 
 #[pub]
 # Require a tool to be present; exit if not
-# Usage: deps_require "sed" ["Custom error message"]
+# Usage: deps_require "sed" ["Custom error message"] -> prints nothing; does not return when the tool is missing, it exits
 deps_require() {
     local tool="${1:-}"
     local msg="${2:-Required tool '$tool' not found}"

--- a/lib/text.sh
+++ b/lib/text.sh
@@ -78,7 +78,7 @@ text_word_count() {
 
 #[pub]
 # Get first N lines of file
-# Usage: text_head "file" [n=10]
+# Usage: text_head "file" [n=10] -> prints the first n lines; returns 1 if the file is not there
 text_head() {
     local file="${1:-}"
     local n="${2:-10}"
@@ -88,7 +88,7 @@ text_head() {
 
 #[pub]
 # Get last N lines of file
-# Usage: text_tail "file" [n=10]
+# Usage: text_tail "file" [n=10] -> prints the last n lines; returns 1 if the file is not there
 text_tail() {
     local file="${1:-}"
     local n="${2:-10}"
@@ -228,7 +228,7 @@ text_count_matches() {
 
 #[pub]
 # Replace pattern in file (in-place)
-# Usage: text_replace "pattern" "replacement" "file"
+# Usage: text_replace "pattern" "replacement" "file" -> prints nothing; rewrites the file in place
 # 
 # Implementation selection:
 #   1. grep+sed combo (optimized: skips sed if pattern not found)
@@ -273,7 +273,7 @@ text_replace() {
 
 #[pub]
 # Replace pattern only in lines matching a filter
-# Usage: text_filtered_replace "filter_regex" "search" "replace" "file"
+# Usage: text_filtered_replace "filter_regex" "search" "replace" "file" -> prints nothing; rewrites in place, touching only lines the filter matches
 # 
 # More efficient than sed alone when only a subset of lines need changes.
 # Falls back to sed-only if grep is not available.
@@ -365,7 +365,7 @@ text_count_in_matches() {
 
 #[pub]
 # Append line to file
-# Usage: text_append "line" "file"
+# Usage: text_append "line" "file" -> prints nothing; returns 1 without a file argument
 text_append() {
     local line="${1:-}"
     local file="${2:-}"
@@ -375,7 +375,7 @@ text_append() {
 
 #[pub]
 # Prepend line to file
-# Usage: text_prepend "line" "file"
+# Usage: text_prepend "line" "file" -> prints nothing; returns 1 if the file is not there
 text_prepend() {
     local line="${1:-}"
     local file="${2:-}"

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -189,7 +189,7 @@ toml_get() {
 
 #[pub]
 # Get a value with a default if not found
-# Usage: toml_get_or "file.toml" "key" "default"
+# Usage: toml_get_or "file.toml" "key" "default" -> prints the value, or the default when the key is absent
 toml_get_or() {
     local file="${1:-}"
     local key="${2:-}"
@@ -231,7 +231,7 @@ toml_sections() {
 
 #[pub]
 # List all keys in a section (or root if no section specified)
-# Usage: toml_keys "file.toml" [section]
+# Usage: toml_keys "file.toml" [section] -> prints one key per line, root keys when no section is named
 toml_keys() {
     local file="${1:-}"
     local section="${2:-}"
@@ -589,7 +589,7 @@ _toml_value_to_json() {
 
 #[pub]
 # Get all key=value pairs from a section as "key=value" lines
-# Usage: toml_section_pairs "file.toml" "section"
+# Usage: toml_section_pairs "file.toml" "section" -> prints one key=value per line, values already unquoted
 toml_section_pairs() {
     local file="${1:-}"
     local section="${2:-}"

--- a/lib/validate.sh
+++ b/lib/validate.sh
@@ -295,7 +295,7 @@ is_hostname() {
 # -----------------------------------------------------------------------------
 
 # Require variable to be set, exit with error if not
-# Usage: require_set "VAR_NAME" "Error message"
+# Usage: require_set "VAR_NAME" "Error message" -> prints nothing; does not return when unset, it exits
 #[pub]
 require_set() {
     local varname="${1:-}"
@@ -308,7 +308,7 @@ require_set() {
 
 #[pub]
 # Require file to exist, exit with error if not
-# Usage: require_file "/path/to/file" "Error message"
+# Usage: require_file "/path/to/file" "Error message" -> prints nothing; does not return when absent, it exits
 require_file() {
     local path="${1:-}"
     local msg="${2:-Required file '$path' not found}"
@@ -320,7 +320,7 @@ require_file() {
 
 #[pub]
 # Require directory to exist, exit with error if not
-# Usage: require_dir "/path/to/dir" "Error message"
+# Usage: require_dir "/path/to/dir" "Error message" -> prints nothing; does not return when absent, it exits
 require_dir() {
     local path="${1:-}"
     local msg="${2:-Required directory '$path' not found}"
@@ -331,7 +331,7 @@ require_dir() {
 }
 
 # Require command to be available, exit with error if not
-# Usage: require_command "git" "Git is required"
+# Usage: require_command "git" "Git is required" -> prints nothing; does not return when the tool is missing, it exits
 #[pub]
 require_command() {
     local cmd="${1:-}"
@@ -344,7 +344,7 @@ require_command() {
 
 #[pub]
 # Require value to be non-empty, exit with error if empty
-# Usage: require_value "$value" "Value cannot be empty"
+# Usage: require_value "$value" "Value cannot be empty" -> prints nothing; does not return when empty, it exits
 require_value() {
     local val="${1:-}"
     local msg="${2:-Value cannot be empty}"
@@ -360,7 +360,7 @@ require_value() {
 # -----------------------------------------------------------------------------
 
 # Ensure variable is set, return 1 if not (caller handles failure)
-# Usage: ensure_set "VAR_NAME" "Error message" || handle_missing_var
+# Usage: ensure_set "VAR_NAME" "Error message" || handle_missing_var -> returns 0 when set, warns and returns 1 when not
 #[pub]
 ensure_set() {
     local varname="${1:-}"
@@ -374,7 +374,7 @@ ensure_set() {
 }
 
 # Ensure value is non-empty, return 1 if empty (caller handles failure)
-# Usage: ensure_value "$value" "Error message" || handle_empty
+# Usage: ensure_value "$value" "Error message" || handle_empty -> returns 0 when non-empty, warns and returns 1 when empty
 #[pub]
 ensure_value() {
     local val="${1:-}"
@@ -389,7 +389,7 @@ ensure_value() {
 
 #[pub]
 # Ensure file exists, return 1 if not (caller handles failure)
-# Usage: ensure_file "/path/to/file" "Error message" || handle_missing
+# Usage: ensure_file "/path/to/file" "Error message" || handle_missing -> returns 0 when the file is there, warns and returns 1 when not
 ensure_file() {
     local path="${1:-}"
     local msg="${2:-File '$path' not found}"
@@ -403,7 +403,7 @@ ensure_file() {
 
 #[pub]
 # Ensure directory exists, return 1 if not (caller handles failure)
-# Usage: ensure_dir "/path/to/dir" "Error message" || handle_missing
+# Usage: ensure_dir "/path/to/dir" "Error message" || handle_missing -> returns 0 when the directory is there, warns and returns 1 when not
 ensure_dir() {
     local path="${1:-}"
     local msg="${2:-Directory '$path' not found}"
@@ -417,7 +417,7 @@ ensure_dir() {
 
 #[pub]
 # Ensure command is available, return 1 if not (caller handles failure)
-# Usage: ensure_command "git" "Git not found" || handle_missing
+# Usage: ensure_command "git" "Git not found" || handle_missing -> returns 0 when the tool is on PATH, warns and returns 1 when not
 ensure_command() {
     local cmd="${1:-}"
     local msg="${2:-Command '$cmd' not found}"

--- a/lib/xdg.sh
+++ b/lib/xdg.sh
@@ -220,7 +220,7 @@ xdg_app_cache_subdir() {
 
 #[pub]
 # Set the application name for XDG paths
-# Usage: xdg_set_app_name "my-app"
+# Usage: xdg_set_app_name "my-app" -> prints nothing; exports XDG_APP_NAME for the xdg_app_* functions
 # This MUST be called before using any xdg_app_* functions.
 xdg_set_app_name() {
     local name="${1:-}"

--- a/nut.toml
+++ b/nut.toml
@@ -28,7 +28,11 @@ description = "Strict conventions. No compromises. No technical debt."
 [paths]
 lib_dir = "lib"
 exclude = [".git", ".legacy", "node_modules", "vendor", "target", "dist", "build", "templates", "/impl/", "impl/"]
-include = ["*.sh"]
+# The extensionless entry points count too. `bin/nutshell` is the interpreter
+# and `init` is the bootstrap, and an `include` of `*.sh` alone means the two
+# files most worth checking are the two the checks cannot see. A change adding
+# public functions to `init` passed `public_api_docs` by being invisible to it.
+include = ["*.sh", "init", "test", "check", "bin/nutshell"]
 
 # -----------------------------------------------------------------------------
 # Annotations - Semantic markers that explain WHY exceptions exist

--- a/test
+++ b/test
@@ -17,6 +17,16 @@ set -uo pipefail
 use test log
 
 if [[ $# -gt 0 ]]; then
+    # A named file that is not there is an error, not an empty run. This used to
+    # print `no test file` and then `[OK] 0 passed` and exit 0, so a typo in a
+    # path produced a green run that ran nothing, which is the one result a test
+    # command must never give.
+    for f in "$@"; do
+        if [[ ! -f "$f" ]]; then
+            log_error "no such test file: ${f}"
+            exit 2
+        fi
+    done
     for f in "$@"; do
         log_step "${f##*/}"
         test_run "$f"

--- a/tests/cli_args_test.sh
+++ b/tests/cli_args_test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# What the interpreter does with its own arguments.
+#
+# `-c` is here because every other shell takes it, so people write it, and this
+# used to read it as a filename and answer `script not found: -c`. That is a
+# true sentence about the wrong thing, and it sends the reader looking for a
+# missing file rather than for a missing feature.
+
+use test
+
+nut() { "${NUT_BIN}" "$@" 2>&1; }
+
+# Resolved once. The suite runs from the repository, and the interpreter under
+# test is this checkout's rather than whichever one is on PATH.
+NUT_BIN="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/bin/nutshell"
+
+#[test]
+it_runs_a_command_given_with_dash_c() {
+    assert_eq "$(nut -c 'echo hello')" "hello"
+}
+
+#[test]
+it_loads_modules_in_a_dash_c_command() {
+    assert_eq "$(nut -c 'use string; str_trim "  x  "')" "x"
+}
+
+# The regression this file exists for. Running the script sits outside the case
+# statement precisely so that two branches can reach it; when it lived inside
+# the path branch, `-c` set a script and then fell out of the case, so the
+# command never ran and the exit code was zero.
+#[test]
+it_actually_runs_the_command_rather_than_exiting_quietly() {
+    local out
+    out="$(nut -c 'printf ran')"
+    assert_eq "$out" "ran"
+    assert_ne "$out" ""
+}
+
+#[test]
+it_refuses_a_dash_c_with_nothing_after_it() {
+    assert_contains "$(nut -c)" "needs a command"
+    assert_exits 2 "${NUT_BIN}" -c
+}
+
+# An unknown flag is a mistake, not a filename. Reported as a file it produces a
+# not-found error naming the flag, which reads as a broken path.
+#[test]
+it_names_an_unknown_option_as_an_option() {
+    local out
+    out="$(nut --no-such-flag)"
+    assert_contains "$out" "unknown option"
+    assert_exits 2 "${NUT_BIN}" --no-such-flag
+}
+
+#[test]
+it_still_runs_an_ordinary_script_path() {
+    local d out
+    d="$(mktemp -d)"
+    printf 'echo from-a-file\n' > "$d/s.sh"
+    out="$(nut "$d/s.sh")"
+    assert_eq "$out" "from-a-file"
+    rm -rf "$d"
+}
+
+#[test]
+it_still_says_so_when_a_script_path_is_wrong() {
+    assert_contains "$(nut /no/such/script.sh)" "script not found"
+}

--- a/tests/own_modules_test.sh
+++ b/tests/own_modules_test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# A unit reaching its own library, and a file knowing where it is.
+#
+# Both exist because of the same gap. `use foo` resolves nutshell's set and
+# `use dep::foo` resolves a declared dependency, so a project had no way at all
+# to name a module it wrote itself, and every consumer hand-rolled a path
+# instead. Those paths were anchored on NUTSHELL_SCRIPT_DIR, which names the
+# entry point rather than the file doing the asking, so they broke the moment
+# the entry point moved. A whole suite went down that way.
+
+use test
+
+# nutshell stats the script it is given, so a process substitution reaching it as
+# /dev/fd/62 is not a path it can resolve. Real file, in the unit.
+run_script() {
+    local dir="$1" body="$2"
+    printf '%b' "$body" > "$dir/entry.sh"
+    (cd "$dir" && nutshell "$dir/entry.sh" 2>&1)
+}
+
+# A throwaway unit: a nut.toml to mark it, a lib/ with a module in it.
+make_unit() {
+    local dir
+    dir="$(mktemp -d)"
+    mkdir -p "$dir/lib"
+    printf '[deps]\n' > "$dir/nut.toml"
+    printf 'nut_once || return 0\ngreet() { printf mine; }\n' > "$dir/lib/mine.sh"
+    printf '%s' "$dir"
+}
+
+#[test]
+it_reaches_a_module_this_unit_wrote() {
+    local d out
+    d="$(make_unit)"
+    out="$(cd "$d" && run_script "$d" 'use super::mine\ngreet\n' 2>&1)"
+    assert_eq "$out" "mine"
+    rm -rf "$d"
+}
+
+#[test]
+it_says_so_when_the_unit_has_no_such_module() {
+    local d out
+    d="$(make_unit)"
+    out="$(cd "$d" && run_script "$d" 'use super::absent\n' 2>&1)"
+    assert_contains "$out" "no module"
+    rm -rf "$d"
+}
+
+# The case that must fail, and the reason `super::` does not fall through.
+#
+# `string` is a real nutshell module. A unit with no `lib/string.sh` that writes
+# `use super::string` has to be told so rather than handed nutshell's, or it
+# loads something it did not write, cannot tell, and gets whatever that module
+# happens to define.
+#[test]
+it_does_not_fall_through_to_nutshells_own_module_of_the_same_name() {
+    local d out
+    d="$(make_unit)"
+    out="$(cd "$d" && run_script "$d" 'use super::string\n' 2>&1)"
+    assert_contains "$out" "no module"
+    rm -rf "$d"
+}
+
+#[test]
+it_refuses_when_there_is_no_manifest_to_mark_the_unit() {
+    local d out
+    d="$(mktemp -d)" # deliberately no nut.toml
+    out="$(cd "$d" && run_script "$d" 'use super::mine\n' 2>&1)"
+    assert_contains "$out" "nut.toml"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_the_calling_file_and_not_the_entry_point() {
+    local d out
+    d="$(mktemp -d)"
+    mkdir -p "$d/lib"
+    printf '[deps]\n' > "$d/nut.toml"
+    printf 'nut_once || return 0\nwhere_am_i() { nut_dir; }\n' > "$d/lib/probe.sh"
+    out="$(cd "$d" && run_script "$d" 'use super::probe\nwhere_am_i\n' 2>&1)"
+    # The module lives in lib/ and the entry script does not, so an answer
+    # derived from NUTSHELL_SCRIPT_DIR would name the entry script's directory.
+    assert_contains "$out" "/lib"
+    rm -rf "$d"
+}
+
+#[test]
+it_gives_a_file_and_a_dir_that_agree() {
+    local d out dir file
+    d="$(mktemp -d)"
+    mkdir -p "$d/lib"
+    printf '[deps]\n' > "$d/nut.toml"
+    printf 'nut_once || return 0\nboth() { printf "%%s|%%s" "$(nut_dir)" "$(nut_file)"; }\n' \
+        > "$d/lib/probe.sh"
+    out="$(cd "$d" && run_script "$d" 'use super::probe\nboth\n' 2>&1)"
+    dir="${out%%|*}"
+    file="${out##*|}"
+    assert_eq "$file" "${dir}/probe.sh"
+    rm -rf "$d"
+}

--- a/tests/own_modules_test.sh
+++ b/tests/own_modules_test.sh
@@ -84,6 +84,53 @@ it_reports_the_calling_file_and_not_the_entry_point() {
     rm -rf "$d"
 }
 
+# The case a review found, and the reason the test below is not enough on its
+# own. A source with no slash in it, which is what `bash s.sh` from the file's
+# own directory produces, made `nut_dir` return empty and `nut_file` return
+# `/s.sh`: a wrong absolute path with a zero exit. The documented
+# `source "$(nut_dir)/helper.sh"` became `source "/helper.sh"`.
+#[test]
+it_resolves_a_source_name_carrying_no_directory() {
+    local d out
+    d="$(mktemp -d)"
+    printf 'printf "dir=%%s file=%%s" "$(nut_dir)" "$(nut_file)"\n' > "$d/s.sh"
+    out="$(cd "$d" && nutshell s.sh 2>&1)"
+    assert_contains "$out" "dir=${d}"
+    assert_contains "$out" "file=${d}/s.sh"
+    # the shape of the old answer, which must not come back
+    assert_ne "$out" "dir= file=/s.sh"
+    rm -rf "$d"
+}
+
+# `super::` resolved from the entry point rather than from the file asking, so a
+# module inside a unit failed when the entry script and the working directory
+# were both outside it. That is the entry-point anchoring `nut_dir` exists to
+# correct, and it shipped in the same change.
+#
+# Every other test here puts the entry script at the unit root and cds there,
+# which is the one arrangement where entry-point and manifest anchoring cannot
+# be told apart. This is the arrangement where they can.
+#[test]
+it_anchors_on_the_asking_file_and_not_on_the_entry_point() {
+    local d out
+    d="$(mktemp -d)"
+    mkdir -p "$d/unit/lib" "$d/elsewhere"
+    printf '[deps]\n' > "$d/unit/nut.toml"
+    printf 'nut_once || return 0\ngreet() { printf mine; }\n' > "$d/unit/lib/mine.sh"
+    printf 'nut_once || return 0\nuse super::mine\n' > "$d/unit/lib/caller.sh"
+    printf 'source "%s/unit/lib/caller.sh"\ngreet\n' "$d" > "$d/elsewhere/entry.sh"
+    out="$(cd "$d/elsewhere" && nutshell "$d/elsewhere/entry.sh" 2>&1)"
+    assert_eq "$out" "mine"
+    rm -rf "$d"
+}
+
+# The control this file was missing. `it_gives_a_file_and_a_dir_that_agree`
+# relates two answers to each other and constrains neither: with `nut_dir`
+# empty and `nut_file` `/probe.sh`, `"${dir}/probe.sh"` equals `"$file"` and it
+# passes. It did pass, in the broken state, in the same run where the
+# correctness test failed.
+#
+# So the agreement is checked against something outside both.
 #[test]
 it_gives_a_file_and_a_dir_that_agree() {
     local d out dir file
@@ -96,5 +143,7 @@ it_gives_a_file_and_a_dir_that_agree() {
     dir="${out%%|*}"
     file="${out##*|}"
     assert_eq "$file" "${dir}/probe.sh"
+    # and against the tree, so an empty dir with a matching file cannot pass
+    assert_eq "$dir" "$(cd "$d/lib" && pwd)"
     rm -rf "$d"
 }


### PR DESCRIPTION
## Summary

Four gaps found by using nutshell hard for a day and getting each one wrong. Every workaround I wrote in two other repositories traced back to one of these.

**A unit could not reach a module it wrote itself.** `use foo` resolves nutshell's set and `use dep::foo` resolves a declared dependency; a project is neither of those to itself. So there was no way to say it, and consumers hand-rolled paths instead. `super::` is the third namespace:

| Written | Resolves to |
|---|---|
| `use log` | nutshell's own module |
| `use shebang::diagnostics/findings` | a module in a declared dependency |
| `use super::mine` | `lib/mine.sh` in **this** unit, found from its `nut.toml` |

Anchored on the manifest rather than the running script, so a module three directories down reaches `lib/` the same way the entry script does. **It does not fall through**: `use super::string` in a project with no `lib/string.sh` errors naming the module rather than quietly loading nutshell's, because a unit handed a module it did not write has no way to tell.

**Nothing named the current file.** Ten `NUTSHELL_*` variables are exported, and `NUTSHELL_SCRIPT_DIR` was the only one usable for a path. It names the *entry point*, so a module building a path from it describes somebody else's location. That took a whole test suite down when a runner moved from `tests/` to a repository root.

`nut_dir` and `nut_file` are the current-file answer. The prior art is unanimous on which way round this goes:

- Deno: `import.meta.dirname` is "the absolute path of the directory containing the **current module**"; the entry point is separately named as `import.meta.main`.
- Rust: `include_str!` is "located **relative to the current file**"; the package root is separately named as `CARGO_MANIFEST_DIR`.

Both make the current file the default and give the entry point its own name. nutshell shipped only the entry point.

**`-c` was read as a filename**, answering `script not found: -c`, a true sentence about the wrong thing, which sends a reader looking for a missing file rather than a missing feature. An unknown flag now says it is a flag.

**None of it was documented**, all ten variables included. That is why somebody who had used this a lot still got every one of them wrong.

## Worth reviewing rather than skimming

Running the script **moved out of the `*)` case arm**, because two branches reach it now. The first version of `-c` left it there, so `-c` set a script and then fell out of the case: `-c 'echo hello'` printed nothing and exited zero. The regression test for exactly that is `it_actually_runs_the_command_rather_than_exiting_quietly`.

Whether `super::` is the right spelling is yours. It reads as "the unit above this file", which is what it resolves to, and it does not collide with a dependency name the way `self` might if somebody names a dep that.

## Test plan

`./test`: **145 passed**, up from 130. Fifteen new across two files.

The controls are real. Making `super::` fall through to nutshell's own set turns **all six** of its tests red, including `it_does_not_fall_through_to_nutshells_own_module_of_the_same_name`, which is the one that matters: it asserts a unit with no `lib/string.sh` is told so rather than handed nutshell's `string`.

`it_reports_the_calling_file_and_not_the_entry_point` puts the module in `lib/` and the entry script outside it, so an answer derived from `NUTSHELL_SCRIPT_DIR` names the wrong directory and fails.

