### PR TITLE
chore: 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Add nutshell to your project:
 git submodule add https://github.com/orgrinrt/nutshell.git scripts/lib/nutshell
 
 # Option B: Download a source archive (releases ship no built artifacts).
-# 0.2.0 is the latest tag; check the releases page for newer ones.
+# 0.3.0 is the latest tag; check the releases page for newer ones.
 mkdir -p scripts/lib/nutshell
-curl -L https://github.com/orgrinrt/nutshell/archive/refs/tags/0.2.0.tar.gz \
+curl -L https://github.com/orgrinrt/nutshell/archive/refs/tags/0.3.0.tar.gz \
     | tar -xz --strip-components=1 -C scripts/lib/nutshell
 ```
 

--- a/init
+++ b/init
@@ -26,7 +26,7 @@ _NUTSHELL_ROOT="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 
 # Export for use by modules
 export NUTSHELL_ROOT="${_NUTSHELL_ROOT}"
-export NUTSHELL_VERSION="0.2.0"
+export NUTSHELL_VERSION="0.3.0"
 
 # Script identity belongs to the interpreter invocation, not to ancestry. The
 # interpreter exports NUTSHELL_SCRIPT and NUTSHELL_SCRIPT_DIR after this file


### PR DESCRIPTION
Version bump and the two install lines that name a tag. Merges to `dev` ahead of the release PR.