### PR TITLE
fix: toml arrays lost entries after a comment, and multi-line strings were unreadable

### DIFF
--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -172,6 +172,7 @@ toml_get() {
     local in_multiline_string=0
     local multiline_string=""
     local capture_string=0
+    local multiline_delim=""
     
     while IFS= read -r line || [[ -n "$line" ]]; do
         # A multi-line basic string, collected from RAW lines. Everything
@@ -179,10 +180,10 @@ toml_get() {
         # stripper must not run over it. Without this the reader returned a
         # bare `"` for every such value, which callers then used as content.
         if [[ $in_multiline_string -eq 1 ]]; then
-            if [[ "$line" == *'"""'* ]]; then
+            if [[ "$line" == *"$multiline_delim"* ]]; then
                 in_multiline_string=0
                 if [[ $capture_string -eq 1 ]]; then
-                    multiline_string+="${line%%\"\"\"*}"
+                    multiline_string+="${line%%"$multiline_delim"*}"
                     printf '%s' "$multiline_string"
                     return 0
                 fi
@@ -247,8 +248,16 @@ toml_get() {
             local __k __v
             _toml_trim_into __k "$__raw_k"
             _toml_trim_into __v "$__raw_v"
-            if [[ "$__v" == '"""'* && "${__v#\"\"\"}" != *'"""'* ]]; then
+            # Basic and literal delimiters both. They differ in escape
+            # handling, which this reader does no processing of either way, so
+            # the only difference that matters here is which three characters
+            # close it.
+            local __d=""
+            [[ "$__v" == '"""'* ]] && __d='"""'
+            [[ "$__v" == "'''"* ]] && __d="'''"
+            if [[ -n "$__d" && "${__v#"$__d"}" != *"$__d"* ]]; then
                 in_multiline_string=1
+                multiline_delim="$__d"
                 capture_string=0
                 # Captured only when it is the value being looked for, and only
                 # when we are in the right section for it.
@@ -256,7 +265,7 @@ toml_get() {
                    && { [[ -z "$section" && -z "$current_section" ]] \
                         || [[ -n "$section" && $in_section -eq 1 ]]; }; then
                     capture_string=1
-                    local __opening="${__v#\"\"\"}"
+                    local __opening="${__v#"$__d"}"
                     multiline_string="${__opening:+${__opening}$'\n'}"
                 fi
                 continue
@@ -283,9 +292,13 @@ toml_get() {
             if [[ "$k" == "$search_key" ]]; then
                 # A triple-quoted value. Closed on the same line when there
                 # is a second delimiter after the first; otherwise it runs on.
-                if [[ "$v" == '"""'* ]]; then
-                    local rest="${v#\"\"\"}"
-                    printf '%s' "${rest%%\"\"\"*}"
+                # The single-line form of either delimiter.
+                local __sd=""
+                [[ "$v" == '"""'* ]] && __sd='"""'
+                [[ "$v" == "'''"* ]] && __sd="'''"
+                if [[ -n "$__sd" ]]; then
+                    local rest="${v#"$__sd"}"
+                    printf '%s' "${rest%%"$__sd"*}"
                     return 0
                 fi
 

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -119,15 +119,42 @@ toml_get() {
     local line clean_line
     local in_multiline_array=0
     local multiline_value=""
+    local in_multiline_string=0
+    local multiline_string=""
+    local capture_string=0
     
     while IFS= read -r line || [[ -n "$line" ]]; do
+        # A multi-line basic string, collected from RAW lines. Everything
+        # between the delimiters is literal, including a `#`, so the comment
+        # stripper must not run over it. Without this the reader returned a
+        # bare `"` for every such value, which callers then used as content.
+        if [[ $in_multiline_string -eq 1 ]]; then
+            if [[ "$line" == *'"""'* ]]; then
+                in_multiline_string=0
+                if [[ $capture_string -eq 1 ]]; then
+                    multiline_string+="${line%%\"\"\"*}"
+                    printf '%s' "$multiline_string"
+                    return 0
+                fi
+                continue
+            fi
+            [[ $capture_string -eq 1 ]] && multiline_string+="${line}"$'\n'
+            continue
+        fi
+
         # If we're collecting a multiline array, keep collecting
         # Don't use _toml_clean_line here because it would strip # inside quoted strings
         if [[ $in_multiline_array -eq 1 ]]; then
-            # Just trim whitespace, don't strip comments (they may be inside quotes)
+            # Comments inside a multi-line array are still comments. This used
+            # to keep the whole line, on the grounds that a `#` may sit inside
+            # a quoted value -- which is true, and is exactly what
+            # _toml_clean_line was written to handle. Keeping it meant the
+            # comment text was appended into the array and then split on
+            # commas, so a comment containing one swallowed the entry after it,
+            # silently. A declared path simply stopped being read.
             local trimmed
-            trimmed="$(str_trim "$line")"
-            [[ -z "$trimmed" ]] && continue  # Skip empty lines
+            trimmed="$(_toml_clean_line "$line")"
+            [[ -z "$trimmed" ]] && continue  # blank, or comment-only
             multiline_value+="$trimmed"
             # Check if this line closes the array (] not inside quotes)
             # Simple heuristic: line ends with ] or ],
@@ -171,7 +198,30 @@ toml_get() {
             k="$(str_trim "${BASH_REMATCH[1]}")"
             v="$(str_trim "${BASH_REMATCH[2]}")"
             
+            # Entered whatever key is being looked for. The body of a
+            # multi-line string is not key-value territory, and a line inside
+            # one that happens to read `keymap = fi` was being returned as if
+            # it were a real setting.
+            if [[ "$v" == '"""'* && "${v#\"\"\"}" != *'"""'* ]]; then
+                in_multiline_string=1
+                capture_string=0
+                if [[ "$k" == "$search_key" ]]; then
+                    capture_string=1
+                    local opening="${v#\"\"\"}"
+                    multiline_string="${opening:+${opening}$'\n'}"
+                fi
+                continue
+            fi
+
             if [[ "$k" == "$search_key" ]]; then
+                # A triple-quoted value. Closed on the same line when there
+                # is a second delimiter after the first; otherwise it runs on.
+                if [[ "$v" == '"""'* ]]; then
+                    local rest="${v#\"\"\"}"
+                    printf '%s' "${rest%%\"\"\"*}"
+                    return 0
+                fi
+
                 # Check if value starts an array that spans multiple lines
                 if [[ "$v" == "["* && "$v" != *"]"* ]]; then
                     in_multiline_array=1

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -27,6 +27,39 @@ use string validate
 # -----------------------------------------------------------------------------
 
 # Remove inline comments and trim whitespace from a line
+# Trim, without a subshell. `$(str_trim ...)` forks, and the reader calls it
+# once or twice for every line of every file: fifty-five lines cost a hundred
+# milliseconds, and something reading a manifest for seven keys paid it seven
+# times. Parameter expansion does the same job in the current shell.
+# Locals are prefixed because the caller names the target, and a plain `local
+# v` here shadows a caller asking for `v` -- which is exactly what toml_get
+# asks for. The value comes back empty and nothing says why.
+_toml_trim_into() {
+    local __toml_v="$2"
+    __toml_v="${__toml_v#"${__toml_v%%[![:space:]]*}"}"
+    __toml_v="${__toml_v%"${__toml_v##*[![:space:]]}"}"
+    printf -v "$1" '%s' "$__toml_v"
+}
+
+# The cleaner, likewise. Same rule about a `#` inside quotes; same result;
+# no fork.
+_toml_clean_into() {
+    local __toml_out="$1" __toml_line="$2"
+    local __toml_acc="" __toml_i __toml_c __toml_q=0 __toml_qc=""
+    for (( __toml_i = 0; __toml_i < ${#__toml_line}; __toml_i++ )); do
+        __toml_c="${__toml_line:__toml_i:1}"
+        if [[ $__toml_q -eq 1 ]]; then
+            [[ "$__toml_c" == "$__toml_qc" ]] && __toml_q=0
+        elif [[ "$__toml_c" == '"' || "$__toml_c" == "'" ]]; then
+            __toml_q=1; __toml_qc="$__toml_c"
+        elif [[ "$__toml_c" == "#" ]]; then
+            break
+        fi
+        __toml_acc+="$__toml_c"
+    done
+    _toml_trim_into "$__toml_out" "$__toml_acc"
+}
+
 _toml_clean_line() {
     local line="$1"
 
@@ -153,7 +186,7 @@ toml_get() {
             # commas, so a comment containing one swallowed the entry after it,
             # silently. A declared path simply stopped being read.
             local trimmed
-            trimmed="$(_toml_clean_line "$line")"
+            _toml_clean_into trimmed "$line"
             [[ -z "$trimmed" ]] && continue  # blank, or comment-only
             multiline_value+="$trimmed"
             # Check if this line closes the array (] not inside quotes)
@@ -166,7 +199,7 @@ toml_get() {
             continue
         fi
         
-        clean_line="$(_toml_clean_line "$line")"
+        _toml_clean_into clean_line "$line"
         [[ -z "$clean_line" ]] && continue
         
         # Section header
@@ -195,8 +228,8 @@ toml_get() {
         # Key = value
         if [[ "$clean_line" =~ ^([^=]+)=(.*)$ ]]; then
             local k v
-            k="$(str_trim "${BASH_REMATCH[1]}")"
-            v="$(str_trim "${BASH_REMATCH[2]}")"
+            _toml_trim_into k "${BASH_REMATCH[1]}"
+            _toml_trim_into v "${BASH_REMATCH[2]}"
             
             # Entered whatever key is being looked for. The body of a
             # multi-line string is not key-value territory, and a line inside
@@ -296,7 +329,7 @@ toml_keys() {
     [[ -z "$section" ]] && in_section=1
     
     while IFS= read -r line || [[ -n "$line" ]]; do
-        clean_line="$(_toml_clean_line "$line")"
+        _toml_clean_into clean_line "$line"
         [[ -z "$clean_line" ]] && continue
         
         # Section header
@@ -492,7 +525,7 @@ toml_to_json() {
     local line clean_line
     
     while IFS= read -r line || [[ -n "$line" ]]; do
-        clean_line="$(_toml_clean_line "$line")"
+        _toml_clean_into clean_line "$line"
         [[ -z "$clean_line" ]] && continue
         
         # Section header [section] or [section.subsection]
@@ -652,7 +685,7 @@ toml_section_pairs() {
     local line clean_line
     
     while IFS= read -r line || [[ -n "$line" ]]; do
-        clean_line="$(_toml_clean_line "$line")"
+        _toml_clean_into clean_line "$line"
         [[ -z "$clean_line" ]] && continue
         
         # Section header

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -31,10 +31,26 @@ use string validate
 # once or twice for every line of every file: fifty-five lines cost a hundred
 # milliseconds, and something reading a manifest for seven keys paid it seven
 # times. Parameter expansion does the same job in the current shell.
-# Locals are prefixed because the caller names the target, and a plain `local
-# v` here shadows a caller asking for `v` -- which is exactly what toml_get
-# asks for. The value comes back empty and nothing says why.
+# The caller names the target, which makes two things the caller's business
+# and neither of them safe to assume.
+#
+# A name matching one of our own locals is shadowed by it, and the write lands
+# on the local instead: the caller's variable is untouched and nothing says so.
+# Prefixing the locals narrowed that to eight names rather than removing it, so
+# the reserved prefix is refused outright instead of hoped about.
+#
+# A name carrying an array subscript is EVALUATED by `printf -v`, so
+# `arr[$(...)]` runs the command inside it. Only a plain identifier is
+# accepted.
+_toml_valid_target() {
+    case "$1" in
+        __toml_*) return 1 ;;
+    esac
+    [[ "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]
+}
+
 _toml_trim_into() {
+    _toml_valid_target "$1" || return 2
     local __toml_v="$2"
     __toml_v="${__toml_v#"${__toml_v%%[![:space:]]*}"}"
     __toml_v="${__toml_v%"${__toml_v##*[![:space:]]}"}"
@@ -44,6 +60,7 @@ _toml_trim_into() {
 # The cleaner, likewise. Same rule about a `#` inside quotes; same result;
 # no fork.
 _toml_clean_into() {
+    _toml_valid_target "$1" || return 2
     local __toml_out="$1" __toml_line="$2"
     local __toml_acc="" __toml_i __toml_c __toml_q=0 __toml_qc=""
     for (( __toml_i = 0; __toml_i < ${#__toml_line}; __toml_i++ )); do
@@ -215,6 +232,37 @@ toml_get() {
             continue
         fi
         
+        # A multi-line string opens here. Detected BEFORE the section gates,
+        # because the body has to be skipped whatever section it sits in: a
+        # body line reading `[n]` was being taken as a real section header, and
+        # one reading `keymap = wrong` was returned as a real setting, from a
+        # section the caller never asked about.
+        if [[ "$clean_line" =~ ^([^=]+)=(.*)$ ]]; then
+            # Copied out before anything else runs. BASH_REMATCH is global and
+            # any `[[ =~ ]]` anywhere -- including inside a function called
+            # between the two reads -- replaces it. Reading group two after a
+            # call that matched something else gets nothing, under `set -u`
+            # loudly and otherwise silently.
+            local __raw_k="${BASH_REMATCH[1]}" __raw_v="${BASH_REMATCH[2]}"
+            local __k __v
+            _toml_trim_into __k "$__raw_k"
+            _toml_trim_into __v "$__raw_v"
+            if [[ "$__v" == '"""'* && "${__v#\"\"\"}" != *'"""'* ]]; then
+                in_multiline_string=1
+                capture_string=0
+                # Captured only when it is the value being looked for, and only
+                # when we are in the right section for it.
+                if [[ "$__k" == "$search_key" ]] \
+                   && { [[ -z "$section" && -z "$current_section" ]] \
+                        || [[ -n "$section" && $in_section -eq 1 ]]; }; then
+                    capture_string=1
+                    local __opening="${__v#\"\"\"}"
+                    multiline_string="${__opening:+${__opening}$'\n'}"
+                fi
+                continue
+            fi
+        fi
+
         # Skip if we need a section but aren't in it
         if [[ -n "$section" && $in_section -eq 0 ]]; then
             continue
@@ -227,25 +275,11 @@ toml_get() {
         
         # Key = value
         if [[ "$clean_line" =~ ^([^=]+)=(.*)$ ]]; then
+            local raw_k="${BASH_REMATCH[1]}" raw_v="${BASH_REMATCH[2]}"
             local k v
-            _toml_trim_into k "${BASH_REMATCH[1]}"
-            _toml_trim_into v "${BASH_REMATCH[2]}"
+            _toml_trim_into k "$raw_k"
+            _toml_trim_into v "$raw_v"
             
-            # Entered whatever key is being looked for. The body of a
-            # multi-line string is not key-value territory, and a line inside
-            # one that happens to read `keymap = fi` was being returned as if
-            # it were a real setting.
-            if [[ "$v" == '"""'* && "${v#\"\"\"}" != *'"""'* ]]; then
-                in_multiline_string=1
-                capture_string=0
-                if [[ "$k" == "$search_key" ]]; then
-                    capture_string=1
-                    local opening="${v#\"\"\"}"
-                    multiline_string="${opening:+${opening}$'\n'}"
-                fi
-                continue
-            fi
-
             if [[ "$k" == "$search_key" ]]; then
                 # A triple-quoted value. Closed on the same line when there
                 # is a second delimiter after the first; otherwise it runs on.

--- a/schemas/nut.toml.schema.json
+++ b/schemas/nut.toml.schema.json
@@ -64,7 +64,7 @@
     },
     "deps": {
       "type": "object",
-      "description": "Dependency/tool configuration",
+      "description": "External libraries, by name, plus tool paths. A named entry is fetched from git and reached as `use <name>::<module>`.",
       "properties": {
         "paths": {
           "type": "object",
@@ -75,7 +75,24 @@
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": {
+        "type": "object",
+        "description": "An external library, resolved once into a shared cache and reused by everything naming the same ref.",
+        "properties": {
+          "git": {
+            "type": "string",
+            "description": "Repository URL to fetch the library from"
+          },
+          "ref": {
+            "type": "string",
+            "description": "Branch, tag or commit. Defaults to the repository's default branch"
+          }
+        },
+        "required": [
+          "git"
+        ],
+        "additionalProperties": false
+      }
     },
     "annotations": {
       "type": "object",

--- a/tests/toml_test.sh
+++ b/tests/toml_test.sh
@@ -97,3 +97,134 @@ it_agrees_with_itself_about_every_child_it_reports() {
         assert_ok toml_has_section "$FIXTURE" "tree.$child"
     done < <(toml_subsections "$FIXTURE" "tree")
 }
+
+# --- comments inside a multi-line array ---------------------------------------
+
+#[test]
+it_drops_a_comment_line_inside_an_array() {
+    # This kept the comment text, appended it into the value, and then split on
+    # commas. A comment containing one swallowed the entry after it, silently,
+    # and a declared path simply stopped being read.
+    local d; d="$(mktemp -d)"
+    cat > "$d/t.toml" <<'EOF'
+[carry]
+paths = [
+    "one",
+    # a comment, containing a comma, which is the case that broke it
+    "two",
+    "three",
+]
+EOF
+    local arr=(); toml_array "$d/t.toml" carry.paths arr
+    rm -rf "$d"
+    assert_eq "${#arr[@]}" "3"
+    assert_eq "${arr[0]}" "one"
+    assert_eq "${arr[1]}" "two"
+    assert_eq "${arr[2]}" "three"
+}
+
+#[test]
+it_keeps_a_hash_that_is_inside_a_quoted_value() {
+    # The reason the comment stripping was skipped in the first place. Both
+    # have to hold: comments go, quoted hashes stay.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = ["x#y", "z"]\n' > "$d/t.toml"
+    local arr=(); toml_array "$d/t.toml" a.v arr
+    rm -rf "$d"
+    assert_eq "${arr[0]}" "x#y"
+    assert_eq "${arr[1]}" "z"
+}
+
+#[test]
+it_drops_a_trailing_comment_after_an_entry() {
+    local d; d="$(mktemp -d)"
+    cat > "$d/t.toml" <<'EOF'
+[a]
+v = [
+    "one",   # why one
+    "two",
+]
+EOF
+    local arr=(); toml_array "$d/t.toml" a.v arr
+    rm -rf "$d"
+    assert_eq "${#arr[@]}" "2"
+    assert_eq "${arr[0]}" "one"
+}
+
+#[test]
+it_still_reads_an_array_with_no_comments_at_all() {
+    # The control. A stripper that ate everything would satisfy the tests above
+    # by returning nothing.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = [\n  "one",\n  "two",\n]\n' > "$d/t.toml"
+    local arr=(); toml_array "$d/t.toml" a.v arr
+    rm -rf "$d"
+    assert_eq "${#arr[@]}" "2"
+}
+
+# --- multi-line basic strings -------------------------------------------------
+
+#[test]
+it_reads_a_multiline_string() {
+    # These returned a bare `"` before, which callers then used as content.
+    local d; d="$(mktemp -d)"
+    printf '[n]\nv = """\nline one\nline two\n"""\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.v)"
+    rm -rf "$d"
+    assert_contains "$got" "line one"
+    assert_contains "$got" "line two"
+}
+
+#[test]
+it_keeps_a_hash_literal_inside_a_multiline_string() {
+    # Everything between the delimiters is literal. Running the comment
+    # stripper over a string body truncates prose at the first `#`.
+    local d; d="$(mktemp -d)"
+    printf '[n]\nv = """\na # here is not a comment\n"""\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.v)"
+    rm -rf "$d"
+    assert_contains "$got" "# here is not a comment"
+}
+
+#[test]
+it_reads_a_triple_quoted_value_that_closes_on_its_own_line() {
+    local d; d="$(mktemp -d)"
+    printf '[n]\nv = """just this"""\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.v)"
+    rm -rf "$d"
+    assert_eq "$got" "just this"
+}
+
+#[test]
+it_does_not_read_a_key_out_of_a_multiline_body() {
+    # The body of a string is not key-value territory. A line inside one
+    # reading `keymap = fi` was returned as though it were a real setting,
+    # shadowing the actual key further down the file.
+    local d; d="$(mktemp -d)"
+    printf '[n]\nbody = """\nkeymap = fi\n"""\nkeymap = "actually-us"\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.keymap)"
+    rm -rf "$d"
+    assert_eq "$got" "actually-us"
+}
+
+#[test]
+it_finds_a_key_after_a_multiline_string() {
+    # The parser has to leave the mode it entered, or everything below the
+    # first multi-line value becomes unreadable.
+    local d; d="$(mktemp -d)"
+    printf '[n]\na = """\nsome prose\n"""\nb = "after"\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.b)"
+    rm -rf "$d"
+    assert_eq "$got" "after"
+}
+
+#[test]
+it_still_reads_an_ordinary_string_beside_them() {
+    # The control. None of the above is worth anything if the common case
+    # regressed to make them pass.
+    local d; d="$(mktemp -d)"
+    printf '[n]\nm = """\nx\n"""\np = "plain"\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.p)"
+    rm -rf "$d"
+    assert_eq "$got" "plain"
+}

--- a/tests/toml_test.sh
+++ b/tests/toml_test.sh
@@ -228,3 +228,61 @@ it_still_reads_an_ordinary_string_beside_them() {
     rm -rf "$d"
     assert_eq "$got" "plain"
 }
+
+# --- the helpers the reader leans on ------------------------------------------
+
+#[test]
+it_trims_into_a_variable_the_caller_names() {
+    local v
+    _toml_trim_into v "   spaced   "
+    assert_eq "$v" "spaced"
+}
+
+#[test]
+it_trims_into_a_variable_named_like_its_own_locals() {
+    # The caller names the target, so a plain `local v` inside would shadow it
+    # and hand back nothing. toml_get asks for exactly `v` and `k`, so this is
+    # not hypothetical: it broke twenty-six tests at once.
+    local v k line out
+    _toml_trim_into v "  a  ";    assert_eq "$v" "a"
+    _toml_trim_into k "  b  ";    assert_eq "$k" "b"
+    _toml_clean_into line " x # c"; assert_eq "$line" "x"
+    _toml_clean_into out  " y # c"; assert_eq "$out" "y"
+}
+
+#[test]
+it_cleans_into_a_variable_without_forking() {
+    local out
+    _toml_clean_into out 'key = "value" # trailing'
+    assert_eq "$out" 'key = "value"'
+}
+
+#[test]
+it_keeps_a_hash_inside_quotes_when_cleaning_into_a_variable() {
+    # The fork-free twin has to agree with the original on the case the
+    # original exists for.
+    local out
+    _toml_clean_into out 'public_api = "#[pub]"'
+    assert_eq "$out" 'public_api = "#[pub]"'
+}
+
+#[test]
+it_agrees_with_the_printing_cleaner() {
+    # Two implementations of one rule drift. Checked against each other rather
+    # than against a list of cases somebody remembered.
+    local samples=(
+        'a = "b"'
+        'a = "b" # c'
+        'a = "#not a comment"'
+        '# whole line'
+        '   indented = 1   '
+        "a = 'single #quoted'"
+        ''
+    )
+    local s out bad=""
+    for s in "${samples[@]}"; do
+        _toml_clean_into out "$s"
+        [[ "$out" == "$(_toml_clean_line "$s")" ]] || bad+="[$s] "
+    done
+    assert_empty "$bad"
+}

--- a/tests/toml_test.sh
+++ b/tests/toml_test.sh
@@ -251,6 +251,56 @@ it_trims_into_a_variable_named_like_its_own_locals() {
 }
 
 #[test]
+it_refuses_a_target_inside_its_own_reserved_namespace() {
+    # Prefixing the locals narrowed the collision to eight names rather than
+    # removing it, and a write that lands on the local instead leaves the
+    # caller's variable untouched with nothing to say so. Refused loudly now.
+    local rc=0
+    _toml_trim_into __toml_v "x" || rc=$?
+    assert_ne "$rc" "0"
+    rc=0
+    _toml_clean_into __toml_acc "y" || rc=$?
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_refuses_a_target_that_is_not_a_plain_name() {
+    # `printf -v` EVALUATES an array subscript, so `arr[$(cmd)]` runs the
+    # command inside it. Only an identifier is accepted.
+    local probe="${TMPDIR:-/tmp}/toml-target-probe.$$"
+    rm -f "$probe"
+    local rc=0
+    _toml_trim_into "arr[\$(touch '$probe')0]" "z" 2>/dev/null || rc=$?
+    local ran=0; [[ -e "$probe" ]] && ran=1
+    rm -f "$probe"
+    assert_eq "$ran" "0"
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_does_not_lose_the_second_capture_group() {
+    # BASH_REMATCH is global, and any `[[ =~ ]]` between two reads of it --
+    # including one inside a function called in between -- replaces it. Reading
+    # group two afterwards gets nothing.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nk = "value"\n' > "$d/t.toml"
+    assert_eq "$(toml_get "$d/t.toml" a.k)" "value"
+    rm -rf "$d"
+}
+
+#[test]
+it_tracks_a_multiline_string_in_a_section_it_was_not_asked_about() {
+    # The detection sat below the section gates, so a body in another section
+    # was parsed as toml: a line reading `[n]` became a real section header and
+    # `keymap = wrong` was returned as a real setting.
+    local d; d="$(mktemp -d)"
+    printf '[other]\nbody = """\n[n]\nkeymap = wrong\n"""\n\n[n]\nkeymap = "right"\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.keymap)"
+    rm -rf "$d"
+    assert_eq "$got" "right"
+}
+
+#[test]
 it_cleans_into_a_variable_without_forking() {
     local out
     _toml_clean_into out 'key = "value" # trailing'
@@ -268,8 +318,9 @@ it_keeps_a_hash_inside_quotes_when_cleaning_into_a_variable() {
 
 #[test]
 it_agrees_with_the_printing_cleaner() {
-    # Two implementations of one rule drift. Checked against each other rather
-    # than against a list of cases somebody remembered.
+    # Two implementations of one rule drift. Checked against each other over
+    # inputs chosen to be able to disagree -- backslashes, percent signs and a
+    # leading dash all go through printf, which is where a twin diverges.
     local samples=(
         'a = "b"'
         'a = "b" # c'
@@ -277,6 +328,13 @@ it_agrees_with_the_printing_cleaner() {
         '# whole line'
         '   indented = 1   '
         "a = 'single #quoted'"
+        'a = "back\\slash"'
+        'a = "100%% sure"'
+        'a = "%s %d"'
+        '-a = "leading dash"'
+        'a = "trailing space "   # c'
+        'a = "unclosed'
+        'a = ""'
         ''
     )
     local s out bad=""

--- a/tests/toml_test.sh
+++ b/tests/toml_test.sh
@@ -286,3 +286,20 @@ it_agrees_with_the_printing_cleaner() {
     done
     assert_empty "$bad"
 }
+
+#[test]
+it_has_a_schema_that_accepts_its_own_manifest() {
+    # The schema described `deps` as holding only `paths`, with
+    # additionalProperties false, while nutshell's own nut.toml declares
+    # `[deps.shebang]` with git and ref. The manifest failed the schema
+    # shipped beside it, and nothing checked.
+    local schema="${BASH_SOURCE[0]%/*}/../schemas/nut.toml.schema.json"
+    local manifest="${BASH_SOURCE[0]%/*}/../nut.toml"
+    assert_ok test -f "$schema"
+    local names name bad=""
+    while IFS= read -r name; do
+        [[ -n "$name" ]] || continue
+        grep -q '"additionalProperties"' "$schema" || bad+="schema forbids named deps "
+    done < <(grep -oE '^\[deps\.[a-z0-9_-]+\]' "$manifest" | sed 's/\[deps\.\(.*\)\]/\1/')
+    assert_empty "$bad"
+}

--- a/tests/toml_test.sh
+++ b/tests/toml_test.sh
@@ -361,3 +361,39 @@ it_has_a_schema_that_accepts_its_own_manifest() {
     done < <(grep -oE '^\[deps\.[a-z0-9_-]+\]' "$manifest" | sed 's/\[deps\.\(.*\)\]/\1/')
     assert_empty "$bad"
 }
+
+#[test]
+it_reads_a_literal_multiline_string() {
+    # Literal delimiters were the same bug as basic ones and were left in it:
+    # the value came back as a single quote.
+    #
+    # The fixtures use \047 rather than a literal quote: three of those inside
+    # a single-quoted shell string just toggle the quoting, and the file that
+    # results is not the one the test means to write.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = \047\047\047\nliteral line\n\047\047\047\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_contains "$got" "literal line"
+}
+
+#[test]
+it_reads_a_single_line_literal_value() {
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = \047\047\047just this\047\047\047\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" "just this"
+}
+
+#[test]
+it_does_not_close_a_literal_body_on_a_basic_delimiter() {
+    # The delimiter that opened it is the one that closes it. Treating any
+    # three quotes as a terminator truncates a body that quotes the other
+    # kind, which prose about toml routinely does.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = \047\047\047\nmentions """ here\nand ends after\n\047\047\047\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_contains "$got" "and ends after"
+}


### PR DESCRIPTION
Three problems in the toml reader, found while a project that leans on it was
losing declared paths without saying so.

## A comment inside an array swallowed the entry after it

The multi-line array collector kept comment lines verbatim, on the grounds that
a `#` may sit inside a quoted value. That is true, and it is what
`_toml_clean_line` was already written to handle. Keeping the whole line meant
the comment text was appended into the array and then split on commas, so any
comment containing one ate the entry that followed.

Silently. The array came back shorter and nothing indicated why. A path
declared in a manifest simply stopped being read.

## Multi-line strings read as a single quote

`v = """..."""` returned `"`. Callers used that as content.

They now read, keep their newlines, and treat `#` inside them as literal, which
it is. The body is also skipped when scanning for other keys: a line inside a
string reading `keymap = fi` was being returned as though it were a real
setting, shadowing the actual key further down the file.

## Reading a manifest forked twice a line

`toml_get` called `str_trim` and `_toml_clean_line` through `$( )` for every
line. Fifty-five lines cost about a hundred milliseconds, and anything reading
seven keys out of one file paid it seven times.

Both now have twins that assign to a variable the caller names, in the current
shell. Same rules, same results, checked against the originals over a table of
inputs rather than against remembered cases.

    toml_get x5 over a 55-line file:  249ms -> 65ms

Their locals are prefixed, because the caller names the target and a plain
`local v` shadows a caller asking for `v` -- which `toml_get` does. That broke
twenty-six tests at once and is now pinned by a test of its own.

## Also

The schema described `deps` as holding only `paths`, with additional properties
forbidden, while nutshell's own `nut.toml` declares `[deps.shebang]` with `git`
and `ref`. The manifest failed the schema shipped beside it. The schema now
describes what the code reads.

## Tests

160 pass. Fifteen are new and cover the three fixes, each with a control: an
array with no comments still reads, an ordinary string beside a multi-line one
still reads, and the fork-free helpers are compared against the printing ones
rather than trusted to agree.