### PR TITLE
perf: resolve an external library once per process

### DIFF
--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -148,10 +148,38 @@ extern_declared() {
     printf '%s %s' "$url" "${ref:-HEAD}"
 }
 
+# Resolved paths, by name, for the life of this process.
+#
+# Every `use <dep>::<module>` resolves the dependency again: the manifest is
+# re-read, the lockfile re-read, the mirror and the worktree each asked whether
+# git will answer for them. None of that can change while a script runs, and a
+# program taking five modules out of one library paid it five times -- about
+# four hundred milliseconds before anything of its own happened.
+declare -gA _EXTERN_RESOLVED=()
+
+#[pub]
+# Forget what has been resolved. For a caller that has changed a lockfile and
+# wants the next lookup to see it, and for tests.
+# Usage: extern_forget [name]
+extern_forget() {
+    if [[ -n "${1:-}" ]]; then unset '_EXTERN_RESOLVED[$1]'; else _EXTERN_RESOLVED=(); fi
+}
+
 #[pub]
 # Usage: extern_path shebang -> prints the checkout, fetching it once if needed
 extern_path() {
     local name="$1" spec url ref mirror commit dir
+
+    if [[ -n "${_EXTERN_RESOLVED[$name]:-}" ]]; then
+        # Still checked, because a cached path whose checkout has been removed
+        # is worse than no cache: the caller gets a directory git will not
+        # answer for and no explanation.
+        if _extern_is_repo "${_EXTERN_RESOLVED[$name]}"; then
+            printf '%s' "${_EXTERN_RESOLVED[$name]}"
+            return 0
+        fi
+        unset '_EXTERN_RESOLVED[$name]'
+    fi
     spec="$(extern_declared "$name")" || return 1
     url="${spec%% *}"
     ref="${spec##* }"
@@ -174,6 +202,7 @@ extern_path() {
         _extern_guard "$dir" _extern_lay_out "$name" "$mirror" "$url" "$commit" "$dir" || return 1
     fi
 
+    _EXTERN_RESOLVED["$name"]="$dir"
     printf '%s' "$dir"
 }
 

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -393,3 +393,47 @@ it_still_resolves_from_the_working_directory_when_nothing_names_a_script() {
     unset NUTSHELL_SCRIPT_DIR
     assert_eq "$(_extern_manifest)" "${root}/project/nut.toml"
 }
+
+# --- resolving once per process -----------------------------------------------
+
+#[test]
+it_remembers_a_resolved_path() {
+    # Every `use <dep>::<module>` resolved the dependency again: manifest
+    # re-read, lockfile re-read, git asked twice. None of it can change while a
+    # script runs, and five modules out of one library cost it five times.
+    _EXTERN_RESOLVED=()
+    _EXTERN_RESOLVED[fixture]="/tmp"
+    _extern_is_repo() { return 0; }
+    assert_eq "$(extern_path fixture)" "/tmp"
+}
+
+#[test]
+it_forgets_one_name_when_asked() {
+    _EXTERN_RESOLVED=()
+    _EXTERN_RESOLVED[a]="/tmp/a"
+    _EXTERN_RESOLVED[b]="/tmp/b"
+    extern_forget a
+    assert_empty "${_EXTERN_RESOLVED[a]:-}"
+    assert_eq "${_EXTERN_RESOLVED[b]:-}" "/tmp/b"
+}
+
+#[test]
+it_forgets_everything_when_given_no_name() {
+    _EXTERN_RESOLVED=()
+    _EXTERN_RESOLVED[a]="/tmp/a"
+    _EXTERN_RESOLVED[b]="/tmp/b"
+    extern_forget
+    assert_eq "${#_EXTERN_RESOLVED[@]}" "0"
+}
+
+#[test]
+it_does_not_hand_back_a_checkout_that_has_gone() {
+    # A cached path whose checkout was removed is worse than no cache: the
+    # caller gets a directory git will not answer for, and no explanation.
+    # It must fall through and resolve again rather than returning it.
+    _EXTERN_RESOLVED=()
+    _EXTERN_RESOLVED[fixture]="/tmp/definitely-not-a-checkout"
+    _extern_is_repo() { return 1; }
+    extern_path fixture >/dev/null 2>&1 || true
+    assert_empty "${_EXTERN_RESOLVED[fixture]:-}"
+}


### PR DESCRIPTION
`use <dep>::<module>` resolved the dependency from scratch every time: the
manifest re-read, the lockfile re-read, and git asked twice whether it would
answer for the mirror and the worktree.

None of that can change while a script runs. A program taking five modules out
of one library paid it five times, about four hundred milliseconds before
anything of its own happened.

    extern_path x5:  378ms -> 134ms

The remainder is deliberate. A cached hit still checks the checkout is really
there, because handing back a path git will not answer for is worse than not
caching: the caller gets a directory and no explanation. When that check fails
the entry is dropped and the lookup falls through to a full resolution.

`extern_forget` clears one name or all of them, for a caller that has changed a
lockfile and wants the next lookup to see it.

Four tests, including the one that matters: a cached path whose checkout has
been removed is not handed back.