### PR TITLE
feat: nest the log, and declare a library's modules

### DIFF
--- a/bin/nut-declare
+++ b/bin/nut-declare
@@ -60,6 +60,7 @@ _scan() {
         [[ "$rel" == */nutshell/* ]] && continue
         name="${rel#lib/}"; name="${name#libs/}"
         name="${name%.sh}"
+        # A file at the root is named by its stem, with no directory to strip.
         name="${name//\//::}"
         # A file under impl/ is chosen at runtime by the module above it and
         # sourced directly. It was never a module anybody names, and declaring
@@ -70,8 +71,32 @@ _scan() {
         else
             printf '%s\t%s\t\n' "$name" "$rel"
         fi
-    done < <(find "$ROOT/lib" "$ROOT/libs" -type f -name '*.sh' 2>/dev/null | sort) \
-        | sort -u
+    done < <({
+        find "$ROOT/lib" "$ROOT/libs" -type f -name '*.sh' 2>/dev/null
+        # And a module flat at the library root, which the resolver tries last
+        # and the scan did not try at all. A migration that drops a module the
+        # resolver can reach, and a check that then certifies the drop, are one
+        # bug counted twice.
+        find "$ROOT" -maxdepth 1 -type f -name '*.sh' 2>/dev/null
+    } | sort) | sort -u
+}
+
+# A name more than one file answers to. The resolver picks by precedence and
+# the declaration would freeze whichever came out of sort, so it is reported
+# rather than silently resolved.
+_dupes() {
+    _scan | awk -F'\t' '{ print $1 }' | sort | uniq -d
+}
+
+# Every name a declaration holds. One parser for the checker, so it and the
+# resolver cannot disagree about what the file says.
+_lib_nut_modules_of() {
+    local r="$1" n _rest
+    [[ -r "${r}/lib.nut" ]] || return 1
+    while read -r n _rest || [[ -n "$n" ]]; do
+        [[ -z "$n" || "${n:0:1}" == "#" ]] && continue
+        printf '%s\n' "$n"
+    done < "${r}/lib.nut"
 }
 
 _render() {
@@ -92,6 +117,7 @@ _render() {
 
 case "$MODE" in
     print) _render ;;
+    dupes) _dupes ;;
     check)
         if [[ ! -r "$ROOT/lib.nut" ]]; then
             printf '%s has no lib.nut. %d modules would be declared:\n\n' \
@@ -102,17 +128,37 @@ case "$MODE" in
         # Declared but absent, and present but undeclared. Both are errors a
         # run would only have found by reaching the module.
         rc=0
-        while IFS= read -r line; do
-            [[ -z "$line" || "${line:0:1}" == "#" ]] && continue
-            set -- $line
-            if [[ ! -f "$ROOT/$2" ]]; then
-                printf 'declared but missing: %s -> %s\n' "$1" "$2"; rc=1
+        # The same parse the resolver does: leading space skipped, a comment is
+        # a comment wherever it starts, a missing newline on the last line does
+        # not lose it, and a line that is not a declaration is reported rather
+        # than crashing on an unset positional.
+        while read -r dname dfile dvis || [[ -n "$dname" ]]; do
+            [[ -z "$dname" || "${dname:0:1}" == "#" ]] && continue
+            if [[ -z "$dfile" ]]; then
+                printf 'not a declaration: %s\n' "$dname"; rc=1; continue
+            fi
+            case "${dvis:-}" in
+                ""|internal) ;;
+                *) printf 'unknown visibility on %s: %s\n' "$dname" "$dvis"; rc=1 ;;
+            esac
+            if [[ ! -f "$ROOT/$dfile" ]]; then
+                printf 'declared but missing: %s -> %s\n' "$dname" "$dfile"; rc=1
             fi
         done < "$ROOT/lib.nut"
         while IFS=$'\t' read -r name rel _vis; do
-            grep -qE "^${name}[[:space:]]" "$ROOT/lib.nut" \
+            # Compared as a word, not matched as a pattern. A module named
+            # `fs.impl` would otherwise match `fsXimpl` and be reported as
+            # declared when it is not.
+            _lib_nut_modules_of "$ROOT" | grep -qxF "$name" \
                 || { printf 'present but undeclared: %s (%s)\n' "$name" "$rel"; rc=1; }
         done < <(_scan)
+        # Not `local`: this is a case arm at file scope, where `local` is a
+        # fatal error that `bash -n` does not catch.
+        d="$(_dupes)"
+        if [[ -n "$d" ]]; then
+            printf 'two files answer to one name: %s\n' "$(tr '\n' ' ' <<<"$d")"
+            rc=1
+        fi
         (( rc == 0 )) && printf '%s: every module declared, every declaration present\n' "$ROOT"
         exit "$rc" ;;
     write)
@@ -121,6 +167,14 @@ case "$MODE" in
             printf 'What a fresh one would say, against what is there:\n\n'
             diff -u "$ROOT/lib.nut" <(_render) && printf '  (no difference)\n'
             exit 0
+        fi
+        d="$(_dupes)"
+        if [[ -n "$d" ]]; then
+            printf 'Two files answer to the same name, so the declaration would\n'
+            printf 'freeze one of them and hide the other:\n\n'
+            printf '%s\n' "$d" | sed 's/^/  /'
+            printf '\nMove or rename one, then run this again.\n'
+            exit 1
         fi
         _render > "$ROOT/lib.nut"
         printf 'wrote %s/lib.nut, %d modules\n' "$ROOT" "$(_scan | grep -c .)" ;;

--- a/bin/nut-declare
+++ b/bin/nut-declare
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nut-declare - Write the lib.nut a library was already implying
+# =============================================================================
+#
+# Before lib.nut, a module name was turned into a file by trying three layouts
+# in order and taking whichever answered. That is a rule, so it can be run
+# backwards: every file those layouts would have found, under the name that
+# would have found it. What this writes therefore resolves exactly what
+# resolved yesterday, which is the point. It is a migration, not a redesign.
+#
+# It never overwrites. A lib.nut that exists is the library's own statement
+# about itself and this has no business editing it; the diff against a fresh
+# one is printed instead, which is also how you check a hand-edited file still
+# covers everything.
+#
+# Usage:
+#   nut-declare                 write ./lib.nut
+#   nut-declare path/to/lib     write path/to/lib/lib.nut
+#   nut-declare --check         print what is missing, write nothing
+#   nut-declare --print         print it, write nothing
+#
+# A file under impl/ is marked internal: those are picked at runtime by the
+# module above them and sourced directly, so they were never names anybody
+# used, and a consumer reaching one would be reaching past the thing whose
+# whole job is to choose between them.
+# =============================================================================
+
+set -uo pipefail
+
+MODE="write"
+ROOT="."
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check) MODE="check"; shift ;;
+        --print) MODE="print"; shift ;;
+        -h|--help) sed -n '3,22p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'; exit 0 ;;
+        -*) printf 'nut-declare: no such option %s\n' "$1" >&2; exit 2 ;;
+        *)  ROOT="$1"; shift ;;
+    esac
+done
+
+ROOT="${ROOT%/}"
+[[ -d "$ROOT" ]] || { printf 'nut-declare: %s is not a directory\n' "$ROOT" >&2; exit 1; }
+
+# Every module file, under the name the old resolver would have reached it by.
+# The three layouts, in the order it tried them, so a file findable two ways
+# gets the name that would have won.
+_scan() {
+    local f rel name
+    for f in "$ROOT"/lib/*.sh "$ROOT"/lib/*/*.sh "$ROOT"/lib/*/*/*.sh \
+             "$ROOT"/libs/*.sh "$ROOT"/libs/*/*.sh "$ROOT"/libs/*/*/*.sh; do
+        [[ -f "$f" ]] || continue
+        rel="${f#$ROOT/}"
+        # nutshell's own vendored copy is not part of the library declaring it.
+        [[ "$rel" == */nutshell/* ]] && continue
+        name="${rel#lib/}"; name="${name#libs/}"
+        name="${name%.sh}"
+        name="${name//\//::}"
+        # A file under impl/ is chosen at runtime by the module above it and
+        # sourced directly. It was never a module anybody names, and declaring
+        # it public would invite a consumer to reach past the thing whose job
+        # is to pick between them.
+        if [[ "$rel" == */impl/* ]]; then
+            printf '%s\t%s\tinternal\n' "$name" "$rel"
+        else
+            printf '%s\t%s\t\n' "$name" "$rel"
+        fi
+    done | sort -u
+}
+
+_render() {
+    local name rel
+    printf '# lib.nut - the modules %s provides.\n' "$(basename "$(cd "$ROOT" && pwd)")"
+    printf '#\n'
+    printf '# One module per line: the name a `use` writes, then the file.\n'
+    printf '# Read before any module is loaded, so it stays a format that needs\n'
+    printf '# no parser: the TOML one is itself a module.\n'
+    printf '\n'
+    local vis
+    while IFS=$'\t' read -r name rel vis; do
+        [[ -n "$name" ]] || continue
+        if [[ -n "$vis" ]]; then printf '%-24s %-28s %s\n' "$name" "$rel" "$vis"
+        else printf '%-24s %s\n' "$name" "$rel"; fi
+    done < <(_scan)
+}
+
+case "$MODE" in
+    print) _render ;;
+    check)
+        if [[ ! -r "$ROOT/lib.nut" ]]; then
+            printf '%s has no lib.nut. %d modules would be declared:\n\n' \
+                "$ROOT" "$(_scan | grep -c .)"
+            _scan | awk -F'\t' '{ printf "  %s\n", $1 }'
+            exit 1
+        fi
+        # Declared but absent, and present but undeclared. Both are errors a
+        # run would only have found by reaching the module.
+        rc=0
+        while IFS= read -r line; do
+            [[ -z "$line" || "${line:0:1}" == "#" ]] && continue
+            set -- $line
+            if [[ ! -f "$ROOT/$2" ]]; then
+                printf 'declared but missing: %s -> %s\n' "$1" "$2"; rc=1
+            fi
+        done < "$ROOT/lib.nut"
+        while IFS=$'\t' read -r name rel _vis; do
+            grep -qE "^${name}[[:space:]]" "$ROOT/lib.nut" \
+                || { printf 'present but undeclared: %s (%s)\n' "$name" "$rel"; rc=1; }
+        done < <(_scan)
+        (( rc == 0 )) && printf '%s: every module declared, every declaration present\n' "$ROOT"
+        exit "$rc" ;;
+    write)
+        if [[ -e "$ROOT/lib.nut" ]]; then
+            printf '%s/lib.nut already exists. Not touching it.\n\n' "$ROOT"
+            printf 'What a fresh one would say, against what is there:\n\n'
+            diff -u "$ROOT/lib.nut" <(_render) && printf '  (no difference)\n'
+            exit 0
+        fi
+        _render > "$ROOT/lib.nut"
+        printf 'wrote %s/lib.nut, %d modules\n' "$ROOT" "$(_scan | grep -c .)" ;;
+esac

--- a/bin/nut-declare
+++ b/bin/nut-declare
@@ -48,8 +48,12 @@ ROOT="${ROOT%/}"
 # gets the name that would have won.
 _scan() {
     local f rel name
-    for f in "$ROOT"/lib/*.sh "$ROOT"/lib/*/*.sh "$ROOT"/lib/*/*/*.sh \
-             "$ROOT"/libs/*.sh "$ROOT"/libs/*/*.sh "$ROOT"/libs/*/*/*.sh; do
+    # find, not a list of globs at fixed depths. A glob per level means a
+    # module one level deeper than anyone wrote a glob for is invisible, and
+    # invisible to the check as well, because both read the same list. That is
+    # how text::impl::combo::grep_sed came to be undeclared while --check
+    # reported the library complete.
+    while IFS= read -r f; do
         [[ -f "$f" ]] || continue
         rel="${f#$ROOT/}"
         # nutshell's own vendored copy is not part of the library declaring it.
@@ -66,7 +70,8 @@ _scan() {
         else
             printf '%s\t%s\t\n' "$name" "$rel"
         fi
-    done | sort -u
+    done < <(find "$ROOT/lib" "$ROOT/libs" -type f -name '*.sh' 2>/dev/null | sort) \
+        | sort -u
 }
 
 _render() {

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1,0 +1,84 @@
+# Modules
+
+A module is a file. The file is its identity, and `lib.nut` says which files a
+library offers and what to call them.
+
+## Naming one
+
+`::` separates every step, the whole way down:
+
+```sh
+use log                     # nutshell's own
+use super::guard            # this unit's, from its own lib.nut
+use shebang::tui::menu      # a declared dependency's
+```
+
+A `/` is refused. It used to work, because the part after `::` was handed to
+the filesystem unchanged, so a nested module resolved without anyone having
+designed one. Two separators in one path, one of them by accident.
+
+## Declaring them
+
+`lib.nut` sits at the root of a library. One module per line: the name a `use`
+writes, then the file, then `internal` if it is not for anybody else.
+
+```
+# lib.nut - the modules shebang provides.
+
+tui::term            libs/tui/term.sh
+tui::menu            libs/tui/menu.sh
+json::impl::jq       lib/json/impl/jq.sh      internal
+```
+
+It is a line format on purpose. `init` reads it before any module is loaded,
+and the TOML parser is itself a module: a declaration file that needs a parser
+you must load a module to obtain is a cycle at the bottom of the stack.
+
+`internal` means the library's own file, reachable by `super::` from inside and
+not by name from outside. The implementations under `impl/` are the case: the
+module above them picks one at runtime by what the machine has, and a consumer
+naming one directly is reaching past the thing whose job is to choose.
+
+## Why a declaration and not a search
+
+A module used to be found by trying `lib/<name>.sh`, then `libs/<name>.sh`,
+then `<name>.sh`, and taking whichever answered. Three guesses, in order.
+
+That has two costs. A file findable in more than one place resolves to
+whichever came first, which is not necessarily the one meant. And nothing can
+say in advance that a name will not resolve, so a missing module is found at
+the moment it is reached, mid-run, under `set -eo pipefail`, with the shell
+exiting and nothing on screen explaining why.
+
+A declaration makes the set of modules a fact rather than a search result. A
+name is in the tree or it is not, and both directions are checkable before
+anything runs.
+
+## Moving a library onto it
+
+`nut-declare` writes the declaration a library was already implying. It runs
+the old resolution backwards: every file those three layouts would have found,
+under the name that would have found it. What it writes therefore resolves
+exactly what resolved before.
+
+```sh
+nut-declare                  # write ./lib.nut
+nut-declare path/to/lib      # write one elsewhere
+nut-declare --print          # see it first
+nut-declare --check          # what disagrees, write nothing
+```
+
+It never overwrites. A `lib.nut` that exists is the library's own statement
+about itself; run against one, it prints the difference against a fresh one,
+which is also how to check a hand-edited file still covers every file.
+
+`--check` reports both directions: a declaration whose file is gone, and a file
+nothing declares. The second is the one a search could never report, because
+the file resolves perfectly well under a name the library never meant to offer.
+
+## Loading happens once per file
+
+A module reachable by two names is one module. Its own unit calls it
+`super::tui::key` and a consumer calls it `shebang::tui::key`; loading is keyed
+on the resolved file, so the second name is a no-op rather than a second
+source. `nutshell_loaded` answers by either name.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -166,3 +166,48 @@ these are reproducible claims rather than repo evidence.
 - [x] Restructured from core/ to lib/
 - [x] Checks in examples/checks/, tests in tests/
 - [x] README with usage patterns and examples
+
+## Where the linting goes, and what the attributes are
+
+op, verbatim:
+
+> I also notice the current nut.toml has duplicated patterns for detecting
+> allowing bypassing the loc stuff. I think we want to write a
+> viola-config-compliant linting engine into the nutshell (optionally sourced),
+> so machines that can just call viola from path can, but those that don't have
+> it, can run the nutshell's own linting engine specifically for bash and
+> nutshell, that only allows or works with bash and nutshell syntax and is
+> perhaps simplified too, but is viola compliant in config shape as well as
+> behaviour (in terms of output from input, not in terms of the same internal
+> steps to get there). Then the lintings and such move on to viola.toml (and if
+> viola doesn't yet support toml, it should, so that's a thing you should add
+> to agenda for someone to pick up later; it already has and supports json
+> format though, pretty sure, so that same schema should translate painlessly
+> into toml). This way the nut.toml is a bit cleaner and doesn't include
+> linting things. Also, I think the #[pub] etc should be some reusable nutshell
+> plugin/extension so depending on some workflow lib could give them, and
+> having [plugins] or [extensions] with default-attributes = enabled or
+> something like that could just make all that boilerplate happen, which all my
+> nutshell libs pretty much use by default anyway
+
+The duplication he spotted is real: `nut.toml:48` and `nut.toml:115` carry the
+same regex for the loc escape hatch, and `trivial_wrapper` is named at both
+`:45` and `:101`. One pattern, two homes, and nothing keeps them in step.
+
+- [ ] **A linting engine in nutshell, optional to source, viola-compliant by
+      config and by behaviour.** Same config in, same findings out; the steps
+      between are its own. It handles bash and nutshell only, and may be
+      simpler for it. A machine with `viola` on PATH calls that instead.
+- [ ] **Lint configuration moves to `viola.toml`.** `nut.toml` keeps what it is
+      for and stops carrying two copies of one pattern.
+- [ ] **Attributes become a plugin.** `#[pub]`, `#[allow(...)]` and the rest are
+      a reusable extension rather than something every library restates.
+      `[plugins]` or `[extensions]` with something like
+      `default-attributes = enabled` turns the boilerplate on, since every
+      nutshell library here wants it anyway.
+
+### For whoever picks up viola
+
+- [ ] **viola should read TOML.** It has JSON already, so the schema carries
+      over without redesign. Filed here because there is no agenda tool on this
+      machine to file it in; move it when there is.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -211,3 +211,23 @@ same regex for the loc escape hatch, and `trivial_wrapper` is named at both
 - [ ] **viola should read TOML.** It has JSON already, so the schema carries
       over without redesign. Filed here because there is no agenda tool on this
       machine to file it in; move it when there is.
+
+## Left from the module-system review
+
+Acted on: the stub recursion, the two guards keyed differently, super:: cached
+globally, the bare-`use` bypass, the missing third layout, the two precedence
+orders, the checker's second parser, the symlink key. Written down instead:
+
+- [ ] **`extern_resolve` runs inside a command substitution, so its memo dies
+      in the subshell.** `lib/extern.sh` writes `_EXTERN_RESOLVED[...]` and
+      `use` calls it as `$( )`, so every resolution pays full price. Measured
+      at 421ms for eight modules in the review. The fix is a resolver that
+      returns through a variable rather than through stdout, which touches
+      every caller.
+- [ ] **A declared path is not confined to the library root.** `../../etc/x`
+      in a `lib.nut` resolves. A declaration is written by the library's own
+      author, so this is not a trust boundary, but it should still refuse.
+- [ ] **Duplicate names inside one `lib.nut` are accepted, first wins.** The
+      migration refuses to write one; a hand-edited file can still have it.
+- [ ] **`nutshell_modules` changed its output from names to paths.** Nothing
+      in the tree reads it. Decide which it is and say so.

--- a/init
+++ b/init
@@ -147,6 +147,25 @@ use() {
     done
 }
 
+# _use_mod_fragment <rest>
+#
+# The path fragment a module path names. `::` separates modules the whole way
+# down, so `tui::key` is the `key` module of the `tui` group and reads the same
+# as the `shebang::` that got you there.
+#
+# A `/` is refused rather than translated. It worked for a while, because the
+# tail was handed to the filesystem unchanged, and a separator that works by
+# accident is one that half the call sites end up using.
+_use_mod_fragment() {
+    local rest="$1"
+    if [[ "$rest" == */* ]]; then
+        echo "nutshell: '${rest}' separates modules with '/'" >&2
+        echo "  use '::' the whole way down: ${rest//\//::}" >&2
+        return 1
+    fi
+    printf '%s' "${rest//:://}"
+}
+
 # _use_super_resolve <rest>
 #
 # The file `super::<rest>` names, from the unit's own manifest directory. The
@@ -158,6 +177,7 @@ use() {
 # something the author did not write and did not mean.
 _use_super_resolve() {
     local rest="$1" from="$2" root candidate dir
+    rest="$(_use_mod_fragment "$rest")" || return 1
 
     # Walk up from the file that wrote the `use`, not from the entry point.
     #

--- a/init
+++ b/init
@@ -63,9 +63,19 @@ declare -gA _NUTSHELL_LOADED_AS=() 2>/dev/null || declare -A _NUTSHELL_LOADED_AS
 # reads as "carry on, or stop".
 nut_once() {
     local src="${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
+    # Canonical, and the same canonical `use` keys on. Keyed on the raw string
+    # instead, a file loaded through the resolver and then sourced again by a
+    # relative path was two different keys, so the second load ran: for a
+    # module whose functions are lazy stubs, that reinstalls the stubs over the
+    # bindings an implementation had already made, and the stub then calls
+    # itself until the stack dies.
+    src="$(_nut_realpath "$src" 2>/dev/null || printf '%s' "$src")"
     local key="_NUT_ONCE_${src//[^A-Za-z0-9]/_}"
     [[ -n "${!key:-}" ]] && return 1
     printf -v "$key" '%s' 1
+    # What `use` knows and what this knows are the same fact, so record it
+    # where `use` looks as well.
+    _NUTSHELL_LOADED[$src]=1
     return 0
 }
 
@@ -97,50 +107,41 @@ use() {
     for mod in "$@"; do
         # A name already known to point at a loaded file, answered without
         # touching the filesystem.
-        [[ -n "${_NUTSHELL_LOADED_AS[$mod]:-}" ]] && continue
-        
-        # Find and source the module
-        # A namespaced module comes from a library declared in nut.toml, so
-        # resolution goes through extern rather than nutshell's own lib.
-        local mod_path
-        if [[ "$mod" == super::* ]]; then
-            # This unit's own library. `super::` is the only way a project
-            # reaches a module it wrote itself, because a bare `use` resolves
-            # nutshell's set and a namespaced one resolves a declared
-            # dependency, and a unit is neither of those to itself.
-            #
-            # Anchored on the unit's manifest rather than on the entry point,
-            # so a module three directories down reaches `lib/` the same way
-            # the entry script does and moving the entry script changes
-            # nothing.
-            # BASH_SOURCE[1] is the file that called `use`, which is the unit
-            # this `super::` belongs to. BASH_SOURCE[0] is `init` itself, and
-            # NUTSHELL_SCRIPT_DIR is the entry point; neither answers "which
-            # unit is asking".
-            local _caller="${BASH_SOURCE[1]:-}"
-            local _from
-            if [[ -n "$_caller" && "$_caller" == */* ]]; then
-                _from="$(cd "${_caller%/*}" 2>/dev/null && pwd)"
-            else
-                _from="$PWD"
-            fi
-            mod_path="$(_use_super_resolve "${mod#super::}" "$_from")" || return 1
-        elif [[ "$mod" == *"::"* ]]; then
-            use extern || return 1
-            mod_path="$(extern_resolve "$mod")" || return 1
-        else
-            mod_path="${_NUTSHELL_ROOT}/lib/${mod}.sh"
+        #
+        # Not for `super::`, which is relative to whoever wrote it: two units
+        # each with their own lib/guard.sh both say `super::guard` and mean
+        # different files. Cached globally, the second unit's `use` matched the
+        # first unit's entry, loaded nothing, and returned 0 -- the module
+        # simply was not there, and nothing said so.
+        if [[ "$mod" != super::* ]]; then
+            [[ -n "${_NUTSHELL_LOADED_AS[$mod]:-}" ]] && continue
         fi
+        
+        # Where it is. One resolver, so `use` and `nut_reload` cannot come to
+        # different conclusions about what a name means.
+        #
+        # BASH_SOURCE[1] is the file that wrote the `use`, which is the unit a
+        # `super::` belongs to. BASH_SOURCE[0] is init itself and
+        # NUTSHELL_SCRIPT_DIR is the entry point; neither answers "which unit
+        # is asking".
+        local mod_path
+        mod_path="$(_use_resolve "$mod" "${BASH_SOURCE[1]:-}")" || return 1
+
         if [[ -f "$mod_path" ]]; then
             # The file decides identity, so a module reached by two names is
             # loaded once. Canonical, because a relative path and an absolute
             # one naming the same file are the same module.
             local _real
-            _real="$(cd "${mod_path%/*}" 2>/dev/null && printf '%s/%s' "$PWD" "${mod_path##*/}")" \
-                || _real="$mod_path"
+            _real="$(_nut_realpath "$mod_path")" || _real="$mod_path"
 
             if [[ -n "${_NUTSHELL_LOADED[$_real]:-}" ]]; then
-                _NUTSHELL_LOADED_AS[$mod]="$_real"
+                # Recorded under a key that carries the unit, so one unit's
+                # answer is never handed to another's question.
+                if [[ "$mod" == super::* ]]; then
+                    _NUTSHELL_LOADED_AS["${_real}::${mod}"]="$_real"
+                else
+                    _NUTSHELL_LOADED_AS[$mod]="$_real"
+                fi
                 continue
             fi
 
@@ -151,13 +152,18 @@ use() {
             # first makes the second entry a no-op, which is what "already
             # loading" should mean.
             _NUTSHELL_LOADED[$_real]=1
-            _NUTSHELL_LOADED_AS[$mod]="$_real"
+            if [[ "$mod" == super::* ]]; then
+                _NUTSHELL_LOADED_AS["${_real}::${mod}"]="$_real"
+            else
+                _NUTSHELL_LOADED_AS[$mod]="$_real"
+            fi
             if ! source "$mod_path"; then
                 # Failed to load, so it is not loaded. Leaving the mark would
                 # make a later retry silently succeed against a module that was
                 # never sourced.
                 unset "_NUTSHELL_LOADED[$_real]"
                 unset "_NUTSHELL_LOADED_AS[$mod]"
+                unset "_NUTSHELL_LOADED_AS[${_real}::${mod}]"
                 return 1
             fi
         else
@@ -223,6 +229,136 @@ _lib_nut_modules() {
         [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
         printf '%s\n' "$name"
     done < "${root}/lib.nut"
+}
+
+# _use_resolve <mod> [caller-file]
+#
+# The file a module name points at, without loading it. `use` and `nut_reload`
+# both need this answer and had one copy each, which is how they came to
+# disagree about which file a name meant.
+_use_resolve() {
+    local mod="$1" caller="${2:-}" mod_path=""
+    # A caller named outright wins. `use` reads the frame that wrote it, which
+    # is right when a file wrote it and wrong when nut_reload did: the frame is
+    # then init, and a `super::` resolves against nutshell instead of the unit
+    # that asked.
+    [[ -n "${_NUT_SUPER_FROM:-}" ]] && caller="$_NUT_SUPER_FROM"
+    if [[ "$mod" == super::* ]]; then
+        local _from
+        if [[ -n "$caller" && "$caller" == */* ]]; then
+            _from="$(cd "${caller%/*}" 2>/dev/null && pwd)"
+        else
+            _from="$PWD"
+        fi
+        mod_path="$(_use_super_resolve "${mod#super::}" "$_from")" || return 1
+    elif [[ "$mod" == *"::"* ]]; then
+        mod_path="$(_lib_nut_lookup "$_NUTSHELL_ROOT" "$mod" 2>/dev/null)" || mod_path=""
+        if [[ -z "$mod_path" ]]; then
+            use extern || return 1
+            mod_path="$(extern_resolve "$mod")" || return 1
+        fi
+    else
+        # nutshell's own, through its own declaration. Straight to
+        # lib/<name>.sh, a bare `use json/impl/jq` reached an internal file by
+        # spelling a path, which is around the declaration and around the bar
+        # that says a consumer may not have it.
+        if [[ "$mod" == */* ]]; then
+            echo "nutshell: '${mod}' separates modules with '/'" >&2
+            echo "  use '::' the whole way down: ${mod//\//::}" >&2
+            return 1
+        fi
+        mod_path="$(_lib_nut_lookup "$_NUTSHELL_ROOT" "$mod" 2>/dev/null)" || mod_path=""
+        [[ -n "$mod_path" ]] || mod_path="${_NUTSHELL_ROOT}/lib/${mod}.sh"
+    fi
+    [[ -n "$mod_path" ]] || return 1
+    printf '%s' "$mod_path"
+}
+
+#[pub]
+# Load a module even if it is already loaded.
+#
+# For one shape: a function that is a stub until an implementation replaces it.
+# The implementation is chosen at the first call, and if something has since
+# put the stub back over the binding, the implementation has to run again to
+# make it. `use` will not, by design, and that is right for every other case.
+#
+# Rare on purpose. If a module needs reloading for any other reason, the thing
+# to fix is why it does not survive being loaded once.
+# Usage: nut_reload super::text::impl::grep_match
+nut_reload() {
+    # The unit that wrote this call, carried through the `use` below so a
+    # `super::` means what it meant where it was written.
+    local _NUT_SUPER_FROM="${BASH_SOURCE[1]:-}"
+    local mod
+    for mod in "$@"; do
+        # Forget the file, and every name that reached it, then load again.
+        #
+        # By file, not by the name this caller happens to use: a module loaded
+        # under one name and reloaded under another would otherwise forget
+        # nothing, `use` would answer "already loaded", and the stub that asked
+        # for the reload would still be the stub.
+        local file="${_NUTSHELL_LOADED_AS[$mod]:-}"
+        if [[ -z "$file" ]]; then
+            local _p; _p="$(_use_resolve "$mod" "${BASH_SOURCE[1]:-}")" || _p=""
+            [[ -n "$_p" ]] && file="$(_nut_realpath "$_p" 2>/dev/null || printf '%s' "$_p")"
+        fi
+        if [[ -n "$file" ]]; then
+            unset "_NUTSHELL_LOADED[$file]"
+            local k
+            for k in "${!_NUTSHELL_LOADED_AS[@]}"; do
+                [[ "${_NUTSHELL_LOADED_AS[$k]}" == "$file" ]] && unset "_NUTSHELL_LOADED_AS[$k]"
+            done
+            # nut_once has its own record of the same fact.
+            local once="_NUT_ONCE_${file//[^A-Za-z0-9]/_}"
+            unset "$once"
+        fi
+        use "$mod" || return 1
+    done
+    return 0
+}
+
+# nut_lazy_guard <name>
+#
+# For a function that loads an implementation and then calls the name that
+# implementation was supposed to rebind. If it was not rebound, that call is
+# the function calling itself, and it does so until the shell runs out of
+# stack: no message, no exit status, the process simply disappears.
+#
+# It used to be safe because `source` re-runs a file every time. `use` loads a
+# file once, so the day the implementation is already loaded and the stub is
+# somehow back in place, the stub is on its own.
+#
+# Called at the top of the stub. Returns 1 when the stub is re-entering itself,
+# with an error that names the module rather than nothing at all.
+nut_lazy_guard() {
+    local name="$1" key="_NUT_LAZY_${1//[^A-Za-z0-9]/_}"
+    if [[ -n "${!key:-}" ]]; then
+        printf '[ERROR] %s: its implementation loaded but did not define %s\n' "$name" "$name" >&2
+        printf '        the module was probably re-sourced over a binding it had already made\n' >&2
+        return 1
+    fi
+    return 0
+}
+
+# _nut_realpath <path>
+#
+# One spelling for one file. `use` and `nut_once` are two guards for the same
+# property, and they keyed it differently: `use` on a canonicalised path,
+# `nut_once` on whatever string `BASH_SOURCE` happened to hold. So a module
+# loaded once through the resolver and then sourced again by a relative path
+# passed the second guard, ran again, and reinstalled its lazy stubs over
+# bindings the implementation had already made.
+_nut_realpath() {
+    local p="$1" d b
+    [[ -n "$p" ]] || return 1
+    d="${p%/*}"; b="${p##*/}"
+    [[ "$d" == "$p" ]] && d="."
+    if cd "$d" 2>/dev/null; then
+        printf '%s/%s' "$PWD" "$b"
+        cd - >/dev/null 2>&1 || true
+        return 0
+    fi
+    printf '%s' "$p"
 }
 
 # _use_mod_fragment <rest>

--- a/init
+++ b/init
@@ -204,7 +204,10 @@ use() {
 _lib_nut_lookup() {
     local root="$1" want="$2" reach="${3:-any}" name file vis
     [[ -r "${root}/lib.nut" ]] || return 1
-    while read -r name file vis; do
+    # `|| [[ -n "$name" ]]`, so a file whose last line has no newline keeps
+    # its last declaration. Without it the module simply is not there, and the
+    # checker agreed because it read the file another way.
+    while read -r name file vis || [[ -n "$name" ]]; do
         [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
         [[ "$name" == "$want" ]] || continue
         [[ -n "$file" ]] || return 1
@@ -225,7 +228,7 @@ _lib_nut_lookup() {
 _lib_nut_modules() {
     local root="$1" name _rest
     [[ -r "${root}/lib.nut" ]] || return 1
-    while read -r name _rest; do
+    while read -r name _rest || [[ -n "$name" ]]; do
         [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
         printf '%s\n' "$name"
     done < "${root}/lib.nut"
@@ -353,9 +356,21 @@ _nut_realpath() {
     [[ -n "$p" ]] || return 1
     d="${p%/*}"; b="${p##*/}"
     [[ "$d" == "$p" ]] && d="."
-    if cd "$d" 2>/dev/null; then
-        printf '%s/%s' "$PWD" "$b"
+    # -P, so the key is the physical file. `cd` without it gives the logical
+    # path, which leaves a symlinked module and its target as two different
+    # keys and therefore two loads of one file.
+    if cd -P "$d" 2>/dev/null; then
+        d="$PWD"
         cd - >/dev/null 2>&1 || true
+        # And the leaf, if that is a link too.
+        if [[ -L "${d}/${b}" ]]; then
+            local t; t="$(readlink "${d}/${b}")"
+            case "$t" in
+                /*) printf '%s' "$t"; return 0 ;;
+                *)  b="$t" ;;
+            esac
+        fi
+        printf '%s/%s' "$d" "$b"
         return 0
     fi
     printf '%s' "$p"
@@ -433,7 +448,11 @@ _use_super_resolve() {
         return 1
     fi
 
-    for candidate in "${root}/lib/${rest}.sh" "${root}/libs/${rest}.sh" "${root}/${rest}.sh"; do
+    # libs, then lib, then the root. The same order extern uses: the two had
+    # one each, `lib` first here and `libs` first there, so a library with both
+    # resolved differently depending on who was asking. Only the undeclared
+    # path reaches this now, and it exists to be migrated away from.
+    for candidate in "${root}/libs/${rest}.sh" "${root}/lib/${rest}.sh" "${root}/${rest}.sh"; do
         [[ -f "$candidate" ]] && { printf '%s' "$candidate"; return 0; }
     done
     echo "nutshell: this unit has no module '${rest}'" >&2

--- a/init
+++ b/init
@@ -43,8 +43,14 @@ export PATH="${_NUTSHELL_ROOT}/bin:$PATH"
 # Module tracking
 # =============================================================================
 
-# Track loaded modules to avoid double-sourcing
+# What has been loaded, keyed by the file rather than by the words that asked
+# for it. One module is reachable by several names: its own unit calls it
+# `super::tui::key`, a consumer calls it `shebang::tui::key`, and both are the
+# same file. Keyed by the spelling, each of those loaded it again, and a module
+# without a guard of its own ran twice.
 declare -gA _NUTSHELL_LOADED=() 2>/dev/null || declare -A _NUTSHELL_LOADED=()
+# The names that reached each file, so `nutshell_loaded <name>` still answers.
+declare -gA _NUTSHELL_LOADED_AS=() 2>/dev/null || declare -A _NUTSHELL_LOADED_AS=()
 
 # nut_once
 #
@@ -89,8 +95,9 @@ nut_once() {
 use() {
     local mod
     for mod in "$@"; do
-        # Skip if already loaded
-        [[ -n "${_NUTSHELL_LOADED[$mod]:-}" ]] && continue
+        # A name already known to point at a loaded file, answered without
+        # touching the filesystem.
+        [[ -n "${_NUTSHELL_LOADED_AS[$mod]:-}" ]] && continue
         
         # Find and source the module
         # A namespaced module comes from a library declared in nut.toml, so
@@ -125,18 +132,32 @@ use() {
             mod_path="${_NUTSHELL_ROOT}/lib/${mod}.sh"
         fi
         if [[ -f "$mod_path" ]]; then
+            # The file decides identity, so a module reached by two names is
+            # loaded once. Canonical, because a relative path and an absolute
+            # one naming the same file are the same module.
+            local _real
+            _real="$(cd "${mod_path%/*}" 2>/dev/null && printf '%s/%s' "$PWD" "${mod_path##*/}")" \
+                || _real="$mod_path"
+
+            if [[ -n "${_NUTSHELL_LOADED[$_real]:-}" ]]; then
+                _NUTSHELL_LOADED_AS[$mod]="$_real"
+                continue
+            fi
+
             # Marked before sourcing, not after. A module that declares its own
             # dependencies can be part of a cycle, and marking afterwards means
             # neither module in one is ever recorded as loaded while it is being
             # loaded, so the pair recurses until the stack gives out. Marking
             # first makes the second entry a no-op, which is what "already
             # loading" should mean.
-            _NUTSHELL_LOADED[$mod]=1
+            _NUTSHELL_LOADED[$_real]=1
+            _NUTSHELL_LOADED_AS[$mod]="$_real"
             if ! source "$mod_path"; then
                 # Failed to load, so it is not loaded. Leaving the mark would
                 # make a later retry silently succeed against a module that was
                 # never sourced.
-                unset "_NUTSHELL_LOADED[$mod]"
+                unset "_NUTSHELL_LOADED[$_real]"
+                unset "_NUTSHELL_LOADED_AS[$mod]"
                 return 1
             fi
         else
@@ -145,6 +166,63 @@ use() {
             return 1
         fi
     done
+}
+
+# _lib_nut_lookup <root> <module-path>
+#
+# The file a library says a module lives in, from the `lib.nut` at its root.
+#
+# A library declares what it provides, in one place, instead of the resolver
+# guessing among three layouts and taking whichever answered first. That guess
+# is why a module could be found in the wrong place and why nothing could say,
+# before running, that a name would not resolve. A declaration turns "no file
+# answered" into "not in the tree", which is checkable without running
+# anything.
+#
+# The format is one module per line, `<module-path> <file>`, because this is
+# read before any module is loaded and the TOML parser is itself a module. A
+# declaration file needing a parser you must load a module to obtain is a cycle
+# at the very bottom of the stack.
+#
+#   # anything after a hash is a comment
+#   log                 lib/log.sh
+#   tui::term           libs/tui/term.sh
+#   json::impl::jq      lib/json/impl/jq.sh      internal
+#
+# `internal` means the library's own file, reachable by `super::` from inside
+# and not by name from outside. Files picked at runtime by capability, like the
+# json and fs implementations, are that: they are sourced directly by the
+# module that chooses between them, and were never modules anybody names.
+# The third argument, when given, is the visibility a caller is allowed to
+# reach: `any` from inside the unit, `public` from outside it.
+_lib_nut_lookup() {
+    local root="$1" want="$2" reach="${3:-any}" name file vis
+    [[ -r "${root}/lib.nut" ]] || return 1
+    while read -r name file vis; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        [[ "$name" == "$want" ]] || continue
+        [[ -n "$file" ]] || return 1
+        if [[ "$reach" == "public" && "${vis:-}" == "internal" ]]; then
+            echo "nutshell: '${want}' is internal to that library" >&2
+            return 1
+        fi
+        printf '%s/%s' "$root" "$file"
+        return 0
+    done < "${root}/lib.nut"
+    return 1
+}
+
+# _lib_nut_modules <root>
+#
+# Every module a library declares, one per line. For the checker, and for an
+# error that can list what was actually available.
+_lib_nut_modules() {
+    local root="$1" name _rest
+    [[ -r "${root}/lib.nut" ]] || return 1
+    while read -r name _rest; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        printf '%s\n' "$name"
+    done < "${root}/lib.nut"
 }
 
 # _use_mod_fragment <rest>
@@ -177,6 +255,7 @@ _use_mod_fragment() {
 # something the author did not write and did not mean.
 _use_super_resolve() {
     local rest="$1" from="$2" root candidate dir
+    local declared="$rest"
     rest="$(_use_mod_fragment "$rest")" || return 1
 
     # Walk up from the file that wrote the `use`, not from the entry point.
@@ -204,6 +283,20 @@ _use_super_resolve() {
         echo "  super:: names this unit's own lib/, and the manifest is what marks the unit" >&2
         return 1
     fi
+    # What the unit declares, if it declares anything. A library with a lib.nut
+    # is answered from it and nowhere else: falling back to a search would put
+    # the guessing back under the declaration and hide a wrong entry.
+    if [[ -r "${root}/lib.nut" ]]; then
+        candidate="$(_lib_nut_lookup "$root" "$declared")" || {
+            echo "nutshell: '${declared}' is not in this unit's lib.nut" >&2
+            echo "  it declares: $(_lib_nut_modules "$root" | tr '\n' ' ')" >&2
+            return 1
+        }
+        [[ -f "$candidate" ]] && { printf '%s' "$candidate"; return 0; }
+        echo "nutshell: lib.nut declares '${declared}' at ${candidate#$root/}, which is not there" >&2
+        return 1
+    fi
+
     for candidate in "${root}/lib/${rest}.sh" "${root}/libs/${rest}.sh" "${root}/${rest}.sh"; do
         [[ -f "$candidate" ]] && { printf '%s' "$candidate"; return 0; }
     done
@@ -275,6 +368,10 @@ export -f use
 # Check if a module is loaded
 # Usage: if nutshell_loaded json; then ...
 nutshell_loaded() {
+    # By name, because that is what a caller has. The name is looked up to a
+    # file first, so a module loaded as `super::x` answers yes when asked about
+    # `dep::x` too, which is the same module.
+    [[ -n "${_NUTSHELL_LOADED_AS[$1]:-}" ]] && return 0
     [[ -n "${_NUTSHELL_LOADED[$1]:-}" ]]
 }
 export -f nutshell_loaded

--- a/lib.nut
+++ b/lib.nut
@@ -29,6 +29,7 @@ string                   lib/string.sh
 test                     lib/test.sh
 text                     lib/text.sh
 text::impl::awk_replace  lib/text/impl/awk_replace.sh internal
+text::impl::combo::grep_sed lib/text/impl/combo/grep_sed.sh internal
 text::impl::grep_match   lib/text/impl/grep_match.sh  internal
 text::impl::perl_match   lib/text/impl/perl_match.sh  internal
 text::impl::perl_replace lib/text/impl/perl_replace.sh internal

--- a/lib.nut
+++ b/lib.nut
@@ -23,6 +23,7 @@ json::impl::perl         lib/json/impl/perl.sh        internal
 json::impl::python       lib/json/impl/python.sh      internal
 log                      lib/log.sh
 modgraph                 lib/modgraph.sh
+nutshell                 nutshell.sh
 os                       lib/os.sh
 prompt                   lib/prompt.sh
 string                   lib/string.sh

--- a/lib.nut
+++ b/lib.nut
@@ -1,0 +1,38 @@
+# lib.nut - the modules nutshell provides.
+#
+# One module per line: the name a `use` writes, then the file.
+# Read before any module is loaded, so it stays a format that needs
+# no parser: the TOML one is itself a module.
+
+array                    lib/array.sh
+attr                     lib/attr.sh
+check-runner             lib/check-runner.sh
+cli                      lib/cli.sh
+color                    lib/color.sh
+deps                     lib/deps.sh
+extern                   lib/extern.sh
+fs                       lib/fs.sh
+fs::impl::perl_stat      lib/fs/impl/perl_stat.sh     internal
+fs::impl::stat_bsd       lib/fs/impl/stat_bsd.sh      internal
+fs::impl::stat_gnu       lib/fs/impl/stat_gnu.sh      internal
+git                      lib/git.sh
+http                     lib/http.sh
+json                     lib/json.sh
+json::impl::jq           lib/json/impl/jq.sh          internal
+json::impl::perl         lib/json/impl/perl.sh        internal
+json::impl::python       lib/json/impl/python.sh      internal
+log                      lib/log.sh
+modgraph                 lib/modgraph.sh
+os                       lib/os.sh
+prompt                   lib/prompt.sh
+string                   lib/string.sh
+test                     lib/test.sh
+text                     lib/text.sh
+text::impl::awk_replace  lib/text/impl/awk_replace.sh internal
+text::impl::grep_match   lib/text/impl/grep_match.sh  internal
+text::impl::perl_match   lib/text/impl/perl_match.sh  internal
+text::impl::perl_replace lib/text/impl/perl_replace.sh internal
+text::impl::sed_replace  lib/text/impl/sed_replace.sh internal
+toml                     lib/toml.sh
+validate                 lib/validate.sh
+xdg                      lib/xdg.sh

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -407,9 +407,25 @@ extern_resolve() {
         log_error "'${spec}' separates modules with '/'; use '::': ${spec//\//::}"
         return 1
     fi
+    local declared="${spec#*::}"
     rest="${rest//:://}"
 
     root="$(extern_path "$name")" || return 1
+
+    # A library that declares its modules is answered from the declaration and
+    # from nowhere else. Falling back to a search would put the guessing back
+    # underneath the declaration, where a wrong entry resolves anyway and
+    # nothing says so.
+    if [[ -r "${root}/lib.nut" ]]; then
+        local from_nut
+        if from_nut="$(_lib_nut_lookup "$root" "$declared" public)"; then
+            [[ -f "$from_nut" ]] && { printf '%s' "$from_nut"; return 0; }
+            log_error "${name}'s lib.nut declares '${declared}' at ${from_nut#$root/}, which is not there"
+            return 1
+        fi
+        log_error "'${declared}' is not among the modules ${name} declares"
+        return 1
+    fi
 
     # Two shapes, tried in order: a library laid out as `libs/<group>/<mod>.sh`,
     # and a flat `lib/<mod>.sh` like nutshell's own. Nothing else is guessed at,

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -401,6 +401,14 @@ extern_resolve() {
     rest="${spec#*::}"
     [[ "$name" == "$spec" ]] && return 1
 
+    # `::` separates modules the whole way down. A `/` is refused rather than
+    # handed to the filesystem, which is what made it work by accident.
+    if [[ "$rest" == */* ]]; then
+        log_error "'${spec}' separates modules with '/'; use '::': ${spec//\//::}"
+        return 1
+    fi
+    rest="${rest//:://}"
+
     root="$(extern_path "$name")" || return 1
 
     # Two shapes, tried in order: a library laid out as `libs/<group>/<mod>.sh`,

--- a/lib/fs.sh
+++ b/lib/fs.sh
@@ -250,6 +250,8 @@ fs_basename_no_ext() {
 # Get file size in bytes
 # Usage: fs_size "/path/to/file" -> "12345"
 fs_size() {
+    nut_lazy_guard fs_size || return 1
+    local _NUT_LAZY_fs_size=1
     # First call: decide which implementation to use
     local impl=""
     
@@ -280,7 +282,7 @@ fs_size() {
         # the module is, loads it once however many callers arrive, and the
         # declaration covers it; a hand-rolled `source` has none of that, and
         # fails at the moment it is reached rather than before the run.
-        use "super::fs::impl::${impl}"
+        nut_reload "super::fs::impl::${impl}"
     else
         # No tool available
         fs_size() {
@@ -297,6 +299,8 @@ fs_size() {
 # Get file modification time (epoch seconds)
 # Usage: fs_mtime "/path/to/file" -> "1234567890"
 fs_mtime() {
+    nut_lazy_guard fs_mtime || return 1
+    local _NUT_LAZY_fs_mtime=1
     # First call: decide which implementation to use
     local impl=""
     
@@ -325,7 +329,7 @@ fs_mtime() {
         # the module is, loads it once however many callers arrive, and the
         # declaration covers it; a hand-rolled `source` has none of that, and
         # fails at the moment it is reached rather than before the run.
-        use "super::fs::impl::${impl}"
+        nut_reload "super::fs::impl::${impl}"
     else
         fs_mtime() {
             echo "[ERROR] fs_mtime: no stat tool available" >&2

--- a/lib/fs.sh
+++ b/lib/fs.sh
@@ -256,27 +256,31 @@ fs_size() {
     if deps_has "stat"; then
         local variant="${_TOOL_VARIANT[stat]:-unknown}"
         case "$variant" in
-            gnu)     impl="stat_gnu.sh" ;;
-            bsd)     impl="stat_bsd.sh" ;;
+            gnu)     impl="stat_gnu" ;;
+            bsd)     impl="stat_bsd" ;;
             *)
                 # Unknown variant; try perl if available
                 if deps_has "perl"; then
-                    impl="perl_stat.sh"
+                    impl="perl_stat"
                 else
                     # Guess based on OS
                     case "$(uname -s)" in
-                        Darwin*) impl="stat_bsd.sh" ;;
-                        *)       impl="stat_gnu.sh" ;;
+                        Darwin*) impl="stat_bsd" ;;
+                        *)       impl="stat_gnu" ;;
                     esac
                 fi
                 ;;
         esac
     elif deps_has "perl"; then
-        impl="perl_stat.sh"
+        impl="perl_stat"
     fi
     
     if [[ -n "$impl" ]]; then
-        source "${_FS_IMPL_DIR}/${impl}"
+        # Named, not sourced by an assembled path. The resolver knows where
+        # the module is, loads it once however many callers arrive, and the
+        # declaration covers it; a hand-rolled `source` has none of that, and
+        # fails at the moment it is reached rather than before the run.
+        use "super::fs::impl::${impl}"
     else
         # No tool available
         fs_size() {
@@ -299,25 +303,29 @@ fs_mtime() {
     if deps_has "stat"; then
         local variant="${_TOOL_VARIANT[stat]:-unknown}"
         case "$variant" in
-            gnu)     impl="stat_gnu.sh" ;;
-            bsd)     impl="stat_bsd.sh" ;;
+            gnu)     impl="stat_gnu" ;;
+            bsd)     impl="stat_bsd" ;;
             *)
                 if deps_has "perl"; then
-                    impl="perl_stat.sh"
+                    impl="perl_stat"
                 else
                     case "$(uname -s)" in
-                        Darwin*) impl="stat_bsd.sh" ;;
-                        *)       impl="stat_gnu.sh" ;;
+                        Darwin*) impl="stat_bsd" ;;
+                        *)       impl="stat_gnu" ;;
                     esac
                 fi
                 ;;
         esac
     elif deps_has "perl"; then
-        impl="perl_stat.sh"
+        impl="perl_stat"
     fi
     
     if [[ -n "$impl" ]]; then
-        source "${_FS_IMPL_DIR}/${impl}"
+        # Named, not sourced by an assembled path. The resolver knows where
+        # the module is, loads it once however many callers arrive, and the
+        # declaration covers it; a hand-rolled `source` has none of that, and
+        # fails at the moment it is reached rather than before the run.
+        use "super::fs::impl::${impl}"
     else
         fs_mtime() {
             echo "[ERROR] fs_mtime: no stat tool available" >&2

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -72,11 +72,13 @@ fi
 # `_JSON_IMPL` a decision taken once at load rather than a value the dispatch
 # reads, which is what lets a caller move it and lets the tests exercise all
 # three rather than whichever the machine happened to pick.
-readonly _JSON_IMPL_DIR="${BASH_SOURCE[0]%/*}/json/impl"
-
-deps_has jq && source "${_JSON_IMPL_DIR}/jq.sh"
-{ deps_has python3 || deps_has python; } && source "${_JSON_IMPL_DIR}/python.sh"
-deps_has perl && source "${_JSON_IMPL_DIR}/perl.sh"
+# Named, not sourced by a path this file assembles. A hand-rolled `source`
+# goes around the resolver, so the file is loaded again for every caller that
+# reaches it, the declaration does not cover it, and nothing can tell before
+# running that the path was wrong.
+deps_has jq                             && use super::json::impl::jq
+{ deps_has python3 || deps_has python; } && use super::json::impl::python
+deps_has perl                           && use super::json::impl::perl
 
 
 # -----------------------------------------------------------------------------

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -10,6 +10,7 @@
 # Environment:
 #   LOG_LEVEL - debug|info|warn|error (default: info)
 #   LOG_COLOR - auto|always|never (default: auto)
+#   LOG_MARKS - auto|icon|text|none (default: auto)
 # =============================================================================
 
 # Prevent multiple inclusion
@@ -62,6 +63,185 @@ _log_format() {
     else
         printf '[%s] %s\n' "$level" "$message"
     fi
+}
+
+# -----------------------------------------------------------------------------
+# Marks and depth
+# -----------------------------------------------------------------------------
+#
+# A run of forty lines where one went wrong should not need reading forty times
+# to find it. Two things make that work, and both are about skimming.
+#
+# Every line can start with a mark saying what kind of line it is, in one
+# column, so the eye scans down rather than across. Icons where the terminal
+# can draw them, words where it cannot, and the caller may insist on either.
+#
+# And a line sits at the depth of the step it belongs to. `log_step` already
+# opened a heading and `log_substep` indented one line under it; what was
+# missing was nesting past one level and a way to close a step with how it
+# went. What produced a message is then a matter of looking left.
+
+LOG_MARKS="${LOG_MARKS:-auto}"
+
+declare -gi LOG_DEPTH=0
+declare -gi LOG_WARNINGS=0
+declare -gi LOG_FAILURES=0
+
+_LOG_MARKS_SET=0
+_LOG_M_OK="+"; _LOG_M_BAD="x"; _LOG_M_WARN="!"; _LOG_M_STEP=">"; _LOG_M_FLAT=" "
+
+# Can this terminal draw a character outside ASCII? A locale that is not UTF-8
+# renders one as several bytes of noise, and the linux console before a font is
+# loaded is where that happens, which is where a recovery script runs.
+_log_unicode_ok() {
+    case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+        *UTF-8*|*utf8*|*UTF8*|*utf-8*) ;;
+        *) return 1 ;;
+    esac
+    [[ "${TERM:-}" != "linux" ]]
+}
+
+_log_marks_init() {
+    (( _LOG_MARKS_SET == 1 )) && return 0
+    _LOG_MARKS_SET=1
+    case "$LOG_MARKS" in
+        none) _LOG_M_OK=" "; _LOG_M_BAD=" "; _LOG_M_WARN=" "; _LOG_M_STEP=" " ;;
+        text) _LOG_M_OK="+"; _LOG_M_BAD="x"; _LOG_M_WARN="!"; _LOG_M_STEP=">" ;;
+        icon) _log_marks_unicode ;;
+        *)    _log_unicode_ok && _log_marks_unicode ;;
+    esac
+}
+
+_log_marks_unicode() {
+    printf -v _LOG_M_OK   '%b' '\u2713'
+    printf -v _LOG_M_BAD  '%b' '\u2717'
+    printf -v _LOG_M_WARN '%b' '\u26a0'
+    printf -v _LOG_M_STEP '%b' '\u203a'
+}
+
+#[pub]
+# Choose how lines are marked, overriding what was detected.
+# Usage: log_marks icon | text | none | auto
+log_marks() { LOG_MARKS="${1:-auto}"; _LOG_MARKS_SET=0; _log_marks_init; }
+
+#[pub]
+# Forget the depth and the counts, for a caller starting a fresh run.
+# Usage: log_reset
+log_reset() { LOG_DEPTH=0; LOG_WARNINGS=0; LOG_FAILURES=0; }
+
+_log_pad() {
+    local n=$(( LOG_DEPTH * 2 ))
+    (( n > 0 )) || return 0
+    printf '%*s' "$n" ''
+}
+
+# One marked line. The mark sits outside the indent, so every mark in a run is
+# in the same column however deep its line is.
+_log_marked() {
+    local mark="$1" color="$2" text="$3" reset=""
+    _log_marks_init
+    _log_should_color && reset='\033[0m' || color=""
+    printf '%b%s%b %s%s\n' "$color" "$mark" "$reset" "$(_log_pad)" "$text"
+}
+
+#[pub]
+# Open a step. Everything after it is indented under it until it is ended.
+# Unlike log_step, which is a flat heading, these nest.
+# Usage: log_open "Partitioning"
+log_open() {
+    _log_should_emit info || { LOG_DEPTH=$(( LOG_DEPTH + 1 )); return 0; }
+    _log_marks_init
+    local bold="" reset=""
+    if _log_should_color; then bold='\033[1m'; reset='\033[0m'; fi
+    _log_marked "$_LOG_M_STEP" '\033[0;36m' "$(printf '%b%s%b' "$bold" "$*" "$reset")"
+    LOG_DEPTH=$(( LOG_DEPTH + 1 ))
+}
+
+#[pub]
+# Close the step, with how it went: ok, warn, fail, or nothing for silence.
+# Usage: log_close ok "3 partitions"
+log_close() {
+    (( LOG_DEPTH > 0 )) && LOG_DEPTH=$(( LOG_DEPTH - 1 ))
+    local how="${1:-}"; shift 2>/dev/null || true
+    case "$how" in
+        ok)   log_ok   "$@" ;;
+        warn) log_warned "$@" ;;
+        fail) log_failed "$@" ;;
+        "")   return 0 ;;
+        *)    log_flat "$how" "$@" ;;
+    esac
+}
+
+#[pub]
+# It worked. Marked, indented, and counted.
+# Usage: log_ok "made an ESP at /dev/sdb1"
+log_ok() {
+    _log_should_emit info || return 0
+    _log_marked "$_LOG_M_OK" '\033[0;32m' "$*"
+}
+
+#[pub]
+# Worth a look, and the run goes on.
+# Usage: log_warned "the free region is tight"
+log_warned() {
+    LOG_WARNINGS=$(( LOG_WARNINGS + 1 ))
+    _log_should_emit warn || return 0
+    _log_marked "$_LOG_M_WARN" '\033[0;33m' "$*"
+}
+
+#[pub]
+# It did not work.
+# Usage: log_failed "could not set the esp flag"
+log_failed() {
+    LOG_FAILURES=$(( LOG_FAILURES + 1 ))
+    _log_should_emit error || return 0
+    _log_marked "$_LOG_M_BAD" '\033[0;31m' "$*"
+}
+
+#[pub]
+# Something true that is neither good nor bad. Unmarked, so a run of these does
+# not read as a run of results.
+# Usage: log_flat "sgdisk: 3 partitions"
+log_flat() {
+    _log_should_emit info || return 0
+    _log_marked "$_LOG_M_FLAT" "" "$*"
+}
+
+#[pub]
+# Run a command as a step: its output indented under it, and a mark on the end
+# saying how it went. Returns what the command returned, which is the reason to
+# use it rather than printing around it.
+# Usage: log_run "writing the table" sgdisk --zap-all /dev/sdb
+log_run() {
+    local label="$1"; shift
+    log_open "$label"
+    local line rc=""
+    while IFS= read -r line; do
+        # The status travels in the stream, because a pipeline loses it and a
+        # runner that reports success on a failed command is worse than none.
+        # Read, never printed: a marker, not output.
+        if [[ "${line:0:1}" == $'\037' ]]; then rc="${line:1}"; break; fi
+        log_flat "$line"
+    done < <("$@" 2>&1; printf '\037%d\n' "$?")
+    [[ "$rc" =~ ^[0-9]+$ ]] || rc=1
+    if (( rc == 0 )); then log_close ok "$label"
+    else log_close fail "${label} (exit ${rc})"; fi
+    return "$rc"
+}
+
+#[pub]
+# How the run went overall: fail if anything failed, warn if anything warned,
+# ok otherwise. Counted even when LOG_LEVEL hid the line, because the verdict
+# is about what happened rather than about what was displayed.
+#
+# The counts live in the shell that logged. A run inside `$( )` or one side of
+# a pipe is a subshell, and what it counted does not come back; capture the
+# text or keep the count, not both from the same call.
+# Usage: log_worst -> ok | warn | fail
+log_worst() {
+    (( LOG_FAILURES > 0 )) && { printf 'fail'; return 0; }
+    (( LOG_WARNINGS > 0 )) && { printf 'warn'; return 0; }
+    printf 'ok'
 }
 
 # -----------------------------------------------------------------------------

--- a/lib/text.sh
+++ b/lib/text.sh
@@ -158,12 +158,14 @@ text_lines() {
 # Find lines matching pattern
 # Usage: text_grep "pattern" "file" -> prints matching lines
 text_grep() {
+    nut_lazy_guard text_grep || return 1
+    local _NUT_LAZY_text_grep=1
     # First call: decide which implementation to use
     if deps_has "grep"; then
-        use super::text::impl::grep_match
+        nut_reload super::text::impl::grep_match
         _TEXT_MATCH_IMPL="grep"
     elif deps_has "perl"; then
-        use super::text::impl::perl_match
+        nut_reload super::text::impl::perl_match
         _TEXT_MATCH_IMPL="perl"
     else
         # No tool available; define a failing function
@@ -182,12 +184,14 @@ text_grep() {
 # Check if file contains pattern
 # Usage: text_contains "pattern" "file" -> returns 0 (true) or 1 (false)
 text_contains() {
+    nut_lazy_guard text_contains || return 1
+    local _NUT_LAZY_text_contains=1
     # First call: decide which implementation to use
     if deps_has "grep"; then
-        use super::text::impl::grep_match
+        nut_reload super::text::impl::grep_match
         _TEXT_MATCH_IMPL="grep"
     elif deps_has "perl"; then
-        use super::text::impl::perl_match
+        nut_reload super::text::impl::perl_match
         _TEXT_MATCH_IMPL="perl"
     else
         text_contains() {
@@ -204,12 +208,14 @@ text_contains() {
 # Count occurrences of pattern in file
 # Usage: text_count_matches "pattern" "file" -> "5"
 text_count_matches() {
+    nut_lazy_guard text_count_matches || return 1
+    local _NUT_LAZY_text_count_matches=1
     # First call: decide which implementation to use
     if deps_has "grep"; then
-        use super::text::impl::grep_match
+        nut_reload super::text::impl::grep_match
         _TEXT_MATCH_IMPL="grep"
     elif deps_has "perl"; then
-        use super::text::impl::perl_match
+        nut_reload super::text::impl::perl_match
         _TEXT_MATCH_IMPL="perl"
     else
         text_count_matches() {
@@ -236,22 +242,24 @@ text_count_matches() {
 #   3. perl
 #   4. awk (slowest, uses temp file)
 text_replace() {
+    nut_lazy_guard text_replace || return 1
+    local _NUT_LAZY_text_replace=1
     # First call: decide which implementation to use based on available tools
     local impl=""
     
     # Prefer combo when both grep and sed are available
     # The combo checks if pattern exists before invoking sed (optimization)
     if deps_has_all "grep" "sed"; then
-        use super::text::impl::combo::grep_sed
+        nut_reload super::text::impl::combo::grep_sed
         _TEXT_REPLACE_IMPL="grep_sed"
     elif deps_has "sed"; then
-        use super::text::impl::sed_replace
+        nut_reload super::text::impl::sed_replace
         _TEXT_REPLACE_IMPL="sed"
     elif deps_has "perl"; then
-        use super::text::impl::perl_replace
+        nut_reload super::text::impl::perl_replace
         _TEXT_REPLACE_IMPL="perl"
     elif deps_has "awk"; then
-        use super::text::impl::awk_replace
+        nut_reload super::text::impl::awk_replace
         _TEXT_REPLACE_IMPL="awk"
     else
         # No tool available
@@ -278,8 +286,10 @@ text_replace() {
 # More efficient than sed alone when only a subset of lines need changes.
 # Falls back to sed-only if grep is not available.
 text_filtered_replace() {
+    nut_lazy_guard text_filtered_replace || return 1
+    local _NUT_LAZY_text_filtered_replace=1
     if deps_has_all "grep" "sed"; then
-        use super::text::impl::combo::grep_sed
+        nut_reload super::text::impl::combo::grep_sed
     else
         # Fallback: just do a regular replace (filter is ignored)
         # This is less efficient but still works
@@ -302,8 +312,10 @@ text_filtered_replace() {
 # 
 # Useful for extracting and reformatting specific lines without modifying the file.
 text_extract_transform() {
+    nut_lazy_guard text_extract_transform || return 1
+    local _NUT_LAZY_text_extract_transform=1
     if deps_has_all "grep" "sed"; then
-        use super::text::impl::combo::grep_sed
+        nut_reload super::text::impl::combo::grep_sed
     else
         # Fallback using separate grep and sed calls
         text_extract_transform() {
@@ -335,8 +347,10 @@ text_extract_transform() {
 # 
 # Useful for scoped counting, e.g., count TODOs only in comment lines.
 text_count_in_matches() {
+    nut_lazy_guard text_count_in_matches || return 1
+    local _NUT_LAZY_text_count_in_matches=1
     if deps_has_all "grep" "sed"; then
-        use super::text::impl::combo::grep_sed
+        nut_reload super::text::impl::combo::grep_sed
     else
         # Fallback
         text_count_in_matches() {

--- a/lib/text.sh
+++ b/lib/text.sh
@@ -160,10 +160,10 @@ text_lines() {
 text_grep() {
     # First call: decide which implementation to use
     if deps_has "grep"; then
-        source "${_TEXT_IMPL_DIR}/grep_match.sh"
+        use super::text::impl::grep_match
         _TEXT_MATCH_IMPL="grep"
     elif deps_has "perl"; then
-        source "${_TEXT_IMPL_DIR}/perl_match.sh"
+        use super::text::impl::perl_match
         _TEXT_MATCH_IMPL="perl"
     else
         # No tool available; define a failing function
@@ -184,10 +184,10 @@ text_grep() {
 text_contains() {
     # First call: decide which implementation to use
     if deps_has "grep"; then
-        source "${_TEXT_IMPL_DIR}/grep_match.sh"
+        use super::text::impl::grep_match
         _TEXT_MATCH_IMPL="grep"
     elif deps_has "perl"; then
-        source "${_TEXT_IMPL_DIR}/perl_match.sh"
+        use super::text::impl::perl_match
         _TEXT_MATCH_IMPL="perl"
     else
         text_contains() {
@@ -206,10 +206,10 @@ text_contains() {
 text_count_matches() {
     # First call: decide which implementation to use
     if deps_has "grep"; then
-        source "${_TEXT_IMPL_DIR}/grep_match.sh"
+        use super::text::impl::grep_match
         _TEXT_MATCH_IMPL="grep"
     elif deps_has "perl"; then
-        source "${_TEXT_IMPL_DIR}/perl_match.sh"
+        use super::text::impl::perl_match
         _TEXT_MATCH_IMPL="perl"
     else
         text_count_matches() {
@@ -242,16 +242,16 @@ text_replace() {
     # Prefer combo when both grep and sed are available
     # The combo checks if pattern exists before invoking sed (optimization)
     if deps_has_all "grep" "sed"; then
-        source "${_TEXT_COMBO_DIR}/grep_sed.sh"
+        use super::text::impl::combo::grep_sed
         _TEXT_REPLACE_IMPL="grep_sed"
     elif deps_has "sed"; then
-        source "${_TEXT_IMPL_DIR}/sed_replace.sh"
+        use super::text::impl::sed_replace
         _TEXT_REPLACE_IMPL="sed"
     elif deps_has "perl"; then
-        source "${_TEXT_IMPL_DIR}/perl_replace.sh"
+        use super::text::impl::perl_replace
         _TEXT_REPLACE_IMPL="perl"
     elif deps_has "awk"; then
-        source "${_TEXT_IMPL_DIR}/awk_replace.sh"
+        use super::text::impl::awk_replace
         _TEXT_REPLACE_IMPL="awk"
     else
         # No tool available
@@ -279,7 +279,7 @@ text_replace() {
 # Falls back to sed-only if grep is not available.
 text_filtered_replace() {
     if deps_has_all "grep" "sed"; then
-        source "${_TEXT_COMBO_DIR}/grep_sed.sh"
+        use super::text::impl::combo::grep_sed
     else
         # Fallback: just do a regular replace (filter is ignored)
         # This is less efficient but still works
@@ -303,7 +303,7 @@ text_filtered_replace() {
 # Useful for extracting and reformatting specific lines without modifying the file.
 text_extract_transform() {
     if deps_has_all "grep" "sed"; then
-        source "${_TEXT_COMBO_DIR}/grep_sed.sh"
+        use super::text::impl::combo::grep_sed
     else
         # Fallback using separate grep and sed calls
         text_extract_transform() {
@@ -336,7 +336,7 @@ text_extract_transform() {
 # Useful for scoped counting, e.g., count TODOs only in comment lines.
 text_count_in_matches() {
     if deps_has_all "grep" "sed"; then
-        source "${_TEXT_COMBO_DIR}/grep_sed.sh"
+        use super::text::impl::combo::grep_sed
     else
         # Fallback
         text_count_in_matches() {

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -437,3 +437,59 @@ it_does_not_hand_back_a_checkout_that_has_gone() {
     extern_path fixture >/dev/null 2>&1 || true
     assert_empty "${_EXTERN_RESOLVED[fixture]:-}"
 }
+
+# --- how a module path is spelled ----------------------------------------------
+#
+# `::` separates modules the whole way down. A `/` used to work, because the
+# tail was handed to the filesystem unchanged, so `shebang::tui/key` found the
+# file and read as two different separators in one path. It is refused now, and
+# the refusal names the spelling that works.
+
+#[test]
+it_takes_a_nested_module_separated_all_the_way_down() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/dep/libs/tui"
+    printf 'MARKER=reached\n' > "$d/dep/libs/tui/key.sh"
+    printf '[meta]\nname="dep"\n' > "$d/dep/nut.toml"
+    extern_path() { printf '%s/dep' "$d"; }
+    local out; out="$(extern_resolve 'dep::tui::key')"
+    assert_eq "$out" "$d/dep/libs/tui/key.sh"
+    unset -f extern_path
+    rm -rf "$d"
+}
+
+#[test]
+it_refuses_a_module_path_that_uses_a_slash() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/dep/libs/tui"
+    printf 'MARKER=reached\n' > "$d/dep/libs/tui/key.sh"
+    extern_path() { printf '%s/dep' "$d"; }
+    # The file is right there. It is still refused, because a separator that
+    # works by accident ends up used in half the call sites and not the other.
+    assert_fails extern_resolve 'dep::tui/key'
+    unset -f extern_path
+    rm -rf "$d"
+}
+
+#[test]
+it_says_the_spelling_that_would_have_worked() {
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/dep/libs/tui"
+    : > "$d/dep/libs/tui/key.sh"
+    extern_path() { printf '%s/dep' "$d"; }
+    out="$(extern_resolve 'dep::tui/key' 2>&1 || true)"
+    assert_ok grep -q 'dep::tui::key' <<<"$out"
+    unset -f extern_path
+    rm -rf "$d"
+}
+
+#[test]
+it_still_takes_a_flat_module() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/dep/lib"
+    : > "$d/dep/lib/plain.sh"
+    extern_path() { printf '%s/dep' "$d"; }
+    assert_eq "$(extern_resolve 'dep::plain')" "$d/dep/lib/plain.sh"
+    unset -f extern_path
+    rm -rf "$d"
+}

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -493,3 +493,63 @@ it_still_takes_a_flat_module() {
     unset -f extern_path
     rm -rf "$d"
 }
+
+# --- one file, one load ----------------------------------------------------------
+#
+# A module is reachable by more than one name: its own unit calls it
+# `super::tui::key`, a consumer calls it `dep::tui::key`, and both are the same
+# file. Loaded-ness was keyed on the words rather than the file, so each name
+# sourced it again, and a module without a guard of its own ran twice.
+
+#[test]
+it_loads_a_module_once_however_it_was_named() {
+    local out
+    out="$(bash -c '
+        cd '"$PWD"'
+        . ./init
+        d=$(mktemp -d); mkdir -p "$d/libs/tui"
+        printf "COUNT=\$(( \${COUNT:-0} + 1 ))\n" > "$d/libs/tui/key.sh"
+        use extern
+        extern_path() { printf "%s" "$d"; }
+        use one::tui::key
+        use two::tui::key
+        printf "%s" "$COUNT"
+        rm -rf "$d"')"
+    assert_eq "$out" "1"
+}
+
+#[test]
+it_answers_that_a_module_is_loaded_by_either_name() {
+    local out
+    out="$(bash -c '
+        cd '"$PWD"'
+        . ./init
+        d=$(mktemp -d); mkdir -p "$d/libs/tui"
+        : > "$d/libs/tui/key.sh"
+        use extern
+        extern_path() { printf "%s" "$d"; }
+        use one::tui::key
+        nutshell_loaded one::tui::key && printf "first "
+        use two::tui::key
+        nutshell_loaded two::tui::key && printf "second"
+        rm -rf "$d"')"
+    assert_eq "$out" "first second"
+}
+
+#[test]
+it_does_not_record_a_module_that_failed_to_load() {
+    local out
+    out="$(bash -c '
+        cd '"$PWD"'
+        . ./init
+        d=$(mktemp -d); mkdir -p "$d/libs"
+        printf "return 1\n" > "$d/libs/bad.sh"
+        use extern
+        extern_path() { printf "%s" "$d"; }
+        use dep::bad 2>/dev/null
+        nutshell_loaded dep::bad && printf "recorded" || printf "not recorded"
+        rm -rf "$d"')"
+    # Leaving the mark would make a later retry succeed against a module that
+    # was never sourced.
+    assert_eq "$out" "not recorded"
+}

--- a/tests/lazy_stub_test.sh
+++ b/tests/lazy_stub_test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Tests for the lazy stubs, and for one module meaning one file per unit.
+#
+# The crash these exist for had no message. A stub loads an implementation and
+# then calls the name that implementation was supposed to rebind; when the
+# rebind had not happened, that call was the stub calling itself until the
+# shell ran out of stack and the process disappeared. Nothing printed, no exit
+# status, nothing to read.
+
+use test
+
+ROOT="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+
+# Each of these runs a fresh shell, because the failure is about what one
+# process has already loaded.
+_run() { bash -c "cd '$ROOT'; . ./init; FUNCNEST=60; $1" 2>&1; }
+
+#[test]
+it_survives_a_module_being_sourced_again() {
+    local out
+    out="$(_run '
+        use text
+        printf "needle\n" > "$TMPDIR/_ck.$$"
+        text_grep needle "$TMPDIR/_ck.$$" >/dev/null
+        source lib/text.sh
+        text_grep needle "$TMPDIR/_ck.$$" >/dev/null
+        printf "SURVIVED"
+        rm -f "$TMPDIR/_ck.$$"')"
+    assert_ok    grep -q 'SURVIVED' <<<"$out"
+    assert_fails grep -q 'nesting level' <<<"$out"
+}
+
+#[test]
+it_survives_an_implementation_loaded_before_its_owner() {
+    local out
+    out="$(_run '
+        use text::impl::grep_match
+        use text
+        printf "needle\n" > "$TMPDIR/_ck2.$$"
+        text_grep needle "$TMPDIR/_ck2.$$" >/dev/null
+        printf "SURVIVED"
+        rm -f "$TMPDIR/_ck2.$$"')"
+    # The owner installs its stubs over the bindings the implementation made,
+    # so the stub has to be able to put them back.
+    assert_ok    grep -q 'SURVIVED' <<<"$out"
+    assert_fails grep -q 'nesting level' <<<"$out"
+}
+
+#[test]
+it_still_answers_after_all_that() {
+    local out
+    out="$(_run '
+        use text
+        printf "needle\nhaystack\n" > "$TMPDIR/_ck3.$$"
+        source lib/text.sh
+        text_grep needle "$TMPDIR/_ck3.$$"
+        rm -f "$TMPDIR/_ck3.$$"')"
+    # Not just "did not crash": it has to still do the thing.
+    assert_ok    grep -q 'needle'   <<<"$out"
+    assert_fails grep -q 'haystack' <<<"$out"
+}
+
+#[test]
+it_survives_the_same_for_fs() {
+    local out
+    out="$(_run '
+        use fs
+        fs_size ./init >/dev/null
+        source lib/fs.sh
+        fs_size ./init >/dev/null
+        printf "SURVIVED"')"
+    assert_ok    grep -q 'SURVIVED' <<<"$out"
+    assert_fails grep -q 'nesting level' <<<"$out"
+}
+
+#[test]
+it_says_something_rather_than_dying_silently() {
+    # The guard's own message, when a stub really is on its own. Provoked by
+    # putting the stub back with the implementation already loaded and the
+    # reload unable to help.
+    local out
+    out="$(_run '
+        use text
+        text_grep() { nut_lazy_guard text_grep || return 1; local _NUT_LAZY_text_grep=1; text_grep "$@"; }
+        text_grep a b
+        printf "EXIT=%s" "$?"')"
+    assert_ok grep -q 'did not define' <<<"$out"
+    assert_ok grep -q 'EXIT=1'         <<<"$out"
+    # A message and a status, rather than a process that disappears.
+    assert_fails grep -q 'nesting level' <<<"$out"
+}
+
+# --- one name, two units ------------------------------------------------------------
+
+#[test]
+it_gives_each_unit_its_own_module_of_the_same_name() {
+    local out
+    out="$(_run '
+        a=$(mktemp -d); b=$(mktemp -d)
+        for d in "$a" "$b"; do mkdir -p "$d/lib"; printf "[meta]\nname=\"x\"\n" > "$d/nut.toml"; done
+        printf "A_MARK=1\n" > "$a/lib/guard.sh"; printf "guard lib/guard.sh\n" > "$a/lib.nut"
+        printf "B_MARK=1\n" > "$b/lib/guard.sh"; printf "guard lib/guard.sh\n" > "$b/lib.nut"
+        printf "use super::guard\n" > "$a/mod.sh"
+        printf "use super::guard\n" > "$b/mod.sh"
+        . "$a/mod.sh"; . "$b/mod.sh"
+        printf "A=%s B=%s" "${A_MARK:-unset}" "${B_MARK:-unset}"
+        rm -rf "$a" "$b"')"
+    # super:: is relative to whoever wrote it. Cached by the name alone, the
+    # second unit matched the first unit's entry, loaded nothing, and returned
+    # success.
+    assert_ok grep -q 'A=1 B=1' <<<"$out"
+}
+
+#[test]
+it_still_loads_one_file_once_within_a_unit() {
+    local out
+    out="$(_run '
+        a=$(mktemp -d); mkdir -p "$a/lib"
+        printf "[meta]\nname=\"x\"\n" > "$a/nut.toml"
+        printf "COUNT=\$(( \${COUNT:-0} + 1 ))\n" > "$a/lib/one.sh"
+        printf "one lib/one.sh\n" > "$a/lib.nut"
+        printf "use super::one\nuse super::one\n" > "$a/mod.sh"
+        . "$a/mod.sh"
+        printf "COUNT=%s" "$COUNT"
+        rm -rf "$a"')"
+    assert_ok grep -q 'COUNT=1' <<<"$out"
+}
+
+# --- reloading on purpose --------------------------------------------------------------
+
+#[test]
+it_loads_again_when_asked_outright() {
+    local out
+    out="$(_run '
+        a=$(mktemp -d); mkdir -p "$a/lib"
+        printf "[meta]\nname=\"x\"\n" > "$a/nut.toml"
+        printf "COUNT=\$(( \${COUNT:-0} + 1 ))\n" > "$a/lib/one.sh"
+        printf "one lib/one.sh\n" > "$a/lib.nut"
+        printf "use super::one\nnut_reload super::one\n" > "$a/mod.sh"
+        . "$a/mod.sh"
+        printf "COUNT=%s" "$COUNT"
+        rm -rf "$a"')"
+    assert_ok grep -q 'COUNT=2' <<<"$out"
+}
+
+#[test]
+it_forgets_by_file_rather_than_by_the_name_it_was_asked_about() {
+    # Loaded under one name and reloaded under another. Forgetting by the name
+    # asked about would forget nothing, `use` would say "already loaded", and
+    # the stub that asked for the reload would still be the stub.
+    #
+    # Written to a file rather than nested inside quotes: the quoting needed to
+    # define a function inside a -c inside a test is its own source of bugs.
+    local f; f="$(mktemp)"
+    cat > "$f" <<'PROBE'
+cd "$NUT_ROOT"
+. ./init
+a=$(mktemp -d); mkdir -p "$a/libs"
+printf 'COUNT=$(( ${COUNT:-0} + 1 ))
+' > "$a/libs/one.sh"
+printf 'one libs/one.sh
+' > "$a/lib.nut"
+use extern
+extern_path() { printf '%s' "$a"; }
+use dep::one
+nut_reload other::one
+printf 'COUNT=%s
+' "$COUNT"
+rm -rf "$a"
+PROBE
+    local out; out="$(NUT_ROOT="$ROOT" bash "$f" 2>&1)"
+    rm -f "$f"
+    assert_ok grep -q 'COUNT=2' <<<"$out"
+}

--- a/tests/lib_nut_test.sh
+++ b/tests/lib_nut_test.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Tests for the module declaration.
+#
+# The point of it is that a name either is in the tree or is not, answerable
+# without running anything. Before it, a module was found by trying three
+# layouts and taking whichever answered, so nothing could say in advance that a
+# name would fail, and the failure arrived mid-run under `set -eo pipefail`
+# with nothing to read.
+
+use extern test
+
+DECLARE="${BASH_SOURCE[0]%/*}/../bin/nut-declare"
+
+# A library with a declaration, laid out the way a real one is.
+_lib() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/libs/tui" "$d/lib/json/impl"
+    : > "$d/libs/tui/term.sh"
+    : > "$d/libs/tui/key.sh"
+    : > "$d/lib/json.sh"
+    : > "$d/lib/json/impl/jq.sh"
+    printf '%s\n' \
+        'tui::term       libs/tui/term.sh' \
+        'tui::key        libs/tui/key.sh' \
+        'json            lib/json.sh' \
+        'json::impl::jq  lib/json/impl/jq.sh  internal' \
+        > "$d/lib.nut"
+    printf '%s' "$d"
+}
+
+# --- resolution -----------------------------------------------------------------
+
+#[test]
+it_resolves_a_module_the_library_declares() {
+    local d; d="$(_lib)"
+    extern_path() { printf '%s' "$d"; }
+    assert_eq "$(extern_resolve 'dep::tui::term')" "$d/libs/tui/term.sh"
+    assert_eq "$(extern_resolve 'dep::json')"      "$d/lib/json.sh"
+    unset -f extern_path; rm -rf "$d"
+}
+
+#[test]
+it_refuses_a_module_the_library_does_not_declare() {
+    local d; d="$(_lib)"
+    # The file is there. It is still refused, because a declaration that a
+    # search can go behind is not a declaration.
+    mkdir -p "$d/libs/tui"; : > "$d/libs/tui/undeclared.sh"
+    extern_path() { printf '%s' "$d"; }
+    assert_fails extern_resolve 'dep::tui::undeclared'
+    unset -f extern_path; rm -rf "$d"
+}
+
+#[test]
+it_says_what_the_library_does_declare() {
+    local d out; d="$(_lib)"
+    extern_path() { printf '%s' "$d"; }
+    out="$(extern_resolve 'dep::nope' 2>&1 || true)"
+    assert_ok grep -qi 'not among the modules' <<<"$out"
+    unset -f extern_path; rm -rf "$d"
+}
+
+#[test]
+it_refuses_a_declaration_pointing_at_a_file_that_is_gone() {
+    local d out; d="$(_lib)"
+    rm -f "$d/libs/tui/key.sh"
+    extern_path() { printf '%s' "$d"; }
+    out="$(extern_resolve 'dep::tui::key' 2>&1 || true)"
+    assert_fails extern_resolve 'dep::tui::key'
+    # Named, so the fix is obvious: either the file moved or the line is stale.
+    assert_ok grep -q 'which is not there' <<<"$out"
+    unset -f extern_path; rm -rf "$d"
+}
+
+#[test]
+it_keeps_an_internal_module_out_of_a_consumers_reach() {
+    local d; d="$(_lib)"
+    extern_path() { printf '%s' "$d"; }
+    # Picked at runtime by the module above it. A consumer reaching it directly
+    # is reaching past the thing whose job is to choose.
+    assert_fails extern_resolve 'dep::json::impl::jq'
+    unset -f extern_path; rm -rf "$d"
+}
+
+#[test]
+it_still_refuses_a_slash_even_with_a_declaration() {
+    local d; d="$(_lib)"
+    extern_path() { printf '%s' "$d"; }
+    assert_fails extern_resolve 'dep::tui/term'
+    unset -f extern_path; rm -rf "$d"
+}
+
+#[test]
+it_ignores_comments_and_blank_lines() {
+    local d; d="$(_lib)"
+    printf '\n# a comment\n\n' >> "$d/lib.nut"
+    extern_path() { printf '%s' "$d"; }
+    assert_eq "$(extern_resolve 'dep::json')" "$d/lib/json.sh"
+    unset -f extern_path; rm -rf "$d"
+}
+
+# --- the migration ----------------------------------------------------------------
+
+#[test]
+it_declares_what_the_old_resolver_would_have_found() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/libs/tui" "$d/lib"
+    : > "$d/libs/tui/term.sh"; : > "$d/lib/log.sh"
+    local out; out="$("$DECLARE" --print "$d")"
+    # The names are the ones a `use` would have written for those files.
+    assert_ok grep -qE '^tui::term[[:space:]]+libs/tui/term\.sh' <<<"$out"
+    assert_ok grep -qE '^log[[:space:]]+lib/log\.sh' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_marks_an_implementation_file_internal() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib/json/impl"
+    : > "$d/lib/json/impl/jq.sh"
+    assert_ok grep -q 'internal' <<<"$("$DECLARE" --print "$d")"
+    rm -rf "$d"
+}
+
+#[test]
+it_does_not_declare_a_vendored_nutshell_as_part_of_the_library() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib/nutshell/lib" "$d/lib"
+    : > "$d/lib/nutshell/lib/log.sh"; : > "$d/lib/own.sh"
+    local out; out="$("$DECLARE" --print "$d")"
+    assert_ok    grep -q 'own' <<<"$out"
+    assert_fails grep -q 'nutshell' <<<"$(grep -v '^#' <<<"$out")"
+    rm -rf "$d"
+}
+
+#[test]
+it_never_overwrites_a_declaration_that_exists() {
+    local d; d="$(_lib)"
+    local before; before="$(cat "$d/lib.nut")"
+    "$DECLARE" "$d" >/dev/null 2>&1
+    assert_eq "$(cat "$d/lib.nut")" "$before"
+    rm -rf "$d"
+}
+
+#[test]
+it_shows_the_difference_rather_than_editing() {
+    local d out; d="$(_lib)"
+    : > "$d/libs/tui/extra.sh"
+    out="$("$DECLARE" "$d" 2>&1)"
+    assert_ok grep -q 'already exists' <<<"$out"
+    assert_ok grep -q 'extra' <<<"$out"
+    rm -rf "$d"
+}
+
+# --- the check --------------------------------------------------------------------
+
+#[test]
+it_passes_a_library_whose_declaration_matches_its_files() {
+    local d; d="$(_lib)"
+    assert_ok "$DECLARE" --check "$d"
+    rm -rf "$d"
+}
+
+#[test]
+it_catches_a_declaration_whose_file_is_missing() {
+    local d out; d="$(_lib)"
+    rm -f "$d/lib/json.sh"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    assert_fails "$DECLARE" --check "$d"
+    assert_ok grep -q 'declared but missing' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_catches_a_file_nothing_declares() {
+    local d out; d="$(_lib)"
+    : > "$d/libs/tui/orphan.sh"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    assert_fails "$DECLARE" --check "$d"
+    # The direction a search could never report: the file resolves fine, and
+    # is reachable by a name the library never meant to offer.
+    assert_ok grep -q 'present but undeclared' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_a_library_with_no_declaration_at_all() {
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/lib/one.sh"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    assert_fails "$DECLARE" --check "$d"
+    assert_ok grep -q 'has no lib.nut' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_checks_every_library_in_this_workspace() {
+    # The declarations shipped here have to match the files shipped here, or
+    # the check is a thing that only passes on fixtures.
+    assert_ok "$DECLARE" --check "${BASH_SOURCE[0]%/*}/.."
+}

--- a/tests/lib_nut_test.sh
+++ b/tests/lib_nut_test.sh
@@ -198,3 +198,56 @@ it_checks_every_library_in_this_workspace() {
     # the check is a thing that only passes on fixtures.
     assert_ok "$DECLARE" --check "${BASH_SOURCE[0]%/*}/.."
 }
+
+#[test]
+it_finds_a_module_however_deep_it_sits() {
+    # The scan used a glob per level, so a module one level deeper than anyone
+    # had written a glob for was invisible. Invisible to --check too, since
+    # both read the same list: the library reported complete while
+    # text::impl::combo::grep_sed was undeclared and would have failed at the
+    # moment it was reached.
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib/text/impl/combo"
+    : > "$d/lib/text/impl/combo/grep_sed.sh"
+    local out; out="$("$DECLARE" --print "$d")"
+    assert_ok grep -q 'text::impl::combo::grep_sed' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_finds_one_deeper_still() {
+    # Not "one more level than the bug had": no level at all.
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib/a/b/c/d/e"
+    : > "$d/lib/a/b/c/d/e/deep.sh"
+    assert_ok grep -q 'a::b::c::d::e::deep' <<<"$("$DECLARE" --print "$d")"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_a_deep_file_as_undeclared() {
+    # The check has to see as far as the scan, or it certifies a tree it did
+    # not look at.
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib/a/b/c"
+    : > "$d/lib/a/b/c/deep.sh"
+    printf 'nothing lib/nothing.sh\n' > "$d/lib.nut"
+    : > "$d/lib/nothing.sh"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    assert_ok grep -q 'a::b::c::deep' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_loads_an_implementation_through_the_resolver() {
+    # A hand-rolled `source` goes around the resolver: loaded again for every
+    # caller, not covered by the declaration, and failing when reached rather
+    # than before the run.
+    local bad=""
+    grep -rn 'source "\${_[A-Z_]*_DIR}' "${BASH_SOURCE[0]%/*}/../lib"/*.sh 2>/dev/null \
+        | grep -v '/nutshell/' | while IFS= read -r line; do
+        printf '%s\n' "$line"
+    done > /tmp/_nut_direct_sources.$$
+    bad="$(cat /tmp/_nut_direct_sources.$$)"; rm -f /tmp/_nut_direct_sources.$$
+    assert_empty "$bad"
+}

--- a/tests/lib_nut_test.sh
+++ b/tests/lib_nut_test.sh
@@ -291,3 +291,128 @@ it_loads_its_own_nested_module_by_name() {
     out="$(bash -c "cd '$ROOT_DIR'; . ./init; use text::impl::grep_match && printf OK" 2>&1)"
     assert_ok grep -q 'OK' <<<"$out"
 }
+
+# --- the ways a declaration was quietly wrong -----------------------------------------
+
+#[test]
+it_declares_a_module_flat_at_the_library_root() {
+    # The resolver tries three layouts and the scan walked two, so a module at
+    # the root resolved before the migration and was refused after it, with
+    # --check certifying the drop because it reads the same scan.
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/helper.sh"; : > "$d/lib/other.sh"
+    local out; out="$("$DECLARE" --print "$d")"
+    assert_ok grep -qE '^helper[[:space:]]+helper\.sh' <<<"$out"
+    assert_ok grep -qE '^other[[:space:]]+lib/other\.sh' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_refuses_to_declare_when_two_files_answer_to_one_name() {
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib" "$d/libs"
+    printf 'WHICH=lib\n'  > "$d/lib/dup.sh"
+    printf 'WHICH=libs\n' > "$d/libs/dup.sh"
+    # Writing one of them freezes a precedence and hides the other file for
+    # good. Better to say so than to pick.
+    out="$("$DECLARE" "$d" 2>&1 || "$DECLARE" "$d" 2>&1)"
+    assert_ok grep -q 'same name' <<<"$out"
+    assert_fails test -f "$d/lib.nut"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_two_files_answering_to_one_name_in_a_check() {
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib" "$d/libs"
+    : > "$d/lib/dup.sh"; : > "$d/libs/dup.sh"
+    printf 'dup lib/dup.sh\n' > "$d/lib.nut"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    assert_ok grep -q 'one name' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_keeps_the_last_declaration_when_the_file_has_no_trailing_newline() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/lib/last.sh"
+    printf 'last lib/last.sh' > "$d/lib.nut"      # no newline
+    # An editor that trims the last newline would otherwise delete a module,
+    # and the checker agreed because it read the file another way.
+    assert_ok bash -c ". '$ROOT_DIR/init'; _lib_nut_lookup '$d' last"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_a_line_that_is_not_a_declaration() {
+    local d out; d="$(mktemp -d)"
+    printf 'nofile\n' > "$d/lib.nut"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    # Rather than a raw bash error about an unset positional under set -u.
+    assert_ok    grep -q 'not a declaration' <<<"$out"
+    assert_fails grep -qi 'unbound\|bad substitution' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_a_visibility_it_does_not_understand() {
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/lib/x.sh"
+    printf 'x lib/x.sh publicish\n' > "$d/lib.nut"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    # A typo in the third column silently made an internal module public.
+    assert_ok grep -q 'unknown visibility' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_skips_an_indented_comment_the_way_the_resolver_does() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/lib/x.sh"
+    printf '   # indented\nx lib/x.sh\n' > "$d/lib.nut"
+    assert_ok "$DECLARE" --check "$d"
+    rm -rf "$d"
+}
+
+#[test]
+it_compares_a_module_name_as_a_word_not_as_a_pattern() {
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib"
+    : > "$d/lib/fs.impl.sh"
+    printf 'fsXimpl lib/other.sh\n' > "$d/lib.nut"
+    : > "$d/lib/other.sh"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    # `fs.impl` as a regex matches `fsXimpl`, and the module would be reported
+    # as declared when nothing declares it.
+    assert_ok grep -q 'present but undeclared: fs.impl' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_loads_a_symlinked_module_once() {
+    # A logical path leaves a link and its target as two keys, so one file
+    # loads twice. Written to a file: the escaping needed to build this inside
+    # a -c inside a test is its own source of bugs.
+    local f; f="$(mktemp)"
+    cat > "$f" <<'PROBE'
+cd "$NUT_ROOT"
+. ./init
+a=$(mktemp -d); mkdir -p "$a/libs"
+printf 'COUNT=$(( ${COUNT:-0} + 1 ))
+' > "$a/libs/real.sh"
+ln -s real.sh "$a/libs/alias.sh"
+printf 'real libs/real.sh
+alias libs/alias.sh
+' > "$a/lib.nut"
+use extern
+extern_path() { printf '%s' "$a"; }
+use dep::real
+use dep::alias
+printf 'COUNT=%s
+' "$COUNT"
+rm -rf "$a"
+PROBE
+    local out; out="$(NUT_ROOT="$ROOT_DIR" bash "$f" 2>&1)"
+    rm -f "$f"
+    assert_ok grep -q 'COUNT=1' <<<"$out"
+}

--- a/tests/lib_nut_test.sh
+++ b/tests/lib_nut_test.sh
@@ -10,6 +10,7 @@
 use extern test
 
 DECLARE="${BASH_SOURCE[0]%/*}/../bin/nut-declare"
+ROOT_DIR="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
 
 # A library with a declaration, laid out the way a real one is.
 _lib() {
@@ -250,4 +251,43 @@ it_loads_an_implementation_through_the_resolver() {
     done > /tmp/_nut_direct_sources.$$
     bad="$(cat /tmp/_nut_direct_sources.$$)"; rm -f /tmp/_nut_direct_sources.$$
     assert_empty "$bad"
+}
+
+# --- the ways around the declaration ------------------------------------------------
+#
+# A declaration a caller can step around is not a declaration. These are the
+# routes that existed: a bare `use` went straight to lib/<name>.sh, so spelling
+# a path reached a file the library had marked internal, in one call, without
+# the declaration being consulted at all.
+
+#[test]
+it_refuses_a_bare_use_that_spells_a_path() {
+    local out
+    out="$(bash -c "cd '$ROOT_DIR'; . ./init; use json/impl/jq" 2>&1 || true)"
+    assert_ok grep -q "separates modules with '/'" <<<"$out"
+    assert_ok grep -q 'json::impl::jq' <<<"$out"
+}
+
+#[test]
+it_does_not_load_an_internal_module_by_spelling_its_path() {
+    local out
+    out="$(bash -c "cd '$ROOT_DIR'; . ./init; use json/impl/jq >/dev/null 2>&1; declare -F _json_jq_get >/dev/null && printf REACHED || printf refused" 2>&1)"
+    assert_ok grep -q 'refused' <<<"$out"
+}
+
+#[test]
+it_still_loads_a_plain_module_by_name() {
+    local out
+    out="$(bash -c "cd '$ROOT_DIR'; . ./init; use json && printf OK" 2>&1)"
+    assert_ok grep -q 'OK' <<<"$out"
+}
+
+#[test]
+it_loads_its_own_nested_module_by_name() {
+    # nutshell's own tree is named the way anybody else's is. Treating every
+    # `::` as a dependency made its own nested modules unreachable except from
+    # inside the unit.
+    local out
+    out="$(bash -c "cd '$ROOT_DIR'; . ./init; use text::impl::grep_match && printf OK" 2>&1)"
+    assert_ok grep -q 'OK' <<<"$out"
 }

--- a/tests/log_marks_test.sh
+++ b/tests/log_marks_test.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Tests for marked, nested log output.
+#
+# Two properties. A run where one line went wrong has to be skimmable, so the
+# mark's column and the depth are the contract rather than decoration. And
+# log_run has to return what the command returned: a runner that reports
+# success on a failed command is worse than no runner.
+
+use log test
+
+setup() { log_reset; LOG_COLOR=never; LOG_LEVEL=info; log_marks text; }
+
+_strip() { sed 's/\x1b\[[0-9;]*[a-zA-Z]//g'; }
+
+# --- marks -------------------------------------------------------------------
+
+#[test]
+it_marks_each_kind_of_line_differently() {
+    local out
+    out="$( { log_ok a; log_warned b; log_failed c; log_flat d; } 2>&1 | _strip)"
+    assert_eq "$(grep -c . <<<"$out")" "4"
+    # Four kinds, four marks in column one.
+    assert_eq "$(cut -c1 <<<"$out" | sort -u | grep -c .)" "4"
+}
+
+#[test]
+it_leaves_a_flat_line_unmarked() {
+    local out; out="$(log_flat "just a fact" 2>&1 | _strip)"
+    assert_eq "${out:0:1}" " "
+}
+
+#[test]
+it_keeps_every_mark_to_one_column() {
+    local out
+    out="$( { log_ok top
+              log_open deeper
+              log_ok inside
+              log_open "deeper still"
+              log_failed "further in"; } 2>&1 | _strip)"
+    # The mark sits outside the indent, so scanning column one finds every
+    # result whatever depth produced it.
+    local second; second="$(cut -c2 <<<"$out" | sort -u)"
+    assert_eq "$(grep -c . <<<"$second")" "1"
+    assert_eq "$second" " "
+}
+
+#[test]
+it_uses_words_when_told_to() {
+    log_marks text
+    local out; out="$( { log_ok a; log_failed b; } 2>&1 | _strip)"
+    assert_ok python3 -c 'import sys; sys.stdin.buffer.read().decode("ascii")' <<<"$out"
+}
+
+#[test]
+it_uses_icons_when_told_to() {
+    log_marks icon
+    local out; out="$(log_ok a 2>&1 | _strip)"
+    assert_fails python3 -c 'import sys; sys.stdin.buffer.read().decode("ascii")' <<<"$out"
+    log_marks text
+}
+
+#[test]
+it_draws_no_marks_when_told_to() {
+    log_marks none
+    local out; out="$( { log_ok a; log_failed b; } 2>&1 | _strip)"
+    # A blank column rather than no column: the text still lines up with a run
+    # that does have marks, which is the point of turning them off rather than
+    # of not having them.
+    assert_eq "$(cut -c1 <<<"$out" | sort -u | tr -d '\n')" " "
+    assert_ok grep -q '^  a$' <<<"$out"
+    log_marks text
+}
+
+#[test]
+it_picks_words_in_a_locale_that_cannot_draw_icons() {
+    local out
+    out="$(LC_ALL=C LANG=C bash -c '
+        cd '"$PWD"'; . ./init; use log
+        LOG_COLOR=never; log_ok a; log_failed b' 2>&1 | _strip)"
+    # An icon that renders as three bytes of noise is worse than a plus.
+    assert_ok python3 -c 'import sys; sys.stdin.buffer.read().decode("ascii")' <<<"$out"
+}
+
+# --- depth --------------------------------------------------------------------
+
+#[test]
+it_indents_what_belongs_to_a_step() {
+    local out; out="$( { log_open outer; log_ok inner; } 2>&1 | _strip)"
+    assert_ok grep -q '^.   inner' <<<"$(sed -n 2p <<<"$out")"
+}
+
+#[test]
+it_nests_further_than_one_level() {
+    local out
+    out="$( { log_open a; log_open b; log_ok c; } 2>&1 | _strip)"
+    # log_substep was fixed at one level. This is the gap that wanted filling.
+    assert_ok grep -q '^.     c' <<<"$(sed -n 3p <<<"$out")"
+}
+
+#[test]
+it_returns_to_the_previous_depth() {
+    log_open one >/dev/null 2>&1; assert_eq "$LOG_DEPTH" "1"
+    log_open two >/dev/null 2>&1; assert_eq "$LOG_DEPTH" "2"
+    log_close ok x >/dev/null 2>&1; assert_eq "$LOG_DEPTH" "1"
+    log_close ok y >/dev/null 2>&1; assert_eq "$LOG_DEPTH" "0"
+}
+
+#[test]
+it_does_not_go_below_the_top() {
+    log_close ok "nothing was open" >/dev/null 2>&1
+    log_close ok "still nothing"    >/dev/null 2>&1
+    # A negative depth is a negative printf width, which is an error and not
+    # an indent.
+    assert_eq "$LOG_DEPTH" "0"
+    assert_ok log_ok after >/dev/null 2>&1
+}
+
+#[test]
+it_closes_a_step_silently_when_told_nothing() {
+    log_open one >/dev/null 2>&1
+    # Two calls, deliberately. Capturing the output puts log_close in a
+    # subshell, where the depth it changes is discarded, so a single call
+    # cannot check both things at once.
+    local out; out="$(log_open two >/dev/null 2>&1; log_close 2>&1)"
+    assert_eq "$out" ""
+    log_close 2>/dev/null
+    assert_eq "$LOG_DEPTH" "0"
+}
+
+#[test]
+it_keeps_the_depth_right_even_when_the_level_hides_the_line() {
+    LOG_LEVEL=error
+    log_open quiet >/dev/null 2>&1
+    # The heading is suppressed. The depth still has to move, or every line
+    # after it is indented wrongly for the rest of the run.
+    assert_eq "$LOG_DEPTH" "1"
+    log_close >/dev/null 2>&1
+    LOG_LEVEL=info
+}
+
+# --- running a command -----------------------------------------------------------
+
+#[test]
+it_returns_what_the_command_returned() {
+    log_run "fine" true >/dev/null 2>&1;   assert_eq "$?" "0"
+    log_run "not fine" false >/dev/null 2>&1; assert_eq "$?" "1"
+    log_run "particular" bash -c 'exit 42' >/dev/null 2>&1; assert_eq "$?" "42"
+}
+
+#[test]
+it_marks_a_failed_command_as_failed() {
+    local out; out="$(log_run "a thing" bash -c 'exit 3' 2>&1 | _strip)"
+    assert_ok grep -q 'exit 3' <<<"$out"
+}
+
+#[test]
+it_counts_a_failed_command() {
+    # Not captured, because a capture is a subshell and the count made in one
+    # does not come back. That is a real property of the counters and callers
+    # need to know it; the doc comment on log_worst says so.
+    log_reset
+    log_run "a thing" bash -c 'exit 3' >/dev/null 2>&1
+    assert_eq "$LOG_FAILURES" "1"
+    assert_eq "$(log_worst)" "fail"
+}
+
+#[test]
+it_shows_both_streams_of_what_the_command_printed() {
+    local out; out="$(log_run noisy bash -c 'echo out; echo err >&2' 2>&1 | _strip)"
+    assert_ok grep -q 'out' <<<"$out"
+    assert_ok grep -q 'err' <<<"$out"
+}
+
+#[test]
+it_keeps_the_status_marker_out_of_the_output() {
+    local out; out="$(log_run quiet true 2>&1 | _strip)"
+    assert_fails grep -qE '^[^ ]? +[0-9]+$' <<<"$out"
+    assert_fails grep -q $'\037' <<<"$out"
+}
+
+#[test]
+it_indents_a_commands_output_under_its_step() {
+    local out; out="$(log_run label bash -c 'echo hello' 2>&1 | _strip)"
+    assert_ok grep -q '^.   hello' <<<"$out"
+}
+
+#[test]
+it_leaves_the_depth_where_it_found_it() {
+    log_open outer >/dev/null 2>&1
+    log_run inner true >/dev/null 2>&1
+    assert_eq "$LOG_DEPTH" "1"
+    log_run "inner that failed" false >/dev/null 2>&1
+    assert_eq "$LOG_DEPTH" "1"
+}
+
+# --- the verdict --------------------------------------------------------------------
+
+#[test]
+it_calls_a_clean_run_ok() {
+    log_ok a >/dev/null 2>&1; log_flat b >/dev/null 2>&1
+    assert_eq "$(log_worst)" "ok"
+}
+
+#[test]
+it_remembers_a_warning() {
+    log_ok a >/dev/null 2>&1; log_warned b >/dev/null 2>&1
+    assert_eq "$(log_worst)" "warn"
+}
+
+#[test]
+it_lets_a_failure_outrank_a_warning() {
+    log_warned a >/dev/null 2>&1; log_failed b >/dev/null 2>&1
+    assert_eq "$(log_worst)" "fail"
+}
+
+#[test]
+it_counts_a_problem_even_when_the_level_hides_it() {
+    LOG_LEVEL=error
+    log_warned "not shown" >/dev/null 2>&1
+    # The verdict is about what happened, not about what was displayed. A run
+    # quieted with LOG_LEVEL must not come out looking clean.
+    assert_eq "$(log_worst)" "warn"
+    LOG_LEVEL=info
+}
+
+#[test]
+it_forgets_the_previous_run_on_reset() {
+    log_failed a >/dev/null 2>&1
+    assert_eq "$(log_worst)" "fail"
+    log_reset
+    assert_eq "$(log_worst)" "ok"
+    assert_eq "$LOG_FAILURES" "0"
+}
+
+# --- what was already here ------------------------------------------------------------
+
+#[test]
+it_leaves_the_existing_levels_alone() {
+    LOG_COLOR=never
+    local out
+    out="$(log_warn "old shape" 2>&1)"
+    # The tagged format is what every caller already prints. Adding marks must
+    # not have changed it.
+    assert_ok grep -q '^\[WARN\] old shape' <<<"$out"
+    out="$(log_step "a heading" 2>&1)"
+    assert_ok grep -q '==>' <<<"$out"
+}


### PR DESCRIPTION
Two things, and the second grew out of a question about the first.

**Logging.** `log_step` opened a heading and `log_substep` indented one line under it, which is one level. A script describing work with steps inside steps had nowhere to put them, and no way to close a step with how it went. `log_open`/`log_close` nest to any depth; `log_ok`, `log_warned`, `log_failed` and `log_flat` put a mark in column one, outside the indent, so scanning that column finds every result whatever depth produced it. Marks are icons where the terminal can draw them and words where it cannot. `log_run` runs a command as a step and returns the command's own status, because a runner that reports success on a failed command is worse than no runner.

**Modules.** `dep::tui/key` resolved because the tail after `::` was handed to the filesystem unchanged, so nested modules worked without anyone having designed them. `::` separates all the way down now and `/` is refused with the spelling that works.

Loading is keyed on the resolved file rather than on the words that asked, so one module reachable by two names loads once.

`lib.nut` declares what a library offers and where each module lives, so a name is in the tree or it is not, and both directions are checkable before anything runs. Previously a module was found by trying three layouts in order, which meant a file findable two ways resolved to whichever came first, and nothing could say in advance that a name would fail — the failure landed mid-run, under `set -eo pipefail`, with the shell exiting and nothing on screen. It is a line format because `init` reads it before any module is loaded and the TOML parser is itself a module.

`nut-declare` writes the declaration a library was already implying, by running the old resolution backwards, so what it writes resolves what resolved before. `--check` reports a declaration whose file is gone and a file nothing declares.

`json`, `fs` and `text` name their implementations instead of assembling a path and sourcing it.

**What a review of this found, and what it cost to fix.** Making `use` load a file once broke the lazy stubs: the stub loads an implementation, the implementation rebinds the stub's name, the stub calls that name — and with the implementation already loaded, it called itself until the shell ran out of stack, with no message at all. Underneath were two guards for one property keyed differently, `super::` cached in a table keyed by name alone so a second library with its own `lib/guard.sh` silently got nothing, and a bare `use json/impl/jq` that reached an internal file past the declaration entirely. All fixed, with tests that fail against the unfixed source.

And a tool installed on PATH could not find its own `nut.toml` when run from anywhere else, because the manifest search had only `PWD`. It anchors per call on the file that wrote the `use`, the same way `super::` does.

Documentation in `docs/MODULES.md`. Four findings written down rather than fixed, in `docs/TODO.md`.

248 tests.