### PR TITLE
fix: let a tool find its own manifest from anywhere

### DIFF
--- a/init
+++ b/init
@@ -258,6 +258,13 @@ _use_resolve() {
         mod_path="$(_lib_nut_lookup "$_NUTSHELL_ROOT" "$mod" 2>/dev/null)" || mod_path=""
         if [[ -z "$mod_path" ]]; then
             use extern || return 1
+            # Where the asking file lives, so extern can find that unit's
+            # manifest rather than searching from wherever the process happens
+            # to have been started.
+            local _NUT_ASKING_FROM=""
+            if [[ -n "$caller" && "$caller" == */* ]]; then
+                _NUT_ASKING_FROM="$(cd "${caller%/*}" 2>/dev/null && pwd)"
+            fi
             mod_path="$(extern_resolve "$mod")" || return 1
         fi
     else

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -57,7 +57,15 @@ use toml xdg fs log validate
 # manifest is the right answer for it.
 _extern_manifest() {
     local start dir
-    for start in "${NUTSHELL_SCRIPT_DIR:-}" "${PWD}"; do
+    # The file that wrote the `use`, first. NUTSHELL_SCRIPT_DIR is unset on
+    # purpose (a process that sources init would inherit an ancestor's), which
+    # left only PWD: so a tool installed on PATH and run from anywhere else
+    # could not find its own nut.toml, and every `use dep::x` in it failed.
+    #
+    # _NUT_ASKING_FROM is set per call by `use`, from BASH_SOURCE, so it says
+    # which unit is asking rather than which process was started. Same
+    # anchoring `super::` uses, for the same reason.
+    for start in "${_NUT_ASKING_FROM:-}" "${NUTSHELL_SCRIPT_DIR:-}" "${PWD}"; do
         [[ -z "$start" ]] && continue
         dir="$start"
         while [[ "$dir" != "/" && -n "$dir" ]]; do

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -553,3 +553,29 @@ it_does_not_record_a_module_that_failed_to_load() {
     # was never sourced.
     assert_eq "$out" "not recorded"
 }
+
+#[test]
+it_finds_a_units_manifest_when_run_from_somewhere_else() {
+    # A tool installed on PATH and run from any other directory could not
+    # resolve a single dependency: the manifest search had only PWD, which is a
+    # fact about where the shell was started rather than about which unit is
+    # asking.
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/unit/lib" "$d/dep/libs"
+    printf '[meta]\nname="unit"\n\n[deps.dep]\ngit = "x"\n' > "$d/unit/nut.toml"
+    printf 'MARKER=reached\n' > "$d/dep/libs/thing.sh"
+    printf 'thing libs/thing.sh\n' > "$d/dep/lib.nut"
+    printf 'use extern\nextern_path() { printf "%%s" "%s/dep"; }\nuse dep::thing\n' "$d" \
+        > "$d/unit/lib/main.sh"
+
+    # Run from a directory that is not the unit and has no manifest above it.
+    # The init path is captured before the cd: `$PWD` inside would be the
+    # directory just moved to, which is the mistake this test is about.
+    local nut; nut="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+    out="$(cd "$d" && bash -c "
+        . '$nut/init' 2>/dev/null
+        . '$d/unit/lib/main.sh'
+        printf '%s' \"\${MARKER:-unset}\"" 2>&1)"
+    assert_ok grep -q 'reached' <<<"$out"
+    rm -rf "$d"
+}


### PR DESCRIPTION
A tool installed on PATH and run from any other directory could not resolve a single dependency: every `use dep::x` failed with "no nut.toml above" whatever the current directory happened to be. Found by running hulilupteri through its PATH symlink from a home directory.

`NUTSHELL_SCRIPT_DIR` is unset deliberately, because a process that sources init would otherwise inherit an ancestor's and resolve that ancestor's manifest as its own. That left the manifest search with only `PWD`, which is a fact about where the shell was started rather than about which unit is asking.

It anchors per call on the file that wrote the `use`, which is the same answer `super::` already uses and cannot inherit anything.