### PR TITLE
feat: write toml as well as read it

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Three namespaces, and they answer three different questions:
 | Written | Resolves to |
 |---|---|
 | `use log` | nutshell's own module |
-| `use shebang::diagnostics::findings` | a module in a library declared in `nut.toml` |
+| `use shebang::tui::term` | a module in a library declared in `nut.toml` |
 | `use super::mine` | `lib/mine.sh` in **this** unit, found from its `nut.toml` |
 
 `super::` is anchored on the manifest rather than on the running script, so a
@@ -389,7 +389,7 @@ ref = "main"
 and a module inside it is reached by namespacing the `use`:
 
 ```bash
-use shebang::diagnostics::findings
+use shebang::tui::term
 ```
 
 Declared in the manifest because a script that fetches its own dependencies

--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ use os log json http
 | `text` | Text processing (`text_grep`, `text_replace`, `text_count_matches`) |
 | `json` | JSON parsing (`json_get`, `json_set`, `json_valid`, `json_pretty`) |
 | `http` | HTTP requests (`http_get`, `http_post`, `http_download`) |
-| `toml` | TOML parsing (`toml_get`, `toml_get_or`, `toml_is_true`) |
+| `toml` | TOML reading (`toml_get`, `toml_get_or`, `toml_is_true`, `toml_array`) |
+| `toml::write` | Changing a TOML file in place (`toml_set`, `toml_unset`) |
+| `toml::json` | TOML as JSON (`toml_to_json`) |
 | `prompt` | User prompts (`prompt_confirm`, `prompt_input`, `prompt_select`) |
 | `color` | Terminal colors (`color_red`, `color_green`, `color_bold`) |
 | `validate` | Validation (`is_set`, `is_integer`, `require_command`) |
@@ -323,7 +325,7 @@ Three namespaces, and they answer three different questions:
 | Written | Resolves to |
 |---|---|
 | `use log` | nutshell's own module |
-| `use shebang::diagnostics/findings` | a module in a library declared in `nut.toml` |
+| `use shebang::diagnostics::findings` | a module in a library declared in `nut.toml` |
 | `use super::mine` | `lib/mine.sh` in **this** unit, found from its `nut.toml` |
 
 `super::` is anchored on the manifest rather than on the running script, so a
@@ -387,7 +389,7 @@ ref = "main"
 and a module inside it is reached by namespacing the `use`:
 
 ```bash
-use shebang::diagnostics/findings
+use shebang::diagnostics::findings
 ```
 
 Declared in the manifest because a script that fetches its own dependencies

--- a/bin/nutshell
+++ b/bin/nutshell
@@ -369,5 +369,10 @@ export NUTSHELL_SCRIPT NUTSHELL_SCRIPT_DIR
 
 # Sourced, not executed, so the script runs in this environment with `use`
 # already defined.
+#
+# By the absolute path, never by the bare name it was typed as: `source` with a
+# no-slash argument searches PATH first, so `nutshell test` in a directory
+# holding a script called `test` sourced `/bin/test` and reported that a binary
+# cannot be executed. The file the argument named was right there.
 # shellcheck source=/dev/null
-source "$_SCRIPT"
+source "$NUTSHELL_SCRIPT"

--- a/examples/checks/check_function_duplication.sh
+++ b/examples/checks/check_function_duplication.sh
@@ -196,6 +196,23 @@ compare_full_names() {
         count = NR
     }
     
+    # The part after the module prefix, which is where two functions in one
+    # family actually differ.
+    function tail_of(name,    t) {
+        t = name
+        if (substr(t, 1, 1) == "_") t = substr(t, 2)
+        if (index(t, "_") > 0) t = substr(t, index(t, "_") + 1)
+        return t
+    }
+
+    # Do two names share the word the module is called?
+    function same_prefix(a, b,    pa, pb) {
+        pa = (substr(a, 1, 1) == "_") ? substr(a, 2) : a
+        pb = (substr(b, 1, 1) == "_") ? substr(b, 2) : b
+        if (index(pa, "_") == 0 || index(pb, "_") == 0) return 0
+        return substr(pa, 1, index(pa, "_")) == substr(pb, 1, index(pb, "_"))
+    }
+
     END {
         # Compare each pair (only once, i < j)
         for (i = 1; i < count; i++) {
@@ -208,9 +225,23 @@ compare_full_names() {
                 
                 score = similarity(names[i], names[j])
                 
-                if (score >= threshold) {
-                    printf "MATCH|%.3f|%s|%s|%s|%s\n", score, names[i], names[j], files[i], files[j]
+                if (score < threshold) continue
+
+                # A module split across files keeps its prefix in every name,
+                # and a long shared prefix carries the score on its own:
+                # `toml_get` and `toml_set` come out at 0.875 while naming two
+                # opposite operations. So a match that survives only because of
+                # the prefix is an artefact of the naming convention, not a
+                # copy. What the two names do has to look alike as well.
+                if (same_prefix(names[i], names[j])) {
+                    t1 = tail_of(names[i]); t2 = tail_of(names[j])
+                    if (length(t1) > 0 && length(t2) > 0) {
+                        if (!can_meet_threshold(t1, t2, threshold)) continue
+                        if (similarity(t1, t2) < threshold) continue
+                    }
                 }
+
+                printf "MATCH|%.3f|%s|%s|%s|%s\n", score, names[i], names[j], files[i], files[j]
             }
         }
     }
@@ -481,5 +512,9 @@ main() {
 # script, which is what makes `use` available from its first line. So `$0` is
 # the interpreter and `BASH_SOURCE[0]` is this file, and `main` was never
 # called. Six of the eight built-in checks exited 0 having done nothing, and
-# `./check` read that as a pass and printed one.
-main "$@"
+# `./check` read that as a pass and printed one.#
+# `NUT_CHECK_LOAD_ONLY` is the one way in for a test that wants the comparison
+# without a scan of the whole repository. It is an explicit opt-out rather than
+# a guess about how the file was loaded, which is the distinction the paragraph
+# above is about.
+[[ -n "${NUT_CHECK_LOAD_ONLY:-}" ]] || main "$@"

--- a/examples/checks/check_function_duplication.sh
+++ b/examples/checks/check_function_duplication.sh
@@ -512,7 +512,8 @@ main() {
 # script, which is what makes `use` available from its first line. So `$0` is
 # the interpreter and `BASH_SOURCE[0]` is this file, and `main` was never
 # called. Six of the eight built-in checks exited 0 having done nothing, and
-# `./check` read that as a pass and printed one.#
+# `./check` read that as a pass and printed one.
+#
 # `NUT_CHECK_LOAD_ONLY` is the one way in for a test that wants the comparison
 # without a scan of the whole repository. It is an explicit opt-out rather than
 # a guess about how the file was loaded, which is the distinction the paragraph

--- a/lib.nut
+++ b/lib.nut
@@ -36,5 +36,7 @@ text::impl::perl_match   lib/text/impl/perl_match.sh  internal
 text::impl::perl_replace lib/text/impl/perl_replace.sh internal
 text::impl::sed_replace  lib/text/impl/sed_replace.sh internal
 toml                     lib/toml.sh
+toml::json               lib/toml/json.sh
+toml::write              lib/toml/write.sh
 validate                 lib/validate.sh
 xdg                      lib/xdg.sh

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -89,7 +89,17 @@ _toml_clean_line() {
     for (( i = 0; i < ${#line}; i++ )); do
         char="${line:i:1}"
         if [[ "$in_quotes" -eq 1 ]]; then
-            [[ "$char" == "$quote" ]] && in_quotes=0
+            # An escaped quote inside a basic string does not close it. Read as
+            # a terminator, the rest of the value falls outside the string and
+            # a `#` in it truncates the line. TOML gives a literal string no
+            # escapes at all, so the backslash only counts inside `"`.
+            if [[ "$char" == "\\" && "$quote" == '"' && $(( i + 1 )) -lt ${#line} ]]; then
+                out+="$char"
+                i=$(( i + 1 ))
+                char="${line:i:1}"
+            elif [[ "$char" == "$quote" ]]; then
+                in_quotes=0
+            fi
         elif [[ "$char" == '"' || "$char" == "'" ]]; then
             in_quotes=1
             quote="$char"
@@ -102,6 +112,57 @@ _toml_clean_line() {
     str_trim "$out"
 }
 
+# Decode the escapes a TOML basic string is allowed to carry.
+#
+# Only a basic string has them: a literal string is taken as typed, which is
+# the whole difference between the two forms. Without this a value written
+# with an escaped quote or a backslash reads back with the backslashes still
+# in it, so a path or a piece of prose does not survive a write and a read.
+_toml_unescape() {
+    local s="$1"
+    # Nothing to do, and this is on the path of every value in every file.
+    if [[ "$s" != *\\* ]]; then
+        printf '%s' "$s"
+        return 0
+    fi
+
+    local out="" i char next
+    for (( i = 0; i < ${#s}; i++ )); do
+        char="${s:i:1}"
+        if [[ "$char" != "\\" || $(( i + 1 )) -ge ${#s} ]]; then
+            out+="$char"
+            continue
+        fi
+        next="${s:i+1:1}"
+        i=$(( i + 1 ))
+        case "$next" in
+            n)  out+=$'\n' ;;
+            t)  out+=$'\t' ;;
+            r)  out+=$'\r' ;;
+            b)  out+=$'\b' ;;
+            f)  out+=$'\f' ;;
+            '"') out+='"' ;;
+            "\\") out+="\\" ;;
+            u|U)
+                # \uXXXX and \UXXXXXXXX. printf knows the escape; anything
+                # that is not the right number of hex digits is not one, and
+                # is kept as typed rather than silently eaten.
+                local n=4; [[ "$next" == "U" ]] && n=8
+                local hex="${s:i+1:n}"
+                if [[ "${#hex}" -eq "$n" && "$hex" =~ ^[0-9A-Fa-f]+$ ]]; then
+                    # shellcheck disable=SC2059
+                    out+="$(printf "\\$next$hex")"
+                    i=$(( i + n ))
+                else
+                    out+="\\$next"
+                fi
+                ;;
+            *)  out+="\\$next" ;;
+        esac
+    done
+    printf '%s' "$out"
+}
+
 # Extract value, handling quotes
 _toml_extract_value() {
     local raw="$1"
@@ -109,7 +170,8 @@ _toml_extract_value() {
     
     # Double-quoted string
     if [[ "$raw" =~ ^\"(.*)\"$ ]]; then
-        echo "${BASH_REMATCH[1]}"
+        _toml_unescape "${BASH_REMATCH[1]}"
+        printf '\n'
         return 0
     fi
     
@@ -556,165 +618,6 @@ toml_is_true() {
     value="$(toml_get "$file" "$key")" || return 1
     
     is_truthy "$value"
-}
-
-#[pub]
-# Convert a TOML file to JSON
-# Usage: toml_to_json "file.toml" -> prints JSON
-toml_to_json() {
-    local file="${1:-}"
-    [[ ! -f "$file" ]] && return 1
-    
-    local json="{"
-    local need_comma=0
-    local current_section=""
-    local section_stack=()
-    local line clean_line
-    
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        _toml_clean_into clean_line "$line"
-        [[ -z "$clean_line" ]] && continue
-        
-        # Section header [section] or [section.subsection]
-        if [[ "$clean_line" =~ ^\[([^\]]+)\]$ ]]; then
-            local new_section="${BASH_REMATCH[1]}"
-            
-            # Close previous section(s) if any
-            while [[ ${#section_stack[@]} -gt 0 ]]; do
-                json+="}"
-                unset 'section_stack[-1]'
-            done
-            
-            # Start new section(s)
-            IFS='.' read -ra parts <<< "$new_section"
-            for part in "${parts[@]}"; do
-                [[ $need_comma -eq 1 ]] && json+=","
-                need_comma=0
-                json+="\"${part}\":{"
-                section_stack+=("$part")
-            done
-            
-            current_section="$new_section"
-            continue
-        fi
-        
-        # Key = value
-        if [[ "$clean_line" =~ ^([^=]+)=(.*)$ ]]; then
-            local key val
-            key="$(str_trim "${BASH_REMATCH[1]}")"
-            val="$(str_trim "${BASH_REMATCH[2]}")"
-            
-            [[ $need_comma -eq 1 ]] && json+=","
-            need_comma=1
-            
-            json+="\"${key}\":"
-            json+="$(_toml_value_to_json "$val")"
-        fi
-    done < "$file"
-    
-    # Close any open sections
-    while [[ ${#section_stack[@]} -gt 0 ]]; do
-        json+="}"
-        unset 'section_stack[-1]'
-    done
-    
-    json+="}"
-    echo "$json"
-}
-
-# Internal: Convert a TOML value to JSON
-_toml_value_to_json() {
-    local val="$1"
-    
-    # Boolean
-    if [[ "$val" == "true" ]]; then
-        echo "true"
-        return
-    fi
-    if [[ "$val" == "false" ]]; then
-        echo "false"
-        return
-    fi
-    
-    # Integer
-    if [[ "$val" =~ ^-?[0-9]+$ ]]; then
-        echo "$val"
-        return
-    fi
-    
-    # Float
-    if [[ "$val" =~ ^-?[0-9]+\.[0-9]+$ ]]; then
-        echo "$val"
-        return
-    fi
-    
-    # Array
-    if [[ "$val" =~ ^\[.*\]$ ]]; then
-        local content="${val#[}"
-        content="${content%]}"
-        content="$(str_trim "$content")"
-        
-        local json_arr="["
-        local first=1
-        local in_quotes=0
-        local item=""
-        local i char
-        
-        for ((i=0; i<${#content}; i++)); do
-            char="${content:$i:1}"
-            
-            if [[ "$char" == '"' ]]; then
-                ((in_quotes = 1 - in_quotes))
-                item+="$char"
-            elif [[ "$char" == ',' && $in_quotes -eq 0 ]]; then
-                item="$(str_trim "$item")"
-                if [[ -n "$item" ]]; then
-                    [[ $first -eq 0 ]] && json_arr+=","
-                    first=0
-                    json_arr+="$(_toml_value_to_json "$item")"
-                fi
-                item=""
-            else
-                item+="$char"
-            fi
-        done
-        
-        # Last item
-        item="$(str_trim "$item")"
-        if [[ -n "$item" ]]; then
-            [[ $first -eq 0 ]] && json_arr+=","
-            json_arr+="$(_toml_value_to_json "$item")"
-        fi
-        
-        json_arr+="]"
-        echo "$json_arr"
-        return
-    fi
-    
-    # Double-quoted string
-    if [[ "$val" =~ ^\"(.*)\"$ ]]; then
-        # Already quoted, just pass through (escape inner quotes if needed)
-        local inner="${BASH_REMATCH[1]}"
-        # Escape backslashes and quotes for JSON
-        inner="${inner//\\/\\\\}"
-        inner="${inner//\"/\\\"}"
-        echo "\"${inner}\""
-        return
-    fi
-    
-    # Single-quoted string (literal in TOML)
-    if [[ "$val" =~ ^\'(.*)\'$ ]]; then
-        local inner="${BASH_REMATCH[1]}"
-        inner="${inner//\\/\\\\}"
-        inner="${inner//\"/\\\"}"
-        echo "\"${inner}\""
-        return
-    fi
-    
-    # Unquoted - treat as string
-    val="${val//\\/\\\\}"
-    val="${val//\"/\\\"}"
-    echo "\"${val}\""
 }
 
 #[pub]

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -66,7 +66,18 @@ _toml_clean_into() {
     for (( __toml_i = 0; __toml_i < ${#__toml_line}; __toml_i++ )); do
         __toml_c="${__toml_line:__toml_i:1}"
         if [[ $__toml_q -eq 1 ]]; then
-            [[ "$__toml_c" == "$__toml_qc" ]] && __toml_q=0
+            # The same escaped-quote rule as `_toml_clean_line`. It was fixed
+            # there and not here, and this is the copy on the hot path: every
+            # read of a value, every section listing and the JSON conversion go
+            # through it, so the truncation stayed for all of them.
+            if [[ "$__toml_c" == "\\" && "$__toml_qc" == '"' \
+                  && $(( __toml_i + 1 )) -lt ${#__toml_line} ]]; then
+                __toml_acc+="$__toml_c"
+                __toml_i=$(( __toml_i + 1 ))
+                __toml_c="${__toml_line:__toml_i:1}"
+            elif [[ "$__toml_c" == "$__toml_qc" ]]; then
+                __toml_q=0
+            fi
         elif [[ "$__toml_c" == '"' || "$__toml_c" == "'" ]]; then
             __toml_q=1; __toml_qc="$__toml_c"
         elif [[ "$__toml_c" == "#" ]]; then

--- a/lib/toml/json.sh
+++ b/lib/toml/json.sh
@@ -27,6 +27,13 @@ use super::toml
 # when `[a]` is already behind it, cannot be converted in one pass without
 # building the whole tree first, so it is refused by name rather than converted
 # into an object with a repeated key.
+#
+# That refusal covers the reopened section and nothing else. This is a one-pass
+# reader, not a validator: a key repeated inside one section comes out as a
+# repeated key, an integer with a leading zero comes out as written, and an
+# array holding a comma inside a quoted element or another array is split on
+# the wrong comma. A file that has been through `toml_get` without complaint is
+# the input this is for.
 # Usage: toml_to_json "file.toml" -> prints JSON, fails on a reopened section
 toml_to_json() {
     local file="${1:-}"
@@ -79,7 +86,7 @@ toml_to_json() {
                 done
                 seen+=("$path")
                 [[ $need_comma -eq 1 ]] && json+=","
-                json+="\"${p}\":{"
+                json+="$(_json_string "$p"):{"
                 need_comma=0
                 stack+=("$p")
             done
@@ -95,7 +102,10 @@ toml_to_json() {
             [[ $need_comma -eq 1 ]] && json+=","
             need_comma=1
 
-            json+="\"${key}\":"
+            # Through the string writer, because a key is a string: a quoted
+            # key, or one with a quote in it, went in raw and the document was
+            # not JSON at all.
+            json+="$(_json_string "$key"):"
             json+="$(_toml_value_to_json "$val")"
         fi
     done < "$file"

--- a/lib/toml/json.sh
+++ b/lib/toml/json.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/toml/json.sh - TOML as JSON
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# Converting to another format is a job of its own, and it is the only part of
+# the toml module that has to know what JSON looks like.
+# =============================================================================
+
+nut_once || return 0
+
+use super::toml
+
+
+#[pub]
+# Convert a TOML file to JSON.
+#
+# Sections nest the way TOML says they do: `[a.b]` after `[a]` is `b` inside
+# `a`, not a second `a` beside it. That second `a` was what this produced, and
+# a JSON object with the same key twice loses whichever half the reader's
+# parser discards.
+#
+# Sections are read in file order and a closed one is not reopened. A file that
+# leaves a section and comes back to it, or that writes `[b]` before `[a.c]`
+# when `[a]` is already behind it, cannot be converted in one pass without
+# building the whole tree first, so it is refused by name rather than converted
+# into an object with a repeated key.
+# Usage: toml_to_json "file.toml" -> prints JSON, fails on a reopened section
+toml_to_json() {
+    local file="${1:-}"
+    [[ ! -f "$file" ]] && return 1
+
+    local json="{"
+    local need_comma=0
+    local line clean_line
+    local -a stack=()
+    local -a seen=()
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        _toml_clean_into clean_line "$line"
+        [[ -z "$clean_line" ]] && continue
+
+        # Section header [section] or [section.subsection]
+        if [[ "$clean_line" =~ ^\[([^\]]+)\]$ ]]; then
+            local new_section="${BASH_REMATCH[1]}"
+            local -a parts=()
+            IFS='.' read -ra parts <<< "$new_section"
+
+            # How much of the path we are already inside. Only what differs
+            # gets closed, so a child section stays within its parent.
+            local common=0
+            while (( common < ${#stack[@]} && common < ${#parts[@]} )) \
+                  && [[ "${stack[$common]}" == "${parts[$common]}" ]]; do
+                common=$(( common + 1 ))
+            done
+
+            local i
+            for (( i = ${#stack[@]}; i > common; i-- )); do
+                json+="}"
+                unset 'stack[-1]'
+                need_comma=1
+            done
+
+            local path="" p
+            for (( i = 0; i < common; i++ )); do
+                path+="${path:+.}${stack[$i]}"
+            done
+            for (( i = common; i < ${#parts[@]}; i++ )); do
+                p="${parts[$i]}"
+                path+="${path:+.}${p}"
+                for prev in ${seen[@]+"${seen[@]}"}; do
+                    if [[ "$prev" == "$path" ]]; then
+                        printf 'toml_to_json: %s: section [%s] comes back to a part of the file already written\n' \
+                            "$file" "$new_section" >&2
+                        return 1
+                    fi
+                done
+                seen+=("$path")
+                [[ $need_comma -eq 1 ]] && json+=","
+                json+="\"${p}\":{"
+                need_comma=0
+                stack+=("$p")
+            done
+            continue
+        fi
+
+        # Key = value
+        if [[ "$clean_line" =~ ^([^=]+)=(.*)$ ]]; then
+            local key val
+            key="$(str_trim "${BASH_REMATCH[1]}")"
+            val="$(str_trim "${BASH_REMATCH[2]}")"
+
+            [[ $need_comma -eq 1 ]] && json+=","
+            need_comma=1
+
+            json+="\"${key}\":"
+            json+="$(_toml_value_to_json "$val")"
+        fi
+    done < "$file"
+
+    local i
+    for (( i = ${#stack[@]}; i > 0; i-- )); do
+        json+="}"
+    done
+
+    json+="}"
+    echo "$json"
+}
+
+# Internal: a string as JSON writes it, quotes included.
+#
+# JSON has its own escapes and they are not TOML's. A tab is a real tab by the
+# time it gets here and JSON will not take one raw inside a string.
+_json_string() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '"%s"' "$s"
+}
+
+# Internal: Convert a TOML value to JSON
+_toml_value_to_json() {
+    local val="$1"
+    
+    # Boolean
+    if [[ "$val" == "true" ]]; then
+        echo "true"
+        return
+    fi
+    if [[ "$val" == "false" ]]; then
+        echo "false"
+        return
+    fi
+    
+    # Integer
+    if [[ "$val" =~ ^-?[0-9]+$ ]]; then
+        echo "$val"
+        return
+    fi
+    
+    # Float
+    if [[ "$val" =~ ^-?[0-9]+\.[0-9]+$ ]]; then
+        echo "$val"
+        return
+    fi
+    
+    # Array
+    if [[ "$val" =~ ^\[.*\]$ ]]; then
+        local content="${val#[}"
+        content="${content%]}"
+        content="$(str_trim "$content")"
+        
+        local json_arr="["
+        local first=1
+        local in_quotes=0
+        local item=""
+        local i char
+        
+        for ((i=0; i<${#content}; i++)); do
+            char="${content:$i:1}"
+            
+            if [[ "$char" == '"' ]]; then
+                ((in_quotes = 1 - in_quotes))
+                item+="$char"
+            elif [[ "$char" == ',' && $in_quotes -eq 0 ]]; then
+                item="$(str_trim "$item")"
+                if [[ -n "$item" ]]; then
+                    [[ $first -eq 0 ]] && json_arr+=","
+                    first=0
+                    json_arr+="$(_toml_value_to_json "$item")"
+                fi
+                item=""
+            else
+                item+="$char"
+            fi
+        done
+        
+        # Last item
+        item="$(str_trim "$item")"
+        if [[ -n "$item" ]]; then
+            [[ $first -eq 0 ]] && json_arr+=","
+            json_arr+="$(_toml_value_to_json "$item")"
+        fi
+        
+        json_arr+="]"
+        echo "$json_arr"
+        return
+    fi
+    
+    # Basic string. Its TOML escapes are decoded first: escaping the raw text
+    # again wrote `\"` as `\\\"`, so a value with a quote or a backslash in it
+    # came out of the conversion with the backslashes doubled.
+    if [[ "$val" =~ ^\"(.*)\"$ ]]; then
+        _json_string "$(_toml_unescape "${BASH_REMATCH[1]}")"
+        printf '\n'
+        return
+    fi
+    
+    # Literal string, which has no escapes to decode.
+    if [[ "$val" =~ ^\'(.*)\'$ ]]; then
+        _json_string "${BASH_REMATCH[1]}"
+        printf '\n'
+        return
+    fi
+    
+    # Unquoted - treat as string
+    _json_string "$val"
+    printf '\n'
+}

--- a/lib/toml/json.sh
+++ b/lib/toml/json.sh
@@ -28,13 +28,18 @@ use super::toml
 # building the whole tree first, so it is refused by name rather than converted
 # into an object with a repeated key.
 #
-# That refusal covers the reopened section and nothing else. This is a one-pass
-# reader, not a validator: a key repeated inside one section comes out as a
-# repeated key, an integer with a leading zero comes out as written, and an
-# array holding a comma inside a quoted element or another array is split on
-# the wrong comma. A file that has been through `toml_get` without complaint is
-# the input this is for.
-# Usage: toml_to_json "file.toml" -> prints JSON, fails on a reopened section
+# A quoted key or section name is refused the same way. Nothing else in this
+# library supports one: `toml_keys` leaves it out, `toml_section_pairs` hands it
+# back with its quotes still on, and `toml_get` cannot address it. Converting it
+# anyway produced valid JSON naming a key that is not the key, and a quoted
+# section holding a dot came out as two nested objects for a section with one
+# level. Wrong and quiet is worse than refused.
+#
+# Beyond those two, this is a one-pass reader and not a validator: a key
+# repeated inside one section comes out repeated, an integer with a leading zero
+# comes out as written, and an array holding a comma inside a quoted element or
+# another array is split on the wrong comma.
+# Usage: toml_to_json "file.toml" -> prints JSON, fails on a key it cannot name
 toml_to_json() {
     local file="${1:-}"
     [[ ! -f "$file" ]] && return 1
@@ -52,6 +57,11 @@ toml_to_json() {
         # Section header [section] or [section.subsection]
         if [[ "$clean_line" =~ ^\[([^\]]+)\]$ ]]; then
             local new_section="${BASH_REMATCH[1]}"
+            if [[ "$new_section" == \"* || "$new_section" == \'* ]]; then
+                printf 'toml_to_json: %s: [%s] is a quoted section name, which nothing here can address\n' \
+                    "$file" "$new_section" >&2
+                return 1
+            fi
             local -a parts=()
             IFS='.' read -ra parts <<< "$new_section"
 
@@ -98,6 +108,12 @@ toml_to_json() {
             local key val
             key="$(str_trim "${BASH_REMATCH[1]}")"
             val="$(str_trim "${BASH_REMATCH[2]}")"
+
+            if [[ "$key" == \"* || "$key" == \'* ]]; then
+                printf 'toml_to_json: %s: %s is a quoted key, which nothing here can address\n' \
+                    "$file" "$key" >&2
+                return 1
+            fi
 
             [[ $need_comma -eq 1 ]] && json+=","
             need_comma=1

--- a/lib/toml/write.sh
+++ b/lib/toml/write.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/toml/write.sh - Changing a TOML file without rewriting it
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# Reading TOML and editing TOML are different jobs and they live apart. The
+# reader parses; this one leaves the file alone except for the line it came
+# for.
+# =============================================================================
+
+nut_once || return 0
+
+#[pub]
+# Write a value, leaving the rest of the file as it was.
+#
+# Editing a config file is not the same as generating one. A person wrote the
+# comments in it, chose the order, put a blank line where they wanted a pause,
+# and a setter that rewrites the file from a parsed model throws all of that
+# away the first time anything saves. So: find the line, change the line, and
+# touch nothing else.
+#
+# A key in a section that does not exist yet gets the section appended. A key
+# that is not there gets appended inside its section, after the last line that
+# belongs to it, rather than at the end of the file where it would land in
+# somebody else's section.
+#
+# Usage: toml_set "file.toml" "section.key" "value"
+toml_set() {
+    local file="$1" key="$2" value="$3"
+    [[ -n "$file" && -n "$key" ]] || return 1
+
+    local section="" leaf="$key"
+    if [[ "$key" == *.* ]]; then
+        section="${key%.*}"; leaf="${key##*.}"
+    fi
+
+    # Written as TOML: a value that looks like a number or a bool goes in bare,
+    # anything else is quoted, and a quoted value has its quotes and
+    # backslashes escaped. Without that, a path with a backslash or a string
+    # with a quote in it writes a file that no longer parses.
+    local written
+    if [[ "$value" =~ ^-?[0-9]+$ ]] || [[ "$value" =~ ^-?[0-9]+\.[0-9]+$ ]] \
+       || [[ "$value" == "true" || "$value" == "false" ]] \
+       || [[ "$value" == \[*\] ]]; then
+        written="$value"
+    else
+        local esc="${value//\\/\\\\}"
+        esc="${esc//\"/\\\"}"
+        written="\"${esc}\""
+    fi
+
+    [[ -f "$file" ]] || { printf '' > "$file" 2>/dev/null || return 1; }
+
+    local tmp; tmp="$(mktemp)" || return 1
+    local in_section=0 done_it=0 last_in_section=0 line n=0 seen_section=0
+
+    # One pass to find where the section ends, so an appended key lands inside
+    # it rather than at the end of the file.
+    if [[ -n "$section" ]]; then
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            n=$(( n + 1 ))
+            if [[ "$line" =~ ^[[:space:]]*\[(.+)\][[:space:]]*$ ]]; then
+                if [[ "${BASH_REMATCH[1]}" == "$section" ]]; then
+                    in_section=1; seen_section=1; last_in_section="$n"
+                else
+                    in_section=0
+                fi
+                continue
+            fi
+            (( in_section == 1 )) && [[ -n "${line// }" ]] && last_in_section="$n"
+        done < "$file"
+    fi
+
+    in_section=0; n=0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        n=$(( n + 1 ))
+        if [[ "$line" =~ ^[[:space:]]*\[(.+)\][[:space:]]*$ ]]; then
+            in_section=0
+            [[ "${BASH_REMATCH[1]}" == "$section" ]] && in_section=1
+            printf '%s\n' "$line" >> "$tmp"
+            continue
+        fi
+
+        # The key itself, in the right section, replaced in place so its
+        # comment and its neighbours survive.
+        if (( done_it == 0 )) \
+           && { [[ -z "$section" && "$in_section" == 0 ]] || (( in_section == 1 )); } \
+           && [[ "$line" =~ ^[[:space:]]*"$leaf"[[:space:]]*= ]]; then
+            printf '%s = %s\n' "$leaf" "$written" >> "$tmp"
+            done_it=1
+            continue
+        fi
+
+        printf '%s\n' "$line" >> "$tmp"
+
+        # Not there, but its section is: append where the section ends.
+        if (( done_it == 0 )) && [[ -n "$section" ]] && (( n == last_in_section )); then
+            printf '%s = %s\n' "$leaf" "$written" >> "$tmp"
+            done_it=1
+        fi
+    done < "$file"
+
+    if (( done_it == 0 )); then
+        if [[ -n "$section" ]] && (( seen_section == 0 )); then
+            [[ -s "$tmp" ]] && printf '\n' >> "$tmp"
+            printf '[%s]\n' "$section" >> "$tmp"
+        fi
+        printf '%s = %s\n' "$leaf" "$written" >> "$tmp"
+    fi
+
+    # Renamed into place, so a reader never sees a half-written file and a
+    # crash partway leaves the original intact.
+    mv -f "$tmp" "$file" || { rm -f "$tmp"; return 1; }
+    return 0
+}
+
+#[pub]
+# Remove a key, leaving everything else alone.
+# Usage: toml_unset "file.toml" "section.key"
+toml_unset() {
+    local file="$1" key="$2"
+    [[ -f "$file" && -n "$key" ]] || return 1
+
+    local section="" leaf="$key"
+    if [[ "$key" == *.* ]]; then section="${key%.*}"; leaf="${key##*.}"; fi
+
+    local tmp; tmp="$(mktemp)" || return 1
+    local in_section=0 line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        if [[ "$line" =~ ^[[:space:]]*\[(.+)\][[:space:]]*$ ]]; then
+            in_section=0
+            [[ "${BASH_REMATCH[1]}" == "$section" ]] && in_section=1
+            printf '%s\n' "$line" >> "$tmp"; continue
+        fi
+        if { [[ -z "$section" && "$in_section" == 0 ]] || (( in_section == 1 )); } \
+           && [[ "$line" =~ ^[[:space:]]*"$leaf"[[:space:]]*= ]]; then
+            continue
+        fi
+        printf '%s\n' "$line" >> "$tmp"
+    done < "$file"
+
+    mv -f "$tmp" "$file" || { rm -f "$tmp"; return 1; }
+    return 0
+}

--- a/lib/toml/write.sh
+++ b/lib/toml/write.sh
@@ -21,10 +21,11 @@ nut_once || return 0
 # away the first time anything saves. So: find the line, change the line, and
 # touch nothing else.
 #
-# A key in a section that does not exist yet gets the section appended. A key
-# that is not there gets appended inside its section, after the last line that
+# A key with no section is a key before the first `[header]`, and only there. A
+# key in a section that does not exist yet gets the section appended. A key that
+# is not there gets appended inside its own section, after the last line that
 # belongs to it, rather than at the end of the file where it would land in
-# somebody else's section.
+# somebody else's.
 #
 # Usage: toml_set "file.toml" "section.key" "value"
 toml_set() {
@@ -36,28 +37,21 @@ toml_set() {
         section="${key%.*}"; leaf="${key##*.}"
     fi
 
-    # Written as TOML: a value that looks like a number or a bool goes in bare,
-    # anything else is quoted, and a quoted value has its quotes and
-    # backslashes escaped. Without that, a path with a backslash or a string
-    # with a quote in it writes a file that no longer parses.
-    local written
-    if [[ "$value" =~ ^-?[0-9]+$ ]] || [[ "$value" =~ ^-?[0-9]+\.[0-9]+$ ]] \
-       || [[ "$value" == "true" || "$value" == "false" ]] \
-       || [[ "$value" == \[*\] ]]; then
-        written="$value"
-    else
-        local esc="${value//\\/\\\\}"
-        esc="${esc//\"/\\\"}"
-        written="\"${esc}\""
-    fi
+    local written; written="$(_toml_write_value "$value")"
 
     [[ -f "$file" ]] || { printf '' > "$file" 2>/dev/null || return 1; }
 
     local tmp; tmp="$(mktemp)" || return 1
     local in_section=0 done_it=0 last_in_section=0 line n=0 seen_section=0
 
-    # One pass to find where the section ends, so an appended key lands inside
-    # it rather than at the end of the file.
+    # One pass to find where the key's own part of the file ends, so an appended
+    # key lands inside it rather than at the end of the file. A section with
+    # nothing in it ends at its own header, which is why the header line counts.
+    #
+    # Root is a part of the file like any other: it runs from the first line to
+    # the line before the first header. `last_in_section` of 0 means it is empty,
+    # which for root means the file opens with a header and the new key goes
+    # above it.
     if [[ -n "$section" ]]; then
         while IFS= read -r line || [[ -n "$line" ]]; do
             n=$(( n + 1 ))
@@ -71,22 +65,48 @@ toml_set() {
             fi
             (( in_section == 1 )) && [[ -n "${line// }" ]] && last_in_section="$n"
         done < "$file"
+    else
+        seen_section=1
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            n=$(( n + 1 ))
+            [[ "$line" =~ ^[[:space:]]*\[(.+)\][[:space:]]*$ ]] && break
+            [[ -n "${line// }" ]] && last_in_section="$n"
+        done < "$file"
     fi
 
+    # Root is a place, not the absence of one: everything before the first
+    # header. Reading it as "no section is open" made a root key match the first
+    # section that happened to have a key by that name, so `toml_set f name x`
+    # rewrote `[a] name` and `toml_get f name` then found nothing.
+    local at_root=1
     in_section=0; n=0
+
+    # The file opens with a header and the key belongs above it.
+    if (( done_it == 0 )) && [[ -z "$section" ]] && (( last_in_section == 0 )); then
+        printf '%s = %s\n' "$leaf" "$written" >> "$tmp"
+        done_it=1
+    fi
+
     while IFS= read -r line || [[ -n "$line" ]]; do
         n=$(( n + 1 ))
         if [[ "$line" =~ ^[[:space:]]*\[(.+)\][[:space:]]*$ ]]; then
+            at_root=0
             in_section=0
             [[ "${BASH_REMATCH[1]}" == "$section" ]] && in_section=1
             printf '%s\n' "$line" >> "$tmp"
+            # An empty section ends at its header, so the append has to be
+            # possible here too.
+            if (( done_it == 0 )) && [[ -n "$section" ]] && (( n == last_in_section )); then
+                printf '%s = %s\n' "$leaf" "$written" >> "$tmp"
+                done_it=1
+            fi
             continue
         fi
 
-        # The key itself, in the right section, replaced in place so its
-        # comment and its neighbours survive.
+        # The key itself, in the right place, replaced so its comment and its
+        # neighbours survive.
         if (( done_it == 0 )) \
-           && { [[ -z "$section" && "$in_section" == 0 ]] || (( in_section == 1 )); } \
+           && { [[ -z "$section" ]] && (( at_root == 1 )) || (( in_section == 1 )); } \
            && [[ "$line" =~ ^[[:space:]]*"$leaf"[[:space:]]*= ]]; then
             printf '%s = %s\n' "$leaf" "$written" >> "$tmp"
             done_it=1
@@ -95,8 +115,8 @@ toml_set() {
 
         printf '%s\n' "$line" >> "$tmp"
 
-        # Not there, but its section is: append where the section ends.
-        if (( done_it == 0 )) && [[ -n "$section" ]] && (( n == last_in_section )); then
+        # Not there, but its part of the file is: append where that part ends.
+        if (( done_it == 0 )) && (( n == last_in_section )); then
             printf '%s = %s\n' "$leaf" "$written" >> "$tmp"
             done_it=1
         fi
@@ -116,8 +136,36 @@ toml_set() {
     return 0
 }
 
+# A value as TOML writes it.
+#
+# A number, a bool and an array go in bare; everything else is a basic string,
+# and a basic string carries escapes. The five the reader decodes are the five
+# encoded here: without them a value with a newline in it wrote a file that no
+# longer parses at all, which loses every other key in it rather than the one
+# being written.
+_toml_write_value() {
+    local value="$1"
+    if [[ "$value" =~ ^-?[0-9]+$ ]] || [[ "$value" =~ ^-?[0-9]+\.[0-9]+$ ]] \
+       || [[ "$value" == "true" || "$value" == "false" ]] \
+       || [[ "$value" == \[*\] ]]; then
+        printf '%s' "$value"
+        return 0
+    fi
+    local esc="${value//\\/\\\\}"
+    esc="${esc//\"/\\\"}"
+    esc="${esc//$'\n'/\\n}"
+    esc="${esc//$'\r'/\\r}"
+    esc="${esc//$'\t'/\\t}"
+    esc="${esc//$'\b'/\\b}"
+    esc="${esc//$'\f'/\\f}"
+    printf '"%s"' "$esc"
+}
+
 #[pub]
 # Remove a key, leaving everything else alone.
+#
+# A key with no section means one before the first `[header]`. Reading that as
+# "no section is open" deleted the key from every section in the file.
 # Usage: toml_unset "file.toml" "section.key"
 toml_unset() {
     local file="$1" key="$2"
@@ -127,14 +175,15 @@ toml_unset() {
     if [[ "$key" == *.* ]]; then section="${key%.*}"; leaf="${key##*.}"; fi
 
     local tmp; tmp="$(mktemp)" || return 1
-    local in_section=0 line
+    local in_section=0 at_root=1 line
     while IFS= read -r line || [[ -n "$line" ]]; do
         if [[ "$line" =~ ^[[:space:]]*\[(.+)\][[:space:]]*$ ]]; then
+            at_root=0
             in_section=0
             [[ "${BASH_REMATCH[1]}" == "$section" ]] && in_section=1
             printf '%s\n' "$line" >> "$tmp"; continue
         fi
-        if { [[ -z "$section" && "$in_section" == 0 ]] || (( in_section == 1 )); } \
+        if { [[ -z "$section" ]] && (( at_root == 1 )) || (( in_section == 1 )); } \
            && [[ "$line" =~ ^[[:space:]]*"$leaf"[[:space:]]*= ]]; then
             continue
         fi

--- a/tests/check_duplication_test.sh
+++ b/tests/check_duplication_test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Tests for the cross-file duplicate-name comparison.
+#
+# The check compares function names across files, so a module split into two
+# files trips it on the shared prefix alone: `toml_get` and `toml_set` score
+# 0.875 while naming opposite operations. What is asserted here is that the
+# prefix no longer carries a match on its own, and, more importantly, that the
+# check can still catch the copy it exists for.
+
+use test
+
+NUT_CHECK_LOAD_ONLY=1 . "${BASH_SOURCE[0]%/*}/../examples/checks/check_function_duplication.sh"
+
+# The comparison takes "name|file" lines and prints a MATCH line per pair.
+_pairs() { compare_full_names "$1" "0.85"; }
+
+#[test]
+it_catches_the_same_function_copied_into_another_file() {
+    # The positive control. Without it every result below is a claim about a
+    # comparison that might match nothing at all.
+    local out; out="$(_pairs "$(printf 'parse_the_line|a.sh\nparse_the_lines|b.sh\n')")"
+    assert_contains "$out" "MATCH"
+    assert_contains "$out" "parse_the_line"
+}
+
+#[test]
+it_does_not_call_a_getter_and_a_setter_a_duplicate() {
+    local out; out="$(_pairs "$(printf 'toml_get|lib/toml.sh\ntoml_set|lib/toml/write.sh\n')")"
+    assert_empty "$out"
+}
+
+#[test]
+it_does_not_call_two_more_operations_of_one_module_duplicates() {
+    local out; out="$(_pairs "$(printf 'huli_run|a.sh\nhuli_add|b.sh\n')")"
+    assert_empty "$out"
+}
+
+#[test]
+it_still_catches_a_copy_that_shares_the_module_prefix() {
+    # The guard is about the prefix carrying a match on its own. Two names in
+    # one family whose own halves also look alike are still a copy.
+    local out; out="$(_pairs "$(printf 'toml_read_value|a.sh\ntoml_read_values|b.sh\n')")"
+    assert_contains "$out" "MATCH"
+}
+
+#[test]
+it_ignores_a_pair_that_lives_in_one_file() {
+    # A getter and a setter side by side are the ordinary way to write a
+    # module, and the check has never been about that.
+    local out; out="$(_pairs "$(printf 'json_get|lib/json.sh\njson_set|lib/json.sh\n')")"
+    assert_empty "$out"
+}
+
+#[test]
+it_ignores_names_that_do_not_look_alike() {
+    local out; out="$(_pairs "$(printf 'toml_get|a.sh\nfs_mkdir|b.sh\n')")"
+    assert_empty "$out"
+}
+
+#[test]
+it_matches_the_identical_name_in_two_files() {
+    local out; out="$(_pairs "$(printf 'do_the_thing|a.sh\ndo_the_thing|b.sh\n')")"
+    assert_contains "$out" "MATCH"
+    assert_contains "$out" "1.000"
+}
+
+#[test]
+it_does_not_compare_a_name_with_no_prefix_by_a_prefix_rule() {
+    # Nothing to strip, so the guard must not fire and swallow the match.
+    local out; out="$(_pairs "$(printf 'render|a.sh\nrenders|b.sh\n')")"
+    assert_contains "$out" "MATCH"
+}

--- a/tests/cli_args_test.sh
+++ b/tests/cli_args_test.sh
@@ -66,3 +66,34 @@ it_still_runs_an_ordinary_script_path() {
 it_still_says_so_when_a_script_path_is_wrong() {
     assert_contains "$(nut /no/such/script.sh)" "script not found"
 }
+
+#[test]
+it_runs_the_script_in_the_working_directory_not_the_one_on_path() {
+    # `source name` searches PATH before the working directory, and a lot of
+    # short script names collide with something in /bin.
+    local d; d="$(mktemp -d)"
+    printf 'echo mine\n' > "$d/test"
+    local out; out="$(cd "$d" && "$NUT_BIN" test 2>&1)"
+    rm -rf "$d"
+    assert_eq "$out" "mine"
+}
+
+#[test]
+it_runs_a_script_named_by_a_relative_path() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/sub"
+    printf 'echo nested\n' > "$d/sub/s.sh"
+    local out; out="$(cd "$d" && "$NUT_BIN" sub/s.sh 2>&1)"
+    rm -rf "$d"
+    assert_eq "$out" "nested"
+}
+
+#[test]
+it_says_so_when_the_script_is_not_there() {
+    local d; d="$(mktemp -d)"
+    local out; out="$(cd "$d" && "$NUT_BIN" nosuchscript 2>&1)"
+    local code=$?
+    rm -rf "$d"
+    assert_contains "$out" "not found"
+    assert_ne "$code" "0"
+}

--- a/tests/toml_json_test.sh
+++ b/tests/toml_json_test.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Tests for the TOML to JSON conversion.
+#
+# It had none, and two of the things it got wrong were the kind a test would
+# have caught on the first run: `[a.b]` after `[a]` emitted a second `a` beside
+# the first, and a string's TOML escapes were escaped a second time on the way
+# out.
+
+use toml::json test
+
+_tj() { mktemp -d; }
+
+# Is this actually JSON, according to something that is not us? Skipped where
+# no parser is installed, which is why nothing relies on it alone.
+_tj_parser() {
+    if command -v jq >/dev/null 2>&1; then printf 'jq'; return 0; fi
+    if command -v python3 >/dev/null 2>&1; then printf 'python3'; return 0; fi
+    return 1
+}
+_tj_valid() {
+    local doc="$1"
+    case "$(_tj_parser)" in
+        jq)      printf '%s' "$doc" | jq -e . >/dev/null 2>&1 ;;
+        python3) printf '%s' "$doc" | python3 -c 'import json,sys; json.load(sys.stdin)' >/dev/null 2>&1 ;;
+        *)       return 0 ;;
+    esac
+}
+
+#[test]
+it_rejects_a_document_that_is_not_json() {
+    # The control for every test below that leans on _tj_valid. Without it a
+    # broken checker would pass everything and say nothing.
+    _tj_parser >/dev/null || return 0
+    assert_fails _tj_valid '{"a":1,}'
+    assert_ok _tj_valid '{"a":1}'
+}
+
+#[test]
+it_converts_a_flat_file() {
+    local d; d="$(_tj)"
+    printf 'title = "t"\n\n[ui]\nwidth = 30\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"title":"t","ui":{"width":30}}'
+}
+
+#[test]
+it_nests_a_subsection_inside_its_parent() {
+    # `[a.b]` used to close `a` and open a second one, so the object carried
+    # the key twice and a parser kept only one of them.
+    local d; d="$(_tj)"
+    printf '[a]\nx = 1\n\n[a.b]\ny = 2\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"x":1,"b":{"y":2}}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_keeps_two_siblings_under_one_parent() {
+    local d; d="$(_tj)"
+    printf '[a]\nx = 1\n[a.b]\ny = 2\n[a.c]\nz = 3\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"x":1,"b":{"y":2},"c":{"z":3}}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_nests_three_deep() {
+    local d; d="$(_tj)"
+    printf '[a.b.c]\nx = 1\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"b":{"c":{"x":1}}}}'
+}
+
+#[test]
+it_refuses_a_file_that_comes_back_to_a_finished_section() {
+    # One pass cannot reopen a closed object, and emitting the key twice is
+    # worse than saying so.
+    local d; d="$(_tj)"
+    printf '[b]\nx = 1\n[a]\ny = 2\n[b.c]\nz = 3\n' > "$d/t.toml"
+    local out; out="$(toml_to_json "$d/t.toml" 2>&1)"
+    local rc=$?
+    rm -rf "$d"
+    assert_ne "$rc" "0"
+    assert_contains "$out" "b.c"
+}
+
+#[test]
+it_does_not_double_escape_a_quoted_string() {
+    local d; d="$(_tj)"
+    printf '[a]\nv = "say \\"hi\\""\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"v":"say \"hi\""}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_does_not_double_escape_a_backslash() {
+    local d; d="$(_tj)"
+    printf '[a]\np = "C:\\\\tools"\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"p":"C:\\tools"}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_writes_a_tab_as_a_json_escape_not_a_raw_tab() {
+    # TOML's \t is a real tab by the time the value is read, and JSON will not
+    # take one inside a string.
+    local d; d="$(_tj)"
+    printf '[a]\nv = "one\\ttwo"\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"v":"one\ttwo"}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_leaves_a_literal_string_as_typed() {
+    local d; d="$(_tj)"
+    printf '[a]\np = \047C:\\tools\047\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"p":"C:\\tools"}}'
+}
+
+#[test]
+it_writes_numbers_and_bools_bare() {
+    local d; d="$(_tj)"
+    printf '[a]\ni = -3\nf = 1.5\nt = true\nf2 = false\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"i":-3,"f":1.5,"t":true,"f2":false}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_writes_an_array() {
+    local d; d="$(_tj)"
+    printf '[a]\nl = ["one", "two"]\ne = []\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"l":["one","two"],"e":[]}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_ignores_comments_and_blank_lines() {
+    local d; d="$(_tj)"
+    printf '# leading\n\n[a]\n# about x\nx = 1  # trailing\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"x":1}}'
+}
+
+#[test]
+it_converts_an_empty_file_to_an_empty_object() {
+    local d; d="$(_tj)"
+    : > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{}'
+}
+
+#[test]
+it_refuses_a_file_that_is_not_there() {
+    local d; d="$(_tj)"
+    assert_fails toml_to_json "$d/nope.toml"
+    rm -rf "$d"
+}
+
+#[test]
+it_keeps_a_hash_that_is_part_of_a_value() {
+    local d; d="$(_tj)"
+    printf '[a]\nv = "#[pub]"\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"v":"#[pub]"}}'
+}

--- a/tests/toml_json_test.sh
+++ b/tests/toml_json_test.sh
@@ -184,30 +184,62 @@ it_keeps_a_hash_that_is_part_of_a_value() {
 }
 
 #[test]
-it_writes_a_key_that_needs_escaping_as_json() {
-    # A key is a string and goes through the string writer. Raw, a quoted key
-    # or one holding a quote made the whole document something no parser reads.
+it_refuses_a_quoted_key() {
+    # Nothing here can address one: `toml_keys` leaves it out and `toml_get`
+    # cannot reach it. Converting it anyway produced valid JSON naming a key
+    # that is not the key, which is a worse failure than refusing.
     local d; d="$(_tj)"
     printf '[a]\n"my key" = 1\n' > "$d/t.toml"
-    local got; got="$(toml_to_json "$d/t.toml")"
+    local out rc=0
+    out="$(toml_to_json "$d/t.toml" 2>&1)" || rc=$?
     rm -rf "$d"
-    assert_ok _tj_valid "$got"
+    assert_ne "$rc" "0"
+    assert_contains "$out" "my key"
+    assert_contains "$out" "quoted key"
 }
 
 #[test]
-it_writes_a_key_holding_a_quote_as_json() {
+it_refuses_a_key_holding_a_quote() {
     local d; d="$(_tj)"
     printf '[a]\n"a\\"b" = 1\n' > "$d/t.toml"
-    local got; got="$(toml_to_json "$d/t.toml")"
+    local rc=0
+    toml_to_json "$d/t.toml" >/dev/null 2>&1 || rc=$?
     rm -rf "$d"
-    assert_ok _tj_valid "$got"
+    assert_ne "$rc" "0"
 }
 
 #[test]
-it_writes_a_section_name_that_needs_escaping_as_json() {
+it_refuses_a_quoted_section_name() {
+    # `["a.b"]` is one section whose name has a dot in it. Split on the dot it
+    # came out as two nested objects for a document with one level.
     local d; d="$(_tj)"
-    printf '["a\\"b"]\nx = 1\n' > "$d/t.toml"
+    printf '["a.b"]\nx = 1\n' > "$d/t.toml"
+    local out rc=0
+    out="$(toml_to_json "$d/t.toml" 2>&1)" || rc=$?
+    rm -rf "$d"
+    assert_ne "$rc" "0"
+    assert_contains "$out" "quoted section"
+}
+
+#[test]
+it_still_converts_an_ordinary_key_beside_the_refusal() {
+    # The control: refusing the ones it cannot name must not refuse the rest.
+    local d; d="$(_tj)"
+    printf '[a]\nplain = 1\nother = "two"\n' > "$d/t.toml"
     local got; got="$(toml_to_json "$d/t.toml")"
     rm -rf "$d"
+    assert_eq "$got" '{"a":{"plain":1,"other":"two"}}'
+}
+
+#[test]
+it_writes_a_value_that_needs_escaping_as_the_value_it_is() {
+    # Asserted as the document rather than as "it parses". Checking only that
+    # the output parses discriminates broken from unbroken and nothing finer,
+    # which is the axis a key-escaping change moves along.
+    local d; d="$(_tj)"
+    printf '[a]\nv = "say \\"hi\\""\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"v":"say \"hi\""}}'
     assert_ok _tj_valid "$got"
 }

--- a/tests/toml_json_test.sh
+++ b/tests/toml_json_test.sh
@@ -182,3 +182,32 @@ it_keeps_a_hash_that_is_part_of_a_value() {
     rm -rf "$d"
     assert_eq "$got" '{"a":{"v":"#[pub]"}}'
 }
+
+#[test]
+it_writes_a_key_that_needs_escaping_as_json() {
+    # A key is a string and goes through the string writer. Raw, a quoted key
+    # or one holding a quote made the whole document something no parser reads.
+    local d; d="$(_tj)"
+    printf '[a]\n"my key" = 1\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_writes_a_key_holding_a_quote_as_json() {
+    local d; d="$(_tj)"
+    printf '[a]\n"a\\"b" = 1\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_writes_a_section_name_that_needs_escaping_as_json() {
+    local d; d="$(_tj)"
+    printf '["a\\"b"]\nx = 1\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_ok _tj_valid "$got"
+}

--- a/tests/toml_test.sh
+++ b/tests/toml_test.sh
@@ -397,3 +397,70 @@ it_does_not_close_a_literal_body_on_a_basic_delimiter() {
     rm -rf "$d"
     assert_contains "$got" "and ends after"
 }
+
+#[test]
+it_decodes_an_escaped_quote_in_a_basic_string() {
+    # TOML gives a basic string escapes. Handing back the backslashes means a
+    # value never survives a write and a read, and every consumer that spliced
+    # the result into a command got a stray backslash.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = "say \\"hi\\""\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" 'say "hi"'
+}
+
+#[test]
+it_decodes_a_backslash_and_the_named_escapes() {
+    local d; d="$(mktemp -d)"
+    printf '[a]\np = "C:\\\\tools"\nt = "one\\ttwo"\n' > "$d/t.toml"
+    local p t
+    p="$(toml_get "$d/t.toml" a.p)"
+    t="$(toml_get "$d/t.toml" a.t)"
+    rm -rf "$d"
+    assert_eq "$p" 'C:\tools'
+    assert_eq "$t" "$(printf 'one\ttwo')"
+}
+
+#[test]
+it_decodes_a_unicode_escape() {
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = "caf\\u00e9"\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" "café"
+}
+
+#[test]
+it_keeps_a_backslash_that_starts_no_escape() {
+    # Not every backslash is an escape. Eating one that introduces nothing
+    # loses a character with no warning.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = "a\\qb"\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" 'a\qb'
+}
+
+#[test]
+it_leaves_a_literal_string_exactly_as_typed() {
+    # The control: a literal string has no escapes at all, so decoding one is
+    # as wrong as failing to decode a basic string.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = \047C:\\tools\047\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" 'C:\tools'
+}
+
+#[test]
+it_does_not_end_a_basic_string_at_an_escaped_quote() {
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = "he said \\"no\\" #1"\nw = 5\n' > "$d/t.toml"
+    local v w
+    v="$(toml_get "$d/t.toml" a.v)"
+    w="$(toml_get "$d/t.toml" a.w)"
+    rm -rf "$d"
+    assert_eq "$v" 'he said "no" #1'
+    assert_eq "$w" "5"
+}

--- a/tests/toml_test.sh
+++ b/tests/toml_test.sh
@@ -464,3 +464,61 @@ it_does_not_end_a_basic_string_at_an_escaped_quote() {
     assert_eq "$v" 'he said "no" #1'
     assert_eq "$w" "5"
 }
+
+#[test]
+it_keeps_a_hash_after_a_single_escaped_quote_on_the_hot_path() {
+    # `_toml_clean_into` is the copy every value read goes through, and the
+    # escaped-quote fix landed only in `_toml_clean_line`. The two cases the
+    # suite had both carried an even number of escaped quotes before the `#`,
+    # where the broken counting cancels out and gets the right answer by luck.
+    # One is the shape that breaks.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = "a \\" b # c"\nafter = 5\n' > "$d/t.toml"
+    local v after
+    v="$(toml_get "$d/t.toml" a.v)"
+    after="$(toml_get "$d/t.toml" a.after)"
+    rm -rf "$d"
+    assert_eq "$v" 'a " b # c'
+    assert_eq "$after" "5"
+}
+
+#[test]
+it_cleans_a_line_the_same_way_through_both_cleaners() {
+    # Two implementations of one rule is two places for it to be wrong, and
+    # only one of them was fixed. Whatever they answer, they answer together.
+    local -a cases=(
+        'v = "a \" b # c"'
+        'v = "a \" b \" c # d"'
+        'v = "plain # hash"'
+        "v = 'literal # hash'"
+        'v = 1  # a real comment'
+        'v = "trailing backslash \\\\"'
+    )
+    local c into wrong=""
+    for c in "${cases[@]}"; do
+        _toml_clean_into into "$c"
+        [[ "$into" == "$(_toml_clean_line "$c")" ]] || wrong="${wrong} [${c}]"
+    done
+    assert_empty "$wrong"
+}
+
+#[test]
+it_has_a_detector_that_notices_the_two_cleaners_disagreeing() {
+    # The control for the comparison above: it has to be able to see a
+    # difference, or its silence means nothing.
+    local into
+    _toml_clean_into into 'v = 1  # comment'
+    assert_ne "$into" "$(_toml_clean_line 'v = 2  # comment')"
+    assert_eq "$into" "$(_toml_clean_line 'v = 1  # comment')"
+}
+
+#[test]
+it_reads_a_section_pair_with_an_escaped_quote_in_it() {
+    # `toml_section_pairs` goes through the hot-path cleaner too.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = "say \\" now"\nn = 2\n' > "$d/t.toml"
+    local pairs; pairs="$(toml_section_pairs "$d/t.toml" a)"
+    rm -rf "$d"
+    assert_contains "$pairs" 'say " now'
+    assert_contains "$pairs" "n=2"
+}

--- a/tests/toml_write_test.sh
+++ b/tests/toml_write_test.sh
@@ -55,6 +55,7 @@ it_keeps_the_leading_comment_and_the_blank_lines() {
     # asserts that somebody counted the fixture correctly.
     local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
     local before; before="$(grep -c '^$' "$d/t.toml")"
+    local before_lines; before_lines="$(wc -l < "$d/t.toml" | tr -d ' ')"
     toml_set "$d/t.toml" "ui.theme" "light"
     local after; after="$(grep -c '^$' "$d/t.toml")"
     local body; body="$(cat "$d/t.toml")"
@@ -63,7 +64,7 @@ it_keeps_the_leading_comment_and_the_blank_lines() {
     assert_contains "$body" "# The user's preferences."
     assert_contains "$body" "# a pause the writer must not close up"
     assert_eq "$after" "$before"
-    assert_eq "$lines" "12"
+    assert_eq "$lines" "$before_lines"
 }
 
 #[test]
@@ -108,7 +109,11 @@ it_appends_a_new_key_inside_its_own_section() {
     line_net="$(grep -n '^\[net\]' "$d/t.toml" | cut -d: -f1)"
     rm -rf "$d"
     assert_eq "$got" "compact"
-    (( line_ui < line_new && line_new < line_net ))
+    # Asserted, not stated. The harness counts assertions and ignores the exit
+    # status by design, so a bare `(( ))` here was a no-op and the ordering the
+    # test is named for went unchecked.
+    assert_ok test "$line_ui" -lt "$line_new"
+    assert_ok test "$line_new" -lt "$line_net"
 }
 
 #[test]
@@ -343,4 +348,149 @@ it_refuses_to_remove_from_a_file_that_is_not_there() {
     local d; d="$(_tw_dir)"
     assert_fails toml_unset "$d/nope.toml" "a.b"
     rm -rf "$d"
+}
+
+# --- root is a place, not the absence of one ---------------------------------
+#
+# Reading "no section" as "no section is open" made a root key match anywhere:
+# `toml_unset f name` deleted `name` from every section in the file, and
+# `toml_set f name x` rewrote the first sectioned key that happened to share
+# the leaf.
+
+#[test]
+it_removes_a_root_key_without_touching_the_same_name_in_a_section() {
+    local d; d="$(mktemp -d)"
+    printf 'name = "root"\n[a]\nname = "x"\n[b]\nname = "y"\n' > "$d/t.toml"
+    toml_unset "$d/t.toml" name
+    local root a b
+    root="$(toml_get "$d/t.toml" name 2>/dev/null || true)"
+    a="$(toml_get "$d/t.toml" a.name)"
+    b="$(toml_get "$d/t.toml" b.name)"
+    rm -rf "$d"
+    assert_empty "$root"
+    assert_eq "$a" "x"
+    assert_eq "$b" "y"
+}
+
+#[test]
+it_removes_a_sectioned_key_without_touching_the_root_one() {
+    # The other direction of the same law.
+    local d; d="$(mktemp -d)"
+    printf 'name = "root"\n[a]\nname = "x"\n[b]\nname = "y"\n' > "$d/t.toml"
+    toml_unset "$d/t.toml" a.name
+    local root a b
+    root="$(toml_get "$d/t.toml" name)"
+    a="$(toml_get "$d/t.toml" a.name 2>/dev/null || true)"
+    b="$(toml_get "$d/t.toml" b.name)"
+    rm -rf "$d"
+    assert_eq "$root" "root"
+    assert_empty "$a"
+    assert_eq "$b" "y"
+}
+
+#[test]
+it_writes_a_root_key_above_the_first_section() {
+    # Appending it at the end of the file puts it inside whatever section ends
+    # there, so the write and the read disagree about the same key.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nname = "x"\n' > "$d/t.toml"
+    toml_set "$d/t.toml" name root
+    local root a first
+    root="$(toml_get "$d/t.toml" name)"
+    a="$(toml_get "$d/t.toml" a.name)"
+    first="$(head -1 "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$root" "root"
+    assert_eq "$a" "x"
+    assert_eq "$first" 'name = "root"'
+}
+
+#[test]
+it_appends_a_root_key_after_the_root_content_it_already_has() {
+    local d; d="$(mktemp -d)"
+    printf '# top\ntitle = "t"\n\n[a]\nx = 1\n' > "$d/t.toml"
+    toml_set "$d/t.toml" other v
+    local got line_new line_a body
+    got="$(toml_get "$d/t.toml" other)"
+    line_new="$(grep -n '^other' "$d/t.toml" | cut -d: -f1)"
+    line_a="$(grep -n '^\[a\]' "$d/t.toml" | cut -d: -f1)"
+    body="$(cat "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" "v"
+    assert_ok test "$line_new" -lt "$line_a"
+    assert_contains "$body" "# top"
+}
+
+#[test]
+it_replaces_a_root_key_rather_than_the_sectioned_one_below_it() {
+    local d; d="$(mktemp -d)"
+    printf 'title = "t"\n[a]\ntitle = "inner"\n' > "$d/t.toml"
+    toml_set "$d/t.toml" title new
+    local root inner
+    root="$(toml_get "$d/t.toml" title)"
+    inner="$(toml_get "$d/t.toml" a.title)"
+    rm -rf "$d"
+    assert_eq "$root" "new"
+    assert_eq "$inner" "inner"
+}
+
+# --- a section with nothing in it --------------------------------------------
+
+#[test]
+it_appends_into_a_section_that_is_empty() {
+    # The section ends at its own header, and the header arm used to skip the
+    # append, so the key landed at the end of the file inside the next section.
+    local d; d="$(mktemp -d)"
+    printf '[a]\n\n[b]\nx = 1\n' > "$d/t.toml"
+    toml_set "$d/t.toml" a.k v
+    local got wrong
+    got="$(toml_get "$d/t.toml" a.k)"
+    wrong="$(toml_get "$d/t.toml" b.k 2>/dev/null || true)"
+    rm -rf "$d"
+    assert_eq "$got" "v"
+    assert_empty "$wrong"
+}
+
+#[test]
+it_appends_into_an_empty_section_at_the_end_of_the_file() {
+    local d; d="$(mktemp -d)"
+    printf '[a]\nx = 1\n[b]\n' > "$d/t.toml"
+    toml_set "$d/t.toml" b.k v
+    local got
+    got="$(toml_get "$d/t.toml" b.k)"
+    rm -rf "$d"
+    assert_eq "$got" "v"
+}
+
+# --- a value the reader can decode -------------------------------------------
+
+#[test]
+it_encodes_a_newline_rather_than_writing_one_into_the_file() {
+    # An unescaped newline does not corrupt the value, it corrupts the file:
+    # every key after it is on the wrong side of an unterminated string.
+    local d; d="$(mktemp -d)"
+    printf '[s]\nafter = 1\n' > "$d/t.toml"
+    toml_set "$d/t.toml" "s.k" "$(printf 'a\nb')"
+    local got after lines
+    got="$(toml_get "$d/t.toml" s.k)"
+    after="$(toml_get "$d/t.toml" s.after)"
+    lines="$(grep -c '^k = ' "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" "$(printf 'a\nb')"
+    assert_eq "$after" "1"
+    assert_eq "$lines" "1"
+}
+
+#[test]
+it_encodes_every_escape_the_reader_decodes() {
+    # The pair has to be symmetric or the round trip is not one.
+    local d; d="$(mktemp -d)"
+    local want; want="$(printf 'a\tb\rc\nd')"
+    toml_set "$d/t.toml" "s.k" "$want"
+    local got line
+    got="$(toml_get "$d/t.toml" s.k)"
+    line="$(grep -c '^k = ' "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" "$want"
+    assert_eq "$line" "1"
 }

--- a/tests/toml_write_test.sh
+++ b/tests/toml_write_test.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# Tests for the TOML writer.
+#
+# The whole point of a setter that edits in place rather than regenerating is
+# that the file survives it: comments, order, blank lines, the neighbouring
+# keys, and the key with the same name in the section next door. Most of these
+# assert exactly that, because a writer that gets the value right and quietly
+# eats the file around it looks correct in every test that only reads the
+# value back.
+
+use toml toml::write test
+
+_tw_dir() { mktemp -d; }
+
+_tw_sample() {
+    cat > "$1" <<'EOF'
+# The user's preferences. Hand-written, and it stays that way.
+title = "root level"
+
+[ui]
+# how wide the sidebar wants to be
+width = 30
+theme = "dark"
+
+# a pause the writer must not close up
+[net]
+width = 99
+timeout = 5
+EOF
+}
+
+#[test]
+it_changes_a_value_in_place() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    assert_ok toml_set "$d/t.toml" "ui.theme" "light"
+    local got; got="$(toml_get "$d/t.toml" ui.theme)"
+    rm -rf "$d"
+    assert_eq "$got" "light"
+}
+
+#[test]
+it_keeps_the_comment_above_the_key_it_changed() {
+    # The reason this function exists rather than a regenerate-from-model one.
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "ui.width" 42
+    local body; body="$(cat "$d/t.toml")"
+    rm -rf "$d"
+    assert_contains "$body" "# how wide the sidebar wants to be"
+}
+
+#[test]
+it_keeps_the_leading_comment_and_the_blank_lines() {
+    # Counted before and after rather than against a number written here: the
+    # law is that the write changes neither, and a hardcoded count only
+    # asserts that somebody counted the fixture correctly.
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    local before; before="$(grep -c '^$' "$d/t.toml")"
+    toml_set "$d/t.toml" "ui.theme" "light"
+    local after; after="$(grep -c '^$' "$d/t.toml")"
+    local body; body="$(cat "$d/t.toml")"
+    local lines; lines="$(wc -l < "$d/t.toml" | tr -d ' ')"
+    rm -rf "$d"
+    assert_contains "$body" "# The user's preferences."
+    assert_contains "$body" "# a pause the writer must not close up"
+    assert_eq "$after" "$before"
+    assert_eq "$lines" "12"
+}
+
+#[test]
+it_leaves_every_other_key_readable() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "ui.theme" "light"
+    local w t n title
+    w="$(toml_get "$d/t.toml" ui.width)"
+    t="$(toml_get "$d/t.toml" net.timeout)"
+    n="$(toml_get "$d/t.toml" net.width)"
+    title="$(toml_get "$d/t.toml" title)"
+    rm -rf "$d"
+    assert_eq "$w" "30"
+    assert_eq "$t" "5"
+    assert_eq "$n" "99"
+    assert_eq "$title" "root level"
+}
+
+#[test]
+it_changes_only_the_key_in_the_named_section() {
+    # `width` exists in both. A writer matching on the leaf alone hits the
+    # first one it sees, which is the wrong file half the time.
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "net.width" 7
+    local ui net
+    ui="$(toml_get "$d/t.toml" ui.width)"
+    net="$(toml_get "$d/t.toml" net.width)"
+    rm -rf "$d"
+    assert_eq "$ui" "30"
+    assert_eq "$net" "7"
+}
+
+#[test]
+it_appends_a_new_key_inside_its_own_section() {
+    # Not at the end of the file, which is somebody else's section.
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "ui.density" "compact"
+    local got line_ui line_new line_net
+    got="$(toml_get "$d/t.toml" ui.density)"
+    line_ui="$(grep -n '^\[ui\]' "$d/t.toml" | cut -d: -f1)"
+    line_new="$(grep -n '^density' "$d/t.toml" | cut -d: -f1)"
+    line_net="$(grep -n '^\[net\]' "$d/t.toml" | cut -d: -f1)"
+    rm -rf "$d"
+    assert_eq "$got" "compact"
+    (( line_ui < line_new && line_new < line_net ))
+}
+
+#[test]
+it_creates_a_section_that_is_not_there() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    assert_ok toml_set "$d/t.toml" "audio.volume" 80
+    local got old
+    got="$(toml_get "$d/t.toml" audio.volume)"
+    old="$(toml_get "$d/t.toml" ui.theme)"
+    rm -rf "$d"
+    assert_eq "$got" "80"
+    assert_eq "$old" "dark"
+}
+
+#[test]
+it_writes_a_file_that_does_not_exist_yet() {
+    local d; d="$(_tw_dir)"
+    assert_ok toml_set "$d/new.toml" "ui.theme" "dark"
+    local got; got="$(toml_get "$d/new.toml" ui.theme)"
+    rm -rf "$d"
+    assert_eq "$got" "dark"
+}
+
+#[test]
+it_writes_a_root_level_key() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "title" "renamed"
+    local got sect
+    got="$(toml_get "$d/t.toml" title)"
+    sect="$(toml_get "$d/t.toml" ui.theme)"
+    rm -rf "$d"
+    assert_eq "$got" "renamed"
+    assert_eq "$sect" "dark"
+}
+
+#[test]
+it_leaves_a_number_unquoted() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "ui.width" 42
+    local line; line="$(grep '^width' "$d/t.toml" | head -1)"
+    rm -rf "$d"
+    assert_eq "$line" "width = 42"
+}
+
+#[test]
+it_leaves_a_negative_and_a_float_unquoted() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.n" -12
+    toml_set "$d/t.toml" "a.f" 1.5
+    local n f
+    n="$(grep '^n = ' "$d/t.toml")"
+    f="$(grep '^f = ' "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$n" "n = -12"
+    assert_eq "$f" "f = 1.5"
+}
+
+#[test]
+it_leaves_a_bool_unquoted() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.on" true
+    toml_set "$d/t.toml" "a.off" false
+    local on off
+    on="$(grep '^on = ' "$d/t.toml")"
+    off="$(grep '^off = ' "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$on" "on = true"
+    assert_eq "$off" "off = false"
+}
+
+#[test]
+it_leaves_an_array_unquoted_and_readable() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.list" '["one", "two"]'
+    local -a out=()
+    toml_array "$d/t.toml" a.list out
+    local n="${#out[@]}" first="${out[0]:-}"
+    rm -rf "$d"
+    assert_eq "$n" "2"
+    assert_eq "$first" "one"
+}
+
+#[test]
+it_quotes_a_string_that_looks_like_neither() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.v" "hello there"
+    local line; line="$(grep '^v = ' "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$line" 'v = "hello there"'
+}
+
+#[test]
+it_escapes_a_quote_in_the_value() {
+    # Unescaped, this writes a file that no longer parses, and the next read
+    # of any key in it fails for a reason nobody would connect to this write.
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.v" 'say "hi"'
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" 'say "hi"'
+}
+
+#[test]
+it_escapes_a_backslash_in_the_value() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.path" 'C:\tools'
+    local line; line="$(grep '^path = ' "$d/t.toml")"
+    local got; got="$(toml_get "$d/t.toml" a.path)"
+    rm -rf "$d"
+    assert_eq "$line" 'path = "C:\\tools"'
+    assert_eq "$got" 'C:\tools'
+}
+
+#[test]
+it_reads_back_a_value_with_a_quote_and_a_backslash_together() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.v" 'a\b"c'
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" 'a\b"c'
+}
+
+#[test]
+it_does_not_read_a_hash_after_an_escaped_quote_as_a_comment() {
+    # The line cleaner counts quotes to find the end of the string. Reading an
+    # escaped one as the terminator puts the rest of the value outside it, and
+    # a `#` there truncates the line.
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.v" 'said "no" #1'
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" 'said "no" #1'
+}
+
+#[test]
+it_keeps_a_hash_in_the_value_readable() {
+    # The reader is quote-aware; the writer has to give it a quoted value for
+    # that to help.
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.v" '#[pub]'
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" '#[pub]'
+}
+
+#[test]
+it_survives_being_written_twice() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "ui.theme" "light"
+    toml_set "$d/t.toml" "ui.theme" "dark"
+    local got count
+    got="$(toml_get "$d/t.toml" ui.theme)"
+    count="$(grep -c '^theme = ' "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" "dark"
+    assert_eq "$count" "1"
+}
+
+#[test]
+it_reads_back_everything_it_wrote() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.one" "first"
+    toml_set "$d/t.toml" "b.two" "second"
+    toml_set "$d/t.toml" "a.three" "third"
+    local one two three
+    one="$(toml_get "$d/t.toml" a.one)"
+    two="$(toml_get "$d/t.toml" b.two)"
+    three="$(toml_get "$d/t.toml" a.three)"
+    rm -rf "$d"
+    assert_eq "$one" "first"
+    assert_eq "$two" "second"
+    assert_eq "$three" "third"
+}
+
+#[test]
+it_refuses_a_call_with_no_key() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    assert_fails toml_set "$d/t.toml" "" "x"
+    rm -rf "$d"
+}
+
+#[test]
+it_refuses_a_call_with_no_file() {
+    assert_fails toml_set "" "a.b" "x"
+}
+
+#[test]
+it_leaves_no_temporary_file_beside_the_target() {
+    # It writes through mktemp and renames, so a reader never sees half a
+    # file. The rename has to actually happen.
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "ui.theme" "light"
+    local n; n="$(find "$d" -type f | wc -l | tr -d ' ')"
+    rm -rf "$d"
+    assert_eq "$n" "1"
+}
+
+#[test]
+it_removes_a_key() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    assert_ok toml_unset "$d/t.toml" "ui.theme"
+    local gone; gone="$(toml_get "$d/t.toml" ui.theme 2>/dev/null || true)"
+    local kept; kept="$(toml_get "$d/t.toml" ui.width)"
+    rm -rf "$d"
+    assert_empty "$gone"
+    assert_eq "$kept" "30"
+}
+
+#[test]
+it_removes_only_the_key_in_the_named_section() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_unset "$d/t.toml" "net.width"
+    local ui; ui="$(toml_get "$d/t.toml" ui.width)"
+    local net; net="$(toml_get "$d/t.toml" net.width 2>/dev/null || true)"
+    rm -rf "$d"
+    assert_eq "$ui" "30"
+    assert_empty "$net"
+}
+
+#[test]
+it_keeps_the_comments_when_removing() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_unset "$d/t.toml" "ui.theme"
+    local body; body="$(cat "$d/t.toml")"
+    rm -rf "$d"
+    assert_contains "$body" "# how wide the sidebar wants to be"
+    assert_contains "$body" "# a pause the writer must not close up"
+}
+
+#[test]
+it_refuses_to_remove_from_a_file_that_is_not_there() {
+    local d; d="$(_tw_dir)"
+    assert_fails toml_unset "$d/nope.toml" "a.b"
+    rm -rf "$d"
+}


### PR DESCRIPTION
`toml_set` and `toml_unset` edit a file in place: the line changes, and the comments, the order and the blank lines around it do not. A key whose section is missing gets the section; a key that is not there is appended inside its own section rather than at the end of the file.

The reader gained two fixes found while testing the writer. A basic string's escapes were never decoded, so a value with a quote or a backslash in it did not survive a write and a read; and the line cleaner ended a string at an escaped quote, which put the rest of the value outside it and truncated the line at any `#`.

- split `lib/toml.sh` into the reader, `toml::write` and `toml::json`, one concept each, and put the JSON converter behind its own `use`
- `toml_to_json` nests `[a.b]` inside `a` instead of emitting a second `a` beside it, which is a JSON object with the same key twice; a file that comes back to a finished section is refused by name rather than converted into one
- stop double-escaping a string on the way to JSON, and write a tab as `\t`
- `source` the script by its absolute path, so `nutshell test` in a directory holding a script called `test` no longer sources `/bin/test`
- stop the duplicate-name check reading a shared module prefix as a copy, and give it a test with a positive control

`use toml` no longer brings `toml_to_json` with it. Nothing calls it, and `use toml::json` says what it wants.

## Test plan

`./test` and `./check`. `tests/toml_write_test.sh` covers what a write leaves alone: the comment above the key, the blank lines, the neighbouring keys and the same key in the section next door. `tests/toml_json_test.sh` checks the conversion against jq or python where either is installed, with a control that shows the validity check can fail.