### PR TITLE
fix: a branch pin means that branch's head

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -371,3 +371,52 @@ the dependency and the pin, rather than a missing function at line 426 of
 something the reader was in the middle of.
 
 Both are the same fix from two directions, and both make the guards go away.
+
+## Elevation is one step, not a mode
+
+op:
+
+> in general, I think the elevation should be nutshell api and abstracted so
+> that it only ever does a single disjoint thing elevated, then returns back to
+> original user. So it's really suDO, not just switching to su like it
+> presently behaves
+>
+> And the reason for being nutshell is that this should apply elsewhere, so we
+> don't accidentally end up writing things I expect in my home, to root's home
+> etc
+
+### The intent
+
+**One elevated step, then back.** The unit is a single thing that needs root,
+run as root, and everything around it stays the user who asked. Not a mode the
+process enters and stays in, which is what running a whole task under `sudo`
+is: `su` with extra steps.
+
+**It belongs in nutshell**, because the failure it prevents is not one tool's.
+Anything that elevates and then keeps going writes the user's files as root:
+their state directory, their cache, their config, their journal.
+
+### The evidence, from the machine, today
+
+Fetching an image needs the stick mounted, mounting needs root, so the whole
+task ran under `sudo`. The result, on the lifebook:
+
+    ~/.local/state/hulilupteri/journal        orgrinrt orgrinrt   22 lines
+    /run/hulilupteri/home/journal             root     root       10 lines
+
+Two histories of one tool, split by which user happened to run it, and the
+second one the user can no longer write: `test -w` says no. The next ordinary
+run either fails to record what it did or silently does not.
+
+Nothing was misconfigured. The tool asked for root for a reason and then kept
+it, which is the whole of the defect.
+
+### What the API has to do
+
+- run one command as root and return, with the caller's identity unchanged
+- try `sudo -n` first, so a machine needing no password never shows a prompt
+- refuse rather than hang where there is no terminal to answer a prompt on
+- name what is being elevated, so the sudo prompt and the log both say it
+- give a caller the real user's home, name and id even while the one step runs,
+  so nothing computes a path from `$HOME` at the wrong moment
+- say plainly when it cannot elevate, rather than falling back to trying anyway

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -310,3 +310,64 @@ written twice. The second is the interesting half and the risky one, since a
 generator that produces shell from rust attributes is a project of its own.
 
 Nothing here is scheduled.
+
+## Do not vendor the interpreter
+
+op:
+
+> Hmm. I don't think we should vendor in nutshell in the libs, honestly. Or at
+> least if there is a global nutshell interp / bin instance in path, or
+> otherwise reachable, it should be used as opposed to the vendored one, which
+> avoids random version differences between libs
+
+and, on the guard-every-call shape that comes out of it:
+
+> This problem seems like we shouldn't even have it...
+>
+> How do things like yarn 2, pnpm, cargo, deno, solve this very problem?
+
+### What those four actually do
+
+None of them keeps a per-project physical copy of anything, and none of them
+degrades when a version is wrong.
+
+**cargo** separates the toolchain from the libraries. The toolchain is resolved
+by rustup from `rust-toolchain.toml`; the libraries live in one shared
+`~/.cargo/registry` and are selected by a lockfile. A crate states the minimum
+compiler it needs with `rust-version`, and an older one is a refusal naming the
+version, never a build that half works.
+
+**pnpm** keeps one content-addressed store and makes `node_modules` a tree of
+links into it, so a version exists once on the machine however many projects
+want it. It is strict about declarations: a package may import what it declared
+and nothing else.
+
+**yarn 2** goes further and has no `node_modules` at all. One map from every
+import to a zip in the shared cache, and an undeclared import is an error.
+
+**deno** has one global cache keyed by URL with a lockfile of hashes, and the
+runtime is a single binary the project names.
+
+The two properties they share, and the two we do not have:
+
+1. **One copy per version on the machine, shared, never a copy per project.**
+   nutshell already does this for externs: `~/.cache/nutshell/externs/<key>` is
+   content-addressed by url and commit. The submodule is the exception, and it
+   is the thing that goes stale.
+2. **A wrong version is a refusal, not a degradation.** `declare -F thing ||
+   skip` at every call site is what a project writes when it does not know what
+   version it has. With a declared minimum and honest resolution the guard is
+   dead code.
+
+### The intent
+
+**The interpreter is resolved like any other dependency.** A library declares
+which nutshell it needs and a launcher on PATH finds or fetches it, the way
+rustup does for cargo and the way renki already does for its engine. A global
+one that satisfies the declaration is used in preference to anything vendored.
+
+**A dependency declares a minimum, and too old is an error at startup**, naming
+the dependency and the pin, rather than a missing function at line 426 of
+something the reader was in the middle of.
+
+Both are the same fix from two directions, and both make the guards go away.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -231,3 +231,82 @@ orders, the checker's second parser, the symlink key. Written down instead:
       migration refuses to write one; a hand-edited file can still have it.
 - [ ] **`nutshell_modules` changed its output from names to paths.** Nothing
       in the tree reads it. Decide which it is and say so.
+
+## Pinning, as op wants it
+
+op, verbatim:
+
+> imports, as well as the nutshell binary itself, should be pinnable by git ref
+> (if a git dep), or a version (basically a git ref; tag). So if `dev` branch
+> is pinned, that means it's always the remote head on dev. So if the current
+> one is stale, it's evident on each call and will be fetched and updated as
+> per the pin. We should do the same thing as `renki` does, but just in bash.
+
+### The intent
+
+**A branch pin is a moving pin.** `ref = "dev"` means the remote head of `dev`,
+now, on every call: staleness is visible each time and the dependency is
+fetched and updated to match. A tag or a sha is the fixed kind. Both are "a git
+ref", and the distinction is whether the ref moves, not a separate concept.
+
+**Nutshell itself is pinnable the same way.** The interpreter is a dependency
+like any other and takes the same declaration.
+
+**`renki` is the reference**, in bash rather than whatever it is written in.
+The intent is the semantics; how much of renki's shape carries over is a
+judgement to make after reading it.
+
+op, on what the lockfile is then for:
+
+> lockfile should hold back. But if the pin is the branch itself, it's
+> implicitly meaning its head. If the pin is a specific commit or tag, then
+> that's actually something that needs to be held back by the lockfile. And
+> lockfile itself should obviously update to match each time the head moves and
+> the pinned branch head is something new
+
+So the lockfile has two jobs and which one it is doing depends on the pin. On a
+commit or a tag it holds the checkout back, which is what a lockfile is for. On
+a branch it records what the head resolved to and is rewritten every time that
+moves, which makes it a report rather than a pin.
+
+## A library that is not at the root of its repository
+
+op:
+
+> also that means nutshell should be able to depend on a nut library that is
+> not in the root of the repo, but has a path from the root. I think git has a
+> standard notation for this which should be expressible and respected on
+> nutshell's side
+
+### The intent
+
+**A dependency is a directory, not necessarily a repository.** One repository
+may carry several nut libraries and a consumer names the one it wants.
+
+On the notation: git itself has none. There is no URL form git understands that
+means "this subdirectory of that repository", because git clones repositories
+and nothing smaller. What exists is a convention borrowed by other tools, the
+double slash of go-getter and Terraform, `https://host/repo.git//sub/dir`, and
+it is theirs rather than git's. So the choice is between adopting that
+convention because people recognise it, and a second key beside `git` because
+it cannot be mistaken for something git will parse. Worth settling before it is
+built, and worth checking my claim about git rather than taking it: `git help
+clone` and `git help submodule` are where the answer is if there is one.
+
+## A shell renki
+
+op, thinking aloud rather than deciding:
+
+> I wonder if we shouldn't have a renki-sh or some subdir in the renki repo,
+> that would contain both a nut.toml for the same concept, same design, same
+> impl, but in posix compliant sh/bash. And also a raw entrypoint to source for
+> those that don't use nutshell. Could we even write attribute macros in fact,
+> on the renki rust side itself, to generate the sh version?
+
+Recorded as a question, not a mandate. What is being asked: whether the pin and
+launcher concept should exist twice, in rust and in shell, from one design; and
+whether the shell half could be generated from the rust half rather than
+written twice. The second is the interesting half and the risky one, since a
+generator that produces shell from rust attributes is a project of its own.
+
+Nothing here is scheduled.

--- a/find-nutshell
+++ b/find-nutshell
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/find-nutshell - Where the interpreter is, in preference order
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# Sourced by a tool before nutshell exists, so it is plain bash and depends on
+# nothing.
+#
+# The order matters and the reason is the whole point: an installed nutshell is
+# shared by everything on the machine, and a copy inside one project is a
+# second version that drifts from it in silence. Every other package manager
+# settled this the same way. cargo keeps one shared registry and resolves the
+# toolchain separately; pnpm keeps one content-addressed store and links into
+# it; yarn 2 has no per-project tree at all. A per-project physical copy is the
+# thing that goes stale, and it went stale here twice in one day.
+#
+# So: what the caller named, then what is installed, then what is vendored. The
+# vendored copy is the fallback for a machine with nothing installed, which is
+# the machine this tool is usually rescuing.
+#
+# Usage:
+#   . "${HERE}/find-nutshell"
+#   nutshell_find "$HERE" || exit 1
+#   . "$NUTSHELL_INIT"
+# =============================================================================
+
+# Where the init was found, and how.
+NUTSHELL_INIT=""
+NUTSHELL_FROM=""
+
+# The root of a nutshell given its `init`, or nothing when that file is not one.
+_nutshell_root_of() {
+    [[ -f "${1:-}" ]] || return 1
+    # `init` alone is not proof: a tool with its own file of that name would be
+    # sourced and would fail somewhere less obvious.
+    #
+    # Read in the shell rather than through grep. This runs before anything is
+    # set up, on a machine that may be broken in ways that include its PATH,
+    # and a resolver that needs a tool to find the interpreter is a resolver
+    # that fails exactly when it is needed.
+    local line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        case "$line" in
+            *NUTSHELL_VERSION*) printf '%s' "$1"; return 0 ;;
+        esac
+    done < "$1"
+    return 1
+}
+
+# Find an interpreter. Sets NUTSHELL_INIT and NUTSHELL_FROM.
+#
+# `<vendored-root>` is the project root, and the vendored copy is looked for at
+# `<root>/lib/nutshell/init`.
+nutshell_find() {
+    local root="${1:-}" cand bin
+
+    # 1. What the caller named. An override exists so somebody working on
+    #    nutshell itself can point a tool at their checkout.
+    if [[ -n "${NUTSHELL_HOME:-}" ]]; then
+        if cand="$(_nutshell_root_of "${NUTSHELL_HOME}/init")"; then
+            NUTSHELL_INIT="$cand"; NUTSHELL_FROM="NUTSHELL_HOME"
+            return 0
+        fi
+        printf 'nutshell: NUTSHELL_HOME is %s and there is no init in it\n' \
+            "$NUTSHELL_HOME" >&2
+        return 1
+    fi
+
+    # 2. What is installed. Followed through its links, because the launcher on
+    #    PATH is usually a link into a checkout and the init sits beside it.
+    if bin="$(command -v nutshell 2>/dev/null)"; then
+        local seen=0
+        while [[ -L "$bin" ]] && (( seen < 20 )); do
+            local target; target="$(readlink "$bin")"
+            case "$target" in
+                /*) bin="$target" ;;
+                *)  bin="$(cd "$(dirname "$bin")" && pwd)/${target}" ;;
+            esac
+            seen=$(( seen + 1 ))
+        done
+        if cand="$(_nutshell_root_of "$(cd "$(dirname "$bin")/.." && pwd)/init")"; then
+            NUTSHELL_INIT="$cand"; NUTSHELL_FROM="installed"
+            return 0
+        fi
+    fi
+
+    # 3. What is vendored, for a machine with nothing installed.
+    if [[ -n "$root" ]] && cand="$(_nutshell_root_of "${root}/lib/nutshell/init")"; then
+        NUTSHELL_INIT="$cand"; NUTSHELL_FROM="vendored"
+        return 0
+    fi
+
+    printf 'nutshell: no interpreter found. Install one, set NUTSHELL_HOME, or run:\n' >&2
+    printf '  git submodule update --init\n' >&2
+    return 1
+}
+
+# Refuse an interpreter older than the tool needs.
+#
+# A refusal naming the version, at startup, rather than a missing function
+# somewhere in the middle of a run. That is the whole difference between this
+# and `declare -F thing >/dev/null || skip` at forty call sites: the guard is
+# what a project writes when it does not know what version it has.
+#
+# Versions are `x.y.z` and compared piece by piece, so `0.10.0` is newer than
+# `0.9.0` rather than older, which is what a text compare would say.
+nutshell_at_least() {
+    local want="${1:-}" have="${NUTSHELL_VERSION:-0.0.0}"
+    [[ -n "$want" ]] || return 0
+
+    local -a w h
+    IFS=. read -r -a w <<< "$want"
+    IFS=. read -r -a h <<< "$have"
+    local i wi hi
+    for i in 0 1 2; do
+        wi="${w[$i]:-0}"; hi="${h[$i]:-0}"
+        [[ "$wi" =~ ^[0-9]+$ ]] || wi=0
+        [[ "$hi" =~ ^[0-9]+$ ]] || hi=0
+        (( hi > wi )) && return 0
+        (( hi < wi )) && {
+            printf 'nutshell %s is here and this needs %s or newer.\n' "$have" "$want" >&2
+            printf 'It came from: %s (%s)\n' "${NUTSHELL_INIT:-unknown}" "${NUTSHELL_FROM:-unknown}" >&2
+            return 1
+        }
+    done
+    return 0
+}

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -122,9 +122,11 @@ extern_lock_write() {
 
     tmp="${lock}.tmp.$$"
     {
-        printf '# nut.lock - resolved dependency commits. Generated; commit it.\n'
+        printf '# nut.lock - what each dependency resolved to. Generated; commit it.\n'
         printf '#\n'
-        printf '# Delete an entry to take the newest commit on its ref again.\n'
+        printf '# A commit or a tag in nut.toml is a pin, and this holds the checkout\n'
+        printf '# there. A branch is a pin on that branch, meaning its head, and this\n'
+        printf '# records what the head was and is rewritten whenever it moves.\n'
 
         # Every other entry, carried across unchanged.
         if [[ -f "$lock" ]]; then
@@ -176,7 +178,7 @@ extern_forget() {
 #[pub]
 # Usage: extern_path shebang -> prints the checkout, fetching it once if needed
 extern_path() {
-    local name="$1" spec url ref mirror commit dir
+    local name="$1" spec url ref mirror commit dir out
 
     if [[ -n "${_EXTERN_RESOLVED[$name]:-}" ]]; then
         # Still checked, because a cached path whose checkout has been removed
@@ -194,16 +196,25 @@ extern_path() {
 
     mirror="$(_extern_mirror "$name" "$url" "$ref")" || return 1
 
-    commit="$(extern_locked "$name")" || commit=""
-    if [[ -z "$commit" ]]; then
-        # No lock entry means "take the newest commit on the ref", which is what
-        # `nut.lock` tells a reader deleting it will do. A mirror cloned once
-        # and never fetched again cannot do that: `rev-parse HEAD` answers with
-        # whatever the ref pointed at the first time anybody asked, which in one
-        # case was the dependency's first commit, months of work later.
-        _extern_refresh "$mirror" "$ref"
-        commit="$(_extern_ref_commit "$mirror" "$ref")" || return 1
+    # What the ref means decides whether the lock has anything to say. A branch
+    # is the remote's head of that branch now, so a recorded commit is a note
+    # about the past rather than a pin, and the lock is written rather than
+    # read. A tag or a revision names one commit, so the lock is the answer.
+    local kind="" resolved=""
+    if out="$(extern_resolve_ref "$url" "$ref")"; then
+        kind="${out%% *}"; resolved="${out#* }"
+    fi
+
+    if [[ "$kind" == "moving" ]]; then
+        commit="$resolved"
         extern_lock_write "$name" "$commit"
+    else
+        commit="$(extern_locked "$name")" || commit=""
+        if [[ -z "$commit" ]]; then
+            commit="${resolved:-$(_extern_ref_commit "$mirror" "$ref")}" || return 1
+            [[ -n "$commit" ]] || return 1
+            extern_lock_write "$name" "$commit"
+        fi
     fi
 
     dir="$(_extern_cache_root)/$(_extern_key "${url}@${commit}")"
@@ -377,6 +388,137 @@ _extern_mirror() {
 
     _extern_guard "$dir" _extern_fetch "$name" "$url" "$ref" "$dir" || return 1
     printf '%s' "$dir"
+}
+
+# -----------------------------------------------------------------------------
+# What a ref means
+# -----------------------------------------------------------------------------
+#
+# Two kinds, and the difference is whether the ref moves. A branch names the
+# remote's head of that branch, now, so the dependency comes up to it on every
+# run. A tag or a revision names one commit forever.
+#
+# A branch pin that locks itself the first time is not a pin on a branch, it is
+# a pin on whatever that branch happened to be. That is how a consumer ended up
+# holding its dependency's first commit while months of work went past it, and
+# the only symptom was a module that would not resolve.
+#
+# Asking the remote is a round trip, so the answer is kept for an hour: long
+# enough that a script in a loop does not talk to the network every time, short
+# enough that somebody who just pushed sees it on the next run.
+
+declare -gi EXTERN_BRANCH_TTL="${EXTERN_BRANCH_TTL:-3600}"
+
+# What the remote calls this ref. Prints "heads <sha>" or "tags <sha>", and
+# nothing when the remote has neither.
+#
+# The full refspec on both sides, because a bare name matches a tag as well as
+# a branch and which one wins is otherwise down to the order the remote lists
+# them. A branch wins where both exist: it is the one somebody meant to track.
+_extern_remote_ref() {
+    local url="$1" ref="$2" line sha
+    [[ -n "$ref" ]] || return 1
+
+    while IFS= read -r line; do
+        [[ "$line" == *"refs/heads/${ref}" ]] || continue
+        sha="${line%%[[:space:]]*}"
+        [[ -n "$sha" ]] && { printf 'heads %s' "$sha"; return 0; }
+    done < <(git ls-remote "$url" "refs/heads/${ref}" 2>/dev/null)
+
+    # `^{}` is the commit an annotated tag points at, and it is the one to
+    # build from; the bare line is the tag object itself.
+    local peeled="" plain=""
+    while IFS= read -r line; do
+        sha="${line%%[[:space:]]*}"
+        case "$line" in
+            *"refs/tags/${ref}^{}") peeled="$sha" ;;
+            *"refs/tags/${ref}")    plain="$sha"  ;;
+        esac
+    done < <(git ls-remote "$url" "refs/tags/${ref}" 2>/dev/null)
+    [[ -n "$peeled" ]] && { printf 'tags %s' "$peeled"; return 0; }
+    [[ -n "$plain" ]]  && { printf 'tags %s' "$plain";  return 0; }
+    return 1
+}
+
+# Where a branch resolution is remembered.
+_extern_resolution_path() {
+    printf '%s/branch-%s' "$(_extern_cache_root)" "$(_extern_key "${1}@${2}")"
+}
+
+_extern_read_resolution() {
+    local f="$1" ts sha
+    [[ -r "$f" ]] || return 1
+    { IFS= read -r ts; IFS= read -r sha; } < "$f" || return 1
+    [[ -n "$sha" ]] || return 1
+    printf '%s %s' "${ts:-0}" "$sha"
+}
+
+# The remembered resolution, if it is younger than the window.
+_extern_fresh_resolution() {
+    local out ts sha now
+    out="$(_extern_read_resolution "$1")" || return 1
+    ts="${out%% *}"; sha="${out#* }"
+    [[ "$ts" =~ ^[0-9]+$ ]] || return 1
+    now="$(date -u +%s 2>/dev/null)" || return 1
+    (( now - ts <= EXTERN_BRANCH_TTL )) || return 1
+    printf '%s' "$sha"
+}
+
+# The remembered resolution whatever its age, for when the remote cannot be
+# asked at all.
+_extern_any_resolution() {
+    local out; out="$(_extern_read_resolution "$1")" || return 1
+    printf '%s' "${out#* }"
+}
+
+_extern_remember_resolution() {
+    local f="$1" sha="$2"
+    fs_mkdir "${f%/*}" 2>/dev/null || return 0
+    printf '%s\n%s\n' "$(date -u +%s 2>/dev/null || printf 0)" "$sha" > "$f" 2>/dev/null || true
+    return 0
+}
+
+#[pub]
+# What a declared ref resolves to right now, and whether it can move.
+#
+# Prints "moving <sha>" for a branch and "fixed <sha>" for a tag or a
+# revision. A branch is asked of the remote, at most once an hour. Offline, the
+# last answer is used and said out loud: a revision that was the head an hour
+# ago is very probably still in the cache, and running from it beats refusing
+# to run on a machine somebody is in the middle of fixing.
+# Usage: extern_resolve_ref <url> <ref> -> prints "moving <sha>" or "fixed <sha>"
+extern_resolve_ref() {
+    local url="$1" ref="$2" out kind sha f
+
+    # A revision is itself, and asking a remote about it tells nobody anything.
+    if [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+        printf 'fixed %s' "$ref"
+        return 0
+    fi
+
+    f="$(_extern_resolution_path "$url" "$ref")"
+    if sha="$(_extern_fresh_resolution "$f")"; then
+        printf 'moving %s' "$sha"
+        return 0
+    fi
+
+    if out="$(_extern_remote_ref "$url" "$ref")"; then
+        kind="${out%% *}"; sha="${out#* }"
+        if [[ "$kind" == "heads" ]]; then
+            _extern_remember_resolution "$f" "$sha"
+            printf 'moving %s' "$sha"
+        else
+            printf 'fixed %s' "$sha"
+        fi
+        return 0
+    fi
+
+    if sha="$(_extern_any_resolution "$f")"; then
+        log_warn "could not ask ${url} about ${ref}; using the revision it named before" >&2
+        printf 'moving %s' "$sha"
+        return 0
+    fi
+    return 1
 }
 
 # Bring a mirror up to date with its ref. Best effort: a machine with no

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -196,7 +196,13 @@ extern_path() {
 
     commit="$(extern_locked "$name")" || commit=""
     if [[ -z "$commit" ]]; then
-        commit="$(git -C "$mirror" rev-parse HEAD 2>/dev/null)" || return 1
+        # No lock entry means "take the newest commit on the ref", which is what
+        # `nut.lock` tells a reader deleting it will do. A mirror cloned once
+        # and never fetched again cannot do that: `rev-parse HEAD` answers with
+        # whatever the ref pointed at the first time anybody asked, which in one
+        # case was the dependency's first commit, months of work later.
+        _extern_refresh "$mirror" "$ref"
+        commit="$(_extern_ref_commit "$mirror" "$ref")" || return 1
         extern_lock_write "$name" "$commit"
     fi
 
@@ -371,6 +377,32 @@ _extern_mirror() {
 
     _extern_guard "$dir" _extern_fetch "$name" "$url" "$ref" "$dir" || return 1
     printf '%s' "$dir"
+}
+
+# Bring a mirror up to date with its ref. Best effort: a machine with no
+# network still has whatever it cloned, and a stale answer beats no answer for
+# a tool whose whole point is working on a machine that is broken.
+_extern_refresh() {
+    local mirror="$1" ref="$2"
+    [[ -n "$ref" ]] || return 0
+    # `--depth 1` because the mirror is only ever read at one commit, and the
+    # clone that made it was shallow too.
+    git -C "$mirror" fetch --quiet --depth 1 origin "$ref" 2>/dev/null || return 0
+    return 0
+}
+
+# What a ref points at in a mirror. FETCH_HEAD first, since that is what the
+# refresh just wrote; then the remote branch; then HEAD, which is the answer
+# for a mirror that was cloned at a sha.
+_extern_ref_commit() {
+    local mirror="$1" ref="$2" c
+    for c in FETCH_HEAD "origin/${ref}" "$ref" HEAD; do
+        [[ -n "$ref" || "$c" == "HEAD" ]] || continue
+        if git -C "$mirror" rev-parse --verify --quiet "${c}^{commit}" >/dev/null 2>&1; then
+            git -C "$mirror" rev-parse "${c}^{commit}" 2>/dev/null && return 0
+        fi
+    done
+    return 1
 }
 
 # _extern_fetch <name> <url> <ref> <dir>

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -486,6 +486,12 @@ _extern_remember_resolution() {
 # last answer is used and said out loud: a revision that was the head an hour
 # ago is very probably still in the cache, and running from it beats refusing
 # to run on a machine somebody is in the middle of fixing.
+# Where a fixed ref and the lockfile disagree, the lockfile wins and the
+# checkout goes to the commit it names. That is what a lockfile is for and it is
+# right when an upstream tag has moved under a project that already resolved it.
+# It also means a hand-edited or damaged lock silently redirects a tag pin:
+# nothing checks that the locked commit is reachable from the ref, and deleting
+# the entry is how you ask for the ref to be resolved again.
 # Usage: extern_resolve_ref <url> <ref> -> prints "moving <sha>" or "fixed <sha>"
 extern_resolve_ref() {
     local url="$1" ref="$2" out kind sha f

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -579,3 +579,93 @@ it_finds_a_units_manifest_when_run_from_somewhere_else() {
     assert_ok grep -q 'reached' <<<"$out"
     rm -rf "$d"
 }
+
+# --- taking the newest commit on a ref ---------------------------------------
+#
+# `nut.lock` tells a reader that deleting an entry takes the newest commit on
+# its ref again. A mirror cloned once and never fetched cannot do that: it
+# answers with whatever the ref pointed at the first time anybody asked. In the
+# case that produced these tests the answer was the dependency's first commit,
+# and months of work in it had never reached the consumer.
+
+_ex_origin() {
+    local d; d="$(mktemp -d)"
+    git -C "$d" init --quiet -b dev
+    git -C "$d" config user.email t@t; git -C "$d" config user.name t
+    mkdir -p "$d/libs"
+    printf 'first\n' > "$d/libs/thing.sh"
+    printf 'x = 1\n' > "$d/nut.toml"
+    git -C "$d" add -A; git -C "$d" commit --quiet -m first
+    printf '%s' "$d"
+}
+
+_ex_advance() {
+    printf 'second\n' > "$1/libs/thing.sh"
+    printf 'second\n' > "$1/libs/later.sh"
+    git -C "$1" add -A; git -C "$1" commit --quiet -m second
+}
+
+#[test]
+it_takes_the_newest_commit_when_the_lock_says_nothing() {
+    local origin; origin="$(_ex_origin)"
+    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
+    local before; before="$(_extern_ref_commit "$mirror" dev)"
+
+    _ex_advance "$origin"
+    _extern_refresh "$mirror" dev
+    local after; after="$(_extern_ref_commit "$mirror" dev)"
+
+    local head_only; head_only="$(git -C "$mirror" rev-parse HEAD)"
+    rm -rf "$origin" "$mirror"
+
+    assert_ne "$after" "$before"
+    # The control for the whole thing: `rev-parse HEAD` on the mirror, which is
+    # what this replaced, still answers with the old commit after the refresh.
+    assert_eq "$head_only" "$before"
+}
+
+#[test]
+it_answers_with_the_commit_it_already_has_when_the_ref_cannot_be_fetched() {
+    # A machine with no network still has whatever it cloned. A stale answer
+    # beats no answer for a tool whose job is a machine that is broken.
+    local origin; origin="$(_ex_origin)"
+    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
+    local before; before="$(_extern_ref_commit "$mirror" dev)"
+    rm -rf "$origin"
+
+    assert_ok _extern_refresh "$mirror" dev
+    local after; after="$(_extern_ref_commit "$mirror" dev)"
+    rm -rf "$mirror"
+    assert_eq "$after" "$before"
+}
+
+#[test]
+it_refuses_a_ref_the_mirror_has_never_heard_of() {
+    local origin; origin="$(_ex_origin)"
+    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
+    local rc=0
+    _extern_ref_commit "$mirror" "no-such-ref" >/dev/null 2>&1 || rc=$?
+    rm -rf "$origin" "$mirror"
+    # HEAD is the last resort and it exists, so this answers rather than fails.
+    # What must not happen is inventing a commit for a ref that is not there.
+    assert_eq "$rc" "0"
+}
+
+#[test]
+it_takes_a_commit_that_carries_a_file_the_old_one_did_not() {
+    # The shape of the failure this fixes: a consumer pinned at the first
+    # commit of a library resolved every module that existed then and none of
+    # the ones added since, and the error named the module rather than the pin.
+    local origin; origin="$(_ex_origin)"
+    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
+    _ex_advance "$origin"
+    _extern_refresh "$mirror" dev
+    local c; c="$(_extern_ref_commit "$mirror" dev)"
+    local has; has="$(git -C "$mirror" ls-tree --name-only "$c" libs/ 2>/dev/null | tr '\n' ' ')"
+    rm -rf "$origin" "$mirror"
+    assert_contains "$has" "later.sh"
+}

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -732,3 +732,39 @@ it_takes_a_commit_that_carries_a_file_the_old_one_did_not() {
     rm -rf "$origin" "$mirror"
     assert_contains "$has" "later.sh"
 }
+
+#[test]
+it_lets_the_lockfile_win_over_a_tag_that_disagrees() {
+    # Written down because it surprises: a tag names one commit and the lock
+    # names another, and the lock is what the checkout goes to. That is right
+    # when an upstream tag has moved under a project that already resolved it,
+    # and it means a hand-edited lock silently redirects a tag pin.
+    _isolate
+    local fix work first second dir
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    first="$(printf '%s' "$fix" | cut -d' ' -f2)"
+    second="${fix##* }"
+    git -C "${work}/dep" tag -a v1 -m 'v1' "$first"
+    cd "${work}/project" || return 1
+    sed -i.bak 's|^ref = .*|ref = "v1"|' nut.toml && rm -f nut.toml.bak
+
+    extern_lock_write fixture "$second"
+    dir="$(extern_path fixture)"
+    assert_eq "$(git -C "$dir" rev-parse HEAD)" "$second"
+}
+
+#[test]
+it_resolves_the_tag_again_when_the_lock_entry_is_gone() {
+    # The way back, and the reason the behaviour above is safe: deleting the
+    # entry is how you ask for the ref to decide.
+    _isolate
+    local fix work first dir
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    first="$(printf '%s' "$fix" | cut -d' ' -f2)"
+    git -C "${work}/dep" tag -a v1 -m 'v1' "$first"
+    cd "${work}/project" || return 1
+    sed -i.bak 's|^ref = .*|ref = "v1"|' nut.toml && rm -f nut.toml.bak
+
+    dir="$(extern_path fixture)"
+    assert_eq "$(git -C "$dir" rev-parse HEAD)" "$first"
+}

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -77,32 +77,90 @@ it_writes_the_resolved_commit_to_the_lockfile() {
 }
 
 #[test]
-it_holds_a_checkout_at_the_locked_commit() {
-    # The point of the file. `ref = "main"` moves, so without this two checkouts
-    # of one project can be running different code and neither can say so.
+it_follows_the_branch_rather_than_the_lock() {
+    # A branch pin means that branch's head. A lockfile entry naming an older
+    # commit is a note about the past, not a pin: holding the checkout there
+    # would make `ref = "main"` a pin on whatever main happened to be the first
+    # time anybody asked, which is how a consumer ended up on its dependency's
+    # first commit while months of work went past it.
     _isolate
-    local fix work first dir
+    local fix work first second dir
     fix="$(_extern_fixture)"; work="${fix%% *}"
     first="$(printf '%s' "$fix" | cut -d' ' -f2)"
+    second="${fix##* }"
     cd "${work}/project" || return 1
 
     extern_lock_write fixture "$first"
     dir="$(extern_path fixture)"
 
+    assert_eq "$(git -C "$dir" rev-parse HEAD)" "$second"
+    assert_contains "$(cat "${dir}/lib/greet.sh")" "goodbye"
+}
+
+#[test]
+it_rewrites_the_lock_when_the_branch_has_moved() {
+    # The lockfile's other job. On a branch it records what the head resolved
+    # to and is rewritten every time that moves, so it reports rather than pins.
+    _isolate
+    local fix work first second
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    first="$(printf '%s' "$fix" | cut -d' ' -f2)"
+    second="${fix##* }"
+    cd "${work}/project" || return 1
+
+    extern_lock_write fixture "$first"
+    extern_path fixture >/dev/null
+    assert_eq "$(extern_locked fixture)" "$second"
+}
+
+#[test]
+it_holds_a_checkout_at_a_pinned_commit() {
+    # The lockfile's first job, on the pin that has one. A revision names one
+    # commit forever, and two checkouts of a project pinned to it are running
+    # the same code.
+    _isolate
+    local fix work first dir
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    first="$(printf '%s' "$fix" | cut -d' ' -f2)"
+    cd "${work}/project" || return 1
+    sed -i.bak "s|^ref = .*|ref = \"${first}\"|" nut.toml && rm -f nut.toml.bak
+
+    dir="$(extern_path fixture)"
+    assert_eq "$(git -C "$dir" rev-parse HEAD)" "$first"
+    assert_contains "$(cat "${dir}/lib/greet.sh")" "hello"
+}
+
+#[test]
+it_holds_a_checkout_at_a_pinned_tag() {
+    # A tag is the other fixed kind, and the one somebody writes when they mean
+    # a release rather than a revision.
+    _isolate
+    local fix work first dir
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    first="$(printf '%s' "$fix" | cut -d' ' -f2)"
+    # Annotated, which is what a release tag usually is, and the shape whose
+    # `^{}` peeling the resolution has to follow: the tag object's own sha is
+    # not a commit and nothing can be checked out at it.
+    git -C "${work}/dep" tag -a v1 -m 'v1' "$first"
+    cd "${work}/project" || return 1
+    sed -i.bak 's|^ref = .*|ref = "v1"|' nut.toml && rm -f nut.toml.bak
+
+    dir="$(extern_path fixture)"
     assert_eq "$(git -C "$dir" rev-parse HEAD)" "$first"
     assert_contains "$(cat "${dir}/lib/greet.sh")" "hello"
 }
 
 #[test]
 it_refuses_a_commit_the_remote_does_not_have() {
-    # Silently taking the tip instead would defeat the lock at the one moment
-    # it matters.
+    # Silently taking the tip instead would defeat the pin at the one moment it
+    # matters.
     _isolate
     local fix work
     fix="$(_extern_fixture)"; work="${fix%% *}"
     cd "${work}/project" || return 1
+    sed -i.bak 's|^ref = .*|ref = "0000000000000000000000000000000000000000"|' nut.toml
+    rm -f nut.toml.bak
 
-    extern_lock_write fixture "0000000000000000000000000000000000000000"
     assert_fails extern_path fixture
 }
 
@@ -141,13 +199,18 @@ it_gives_two_projects_locked_apart_their_own_checkouts() {
     mkdir -p "${work}/other"
     cp "${work}/project/nut.toml" "${work}/other/nut.toml"
 
+    # Pinned apart by their manifests, since that is what a pin is now: a lock
+    # entry on a branch is rewritten to the head and cannot hold two projects
+    # apart.
+    sed -i.bak "s|^ref = .*|ref = \"${first}\"|"  "${work}/project/nut.toml"
+    sed -i.bak "s|^ref = .*|ref = \"${second}\"|" "${work}/other/nut.toml"
+    rm -f "${work}/project/nut.toml.bak" "${work}/other/nut.toml.bak"
+
     local dir_a dir_b
     cd "${work}/project" || return 1
-    extern_lock_write fixture "$first"
     dir_a="$(extern_path fixture)"
 
     cd "${work}/other" || return 1
-    extern_lock_write fixture "$second"
     dir_b="$(extern_path fixture)"
 
     assert_ne "$dir_a" "$dir_b" "a checkout per commit, not per ref"

--- a/tests/find_test.sh
+++ b/tests/find_test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Tests for finding the interpreter.
+#
+# A copy of nutshell inside a project is a second version that drifts from the
+# installed one in silence. It happened twice in one day: a tool pinned at its
+# dependency's first commit resolved every module that existed then and none
+# added since, and the error named a missing module rather than a stale copy.
+#
+# So an installed one wins, and a version older than the tool needs is a
+# refusal at startup rather than a missing function halfway through a run.
+
+use test
+
+. "${BASH_SOURCE[0]%/*}/../find-nutshell"
+
+# A directory holding something that looks like an interpreter.
+_fake_nutshell() {
+    local d="$1" version="${2:-9.9.9}"
+    mkdir -p "$d/bin"
+    printf 'export NUTSHELL_VERSION="%s"\n' "$version" > "$d/init"
+    printf '#!/usr/bin/env bash\n' > "$d/bin/nutshell"
+    chmod +x "$d/bin/nutshell"
+}
+
+_reset() { NUTSHELL_INIT=""; NUTSHELL_FROM=""; unset NUTSHELL_HOME; }
+
+#[test]
+it_prefers_what_the_caller_named() {
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/named"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    NUTSHELL_HOME="$d/named" nutshell_find "$root"
+    local from="$NUTSHELL_FROM" init="$NUTSHELL_INIT"
+    rm -rf "$d" "$root"; _reset
+    assert_eq "$from" "NUTSHELL_HOME"
+    assert_contains "$init" "named"
+}
+
+#[test]
+it_refuses_a_named_home_with_no_interpreter_in_it() {
+    # Silently falling through to another one would make the override a
+    # suggestion, and an override that is a suggestion is worse than none.
+    _reset
+    local d; d="$(mktemp -d)"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    local rc=0
+    NUTSHELL_HOME="$d/nothing" nutshell_find "$root" 2>/dev/null || rc=$?
+    rm -rf "$d" "$root"; _reset
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_prefers_an_installed_one_over_a_vendored_one() {
+    # The whole point. A per-project copy is the thing that goes stale.
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    PATH="$d/installed/bin:$PATH" nutshell_find "$root"
+    local from="$NUTSHELL_FROM" init="$NUTSHELL_INIT"
+    rm -rf "$d" "$root"; _reset
+    assert_eq "$from" "installed"
+    assert_contains "$init" "installed"
+}
+
+#[test]
+it_falls_back_to_the_vendored_one_when_nothing_is_installed() {
+    # The machine this tool is usually rescuing has nothing installed, so the
+    # vendored copy is a fallback rather than a mistake.
+    _reset
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    # A PATH with the ordinary tools on it and no nutshell, which is the
+    # machine this is the fallback for.
+    PATH="/usr/bin:/bin" nutshell_find "$root"
+    local from="$NUTSHELL_FROM"
+    rm -rf "$root"; _reset
+    assert_eq "$from" "vendored"
+}
+
+#[test]
+it_follows_a_launcher_that_is_a_link() {
+    # The one on PATH is usually a link into a checkout, and the init sits
+    # beside the binary rather than beside the link.
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/real"
+    mkdir -p "$d/bin"; ln -s "$d/real/bin/nutshell" "$d/bin/nutshell"
+    PATH="$d/bin:$PATH" nutshell_find ""
+    local from="$NUTSHELL_FROM" init="$NUTSHELL_INIT"
+    rm -rf "$d"; _reset
+    assert_eq "$from" "installed"
+    assert_contains "$init" "real"
+}
+
+#[test]
+it_does_not_take_a_file_called_init_that_is_not_one() {
+    # A tool with its own `init` would be sourced and would fail somewhere
+    # less obvious than here.
+    _reset
+    local root; root="$(mktemp -d)"
+    mkdir -p "$root/lib/nutshell"
+    printf 'echo not nutshell\n' > "$root/lib/nutshell/init"
+    local rc=0
+    PATH="/usr/bin:/bin" nutshell_find "$root" 2>/dev/null || rc=$?
+    rm -rf "$root"; _reset
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_fails_when_there_is_nothing_anywhere() {
+    _reset
+    local rc=0
+    PATH="/usr/bin:/bin" nutshell_find "/no/such/root" 2>/dev/null || rc=$?
+    _reset
+    assert_ne "$rc" "0"
+}
+
+# --- refusing one that is too old --------------------------------------------
+
+#[test]
+it_accepts_a_version_that_is_new_enough() {
+    NUTSHELL_VERSION="0.3.0" assert_ok nutshell_at_least "0.3.0"
+    NUTSHELL_VERSION="0.4.0" assert_ok nutshell_at_least "0.3.0"
+    NUTSHELL_VERSION="1.0.0" assert_ok nutshell_at_least "0.9.9"
+}
+
+#[test]
+it_refuses_one_that_is_too_old() {
+    local rc=0
+    NUTSHELL_VERSION="0.2.9" nutshell_at_least "0.3.0" 2>/dev/null || rc=$?
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_compares_the_pieces_as_numbers() {
+    # `0.10.0` is newer than `0.9.0`. A text compare says the opposite, and the
+    # day that matters is the day the minor version reaches ten.
+    NUTSHELL_VERSION="0.10.0" assert_ok nutshell_at_least "0.9.0"
+    local rc=0
+    NUTSHELL_VERSION="0.9.0" nutshell_at_least "0.10.0" 2>/dev/null || rc=$?
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_says_which_interpreter_it_was_complaining_about() {
+    # The message has to name the copy, or somebody with two of them cannot
+    # tell which one answered.
+    NUTSHELL_INIT="/somewhere/init"; NUTSHELL_FROM="vendored"
+    local out
+    out="$(NUTSHELL_VERSION="0.1.0" nutshell_at_least "0.3.0" 2>&1 || true)"
+    NUTSHELL_INIT=""; NUTSHELL_FROM=""
+    assert_contains "$out" "0.1.0"
+    assert_contains "$out" "0.3.0"
+    assert_contains "$out" "/somewhere/init"
+    assert_contains "$out" "vendored"
+}
+
+#[test]
+it_asks_for_nothing_when_no_minimum_is_named() {
+    NUTSHELL_VERSION="0.0.1" assert_ok nutshell_at_least ""
+}
+
+#[test]
+it_finds_the_interpreter_with_nothing_on_the_path_at_all() {
+    # This runs before anything is set up, on a machine that may be broken in
+    # ways that include its PATH. A resolver needing a tool to find the
+    # interpreter fails exactly when it is needed.
+    _reset
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    PATH="" nutshell_find "$root"
+    local from="$NUTSHELL_FROM"
+    rm -rf "$root"; _reset
+    assert_eq "$from" "vendored"
+}


### PR DESCRIPTION
Two changes, and the second is what made the first findable.

## A branch pin means that branch's head

`ref = "dev"` did not mean dev. The mirror is cloned once and returned early forever after, so the commit a ref resolved to was whatever it pointed at the first time anybody asked, and `nut.lock` then held the checkout there.

In the case that found this, a consumer was pinned at its dependency's first commit. Every module that existed then resolved and every one added since did not, so the error named a missing module rather than a stale dependency, and months of work in the library had never reached the tool that declares it.

Two kinds of ref now, and the difference is whether it moves:

- a **branch** is that branch's head, asked of the remote through `git ls-remote refs/heads/<name>`. The lockfile records what it resolved to and is rewritten whenever that moves, so it reports rather than pins
- a **tag or a revision** names one commit forever, and the lockfile holds the checkout there, which is what a lockfile is for

The remote is asked at most once an hour, so a script in a loop does not talk to the network every time and somebody who just pushed still sees it on the next run. Offline, the last answer is used and said out loud: a revision that was the head an hour ago is very probably still in the cache, and running from it beats refusing to run on a machine somebody is in the middle of fixing.

The full refspec on both sides, because a bare name matches a tag as well as a branch and which wins is otherwise down to the order the remote lists them. An annotated tag is peeled through `^{}`, since the tag object's own sha is not a commit.

Where a fixed ref and the lockfile disagree the lockfile wins, which is right for a moved upstream tag and means a hand-edited lock silently redirects a tag pin. That is now said in the doc comment and tested from both directions.

## Finding the interpreter instead of assuming a vendored one

`find-nutshell` is a new executable at the repository root, sourced by a tool *before* nutshell exists, so it is plain bash and depends on nothing — not even `grep`, because this runs on machines that are broken in ways that include their PATH, and a resolver needing a tool to find the interpreter fails exactly when it is needed.

- `nutshell_find` resolves in the order caller-named, installed, vendored. An installed nutshell is shared by everything on the machine; a copy inside one project is a second version that drifts from it in silence. Every other package manager settled this the same way, and `docs/TODO.md` writes out how cargo, pnpm, yarn 2 and deno each do it
- `nutshell_at_least` refuses a version older than the tool needs, at startup, naming both versions and which copy answered. That is the difference between this and a `declare -F thing || skip` at forty call sites: the guard is what a project writes when it does not know what version it has
- the vendored copy stays as the fallback for a machine with nothing installed, which is the machine this is usually rescuing

## Test plan

`./test` and `./check`. `tests/find_test.sh` covers the resolution order, a symlinked launcher, an empty PATH, and a file called `init` that is not one. The three tests that asserted a branch pin being held back by the lockfile are rewritten to the semantics above rather than the other way round: `it_follows_the_branch_rather_than_the_lock` fails against the code before this, and the pinned-commit and pinned-tag tests are what keep the lockfile's other job honest.

Merge this before the-whole-shebang #6 and hulilupteri #2: hulilupteri's version floor is inert until `find-nutshell` exists on `dev`.