### PR TITLE
feat: do one thing as root, then not be root

### DIFF
--- a/lib.nut
+++ b/lib.nut
@@ -25,6 +25,7 @@ log                      lib/log.sh
 modgraph                 lib/modgraph.sh
 nutshell                 nutshell.sh
 os                       lib/os.sh
+priv                     lib/priv.sh
 prompt                   lib/prompt.sh
 string                   lib/string.sh
 test                     lib/test.sh

--- a/lib/priv.sh
+++ b/lib/priv.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/priv.sh - Doing one thing as root, and then not being root
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# Elevation is a step, not a mode. `priv_run` takes one command, runs that as
+# root, and returns with the caller unchanged. Nothing else in the process
+# becomes root and nothing after it is.
+#
+# The failure this exists to prevent is quiet and it is not one tool's. A
+# program that needs root for one thing, gets it by being started under `sudo`,
+# and then keeps going writes the user's own files as root: their state
+# directory, their cache, their config, their history. It happened here. One
+# tool ended up with two journals, `~/.local/state/<tool>/journal` owned by the
+# person and a second one owned by root, and the person could no longer write
+# the second.
+#
+# Running a whole program under `sudo` is `su` with extra steps. This is the
+# other thing, the one the name always meant: do this, as root, now.
+#
+# Usage:
+#   use priv
+#
+#   priv_run "mount the stick" mount /dev/sda2 /mnt/stick || return 1
+#
+#   # Where a path belongs to the person, ask rather than reading $HOME.
+#   printf '%s/.local/state\n' "$(priv_user_home)"
+# =============================================================================
+
+nut_once || return 0
+
+use log
+
+# Who this actually is, worked out once and before anything elevates.
+#
+# Read at load time on purpose. A caller asking later, from inside something
+# that has already elevated, would be told about root, and the whole point is
+# to answer about the person.
+declare -g PRIV_USER="${PRIV_USER:-}"
+declare -g PRIV_HOME="${PRIV_HOME:-}"
+declare -g PRIV_UID="${PRIV_UID:-}"
+
+_priv_learn_user() {
+    [[ -z "$PRIV_UID" ]] || return 0
+
+    # `SUDO_USER` is set when this process was itself started under sudo, and
+    # then it names the person rather than root. That case is the one this
+    # module is trying to make unnecessary, and it still has to be answered
+    # correctly while it exists.
+    if [[ "$(id -u 2>/dev/null)" == "0" && -n "${SUDO_USER:-}" ]]; then
+        PRIV_USER="$SUDO_USER"
+        PRIV_UID="${SUDO_UID:-}"
+        [[ -n "$PRIV_UID" ]] || PRIV_UID="$(id -u "$PRIV_USER" 2>/dev/null)"
+        PRIV_HOME="$(_priv_home_of "$PRIV_USER")"
+        return 0
+    fi
+
+    PRIV_USER="$(id -un 2>/dev/null)"
+    PRIV_UID="$(id -u 2>/dev/null)"
+    PRIV_HOME="${HOME:-$(_priv_home_of "$PRIV_USER")}"
+}
+
+# A user's home from the password database rather than from the environment,
+# because the environment is what is wrong in the case this is for.
+_priv_home_of() {
+    # Initialised, not merely declared: `local x` leaves it unset, and a caller
+    # running under `set -u` gets an error rather than an empty string.
+    local u="$1" line=""
+    [[ -n "$u" ]] || return 1
+    if command -v getent >/dev/null 2>&1; then
+        line="$(getent passwd "$u" 2>/dev/null)" || line=""
+    fi
+    if [[ -z "$line" && -r /etc/passwd ]]; then
+        while IFS= read -r line; do
+            [[ "$line" == "${u}:"* ]] && break
+            line=""
+        done < /etc/passwd
+    fi
+    if [[ -n "$line" ]]; then
+        # name:passwd:uid:gid:gecos:home:shell
+        local IFS=:
+        # shellcheck disable=SC2206
+        local -a f=($line)
+        [[ -n "${f[5]:-}" ]] && { printf '%s' "${f[5]}"; return 0; }
+    fi
+    # A mac keeps its users elsewhere, and `dscl` is how you ask.
+    if command -v dscl >/dev/null 2>&1; then
+        local h; h="$(dscl . -read "/Users/${u}" NFSHomeDirectory 2>/dev/null)" || h=""
+        h="${h#*: }"
+        [[ -n "$h" ]] && { printf '%s' "$h"; return 0; }
+    fi
+    return 1
+}
+
+_priv_learn_user
+
+#[pub]
+# The person who started this, whatever has elevated since.
+# Usage: priv_user -> a name
+priv_user() { _priv_learn_user; printf '%s' "$PRIV_USER"; }
+#[pub]
+# Usage: priv_uid -> a number
+priv_uid()  { _priv_learn_user; printf '%s' "$PRIV_UID"; }
+#[pub]
+# Their home, from the password database rather than from `$HOME`.
+#
+# `$HOME` is exactly what is wrong inside something that elevated, so anything
+# building a path the person will look for asks this instead.
+# Usage: priv_user_home -> a path
+priv_user_home() { _priv_learn_user; printf '%s' "$PRIV_HOME"; }
+
+#[pub]
+# Is this already root?
+# Usage: priv_is_root
+priv_is_root() { [[ "$(id -u 2>/dev/null)" == "0" ]]; }
+
+#[pub]
+# Can this ask for root at all, and how?
+#
+# Prints the command that would do it, or nothing. `doas` as well as `sudo`,
+# because a machine that has chosen one usually does not have the other.
+# Usage: priv_how -> "sudo", "doas", or nothing
+priv_how() {
+    priv_is_root && { printf 'already'; return 0; }
+    local c
+    for c in sudo doas; do
+        command -v "$c" >/dev/null 2>&1 && { printf '%s' "$c"; return 0; }
+    done
+    return 1
+}
+
+#[pub]
+# Would asking for root need a password right now?
+#
+# Answers without asking for one. A caller that wants to warn before a prompt
+# appears, or to decide whether an unattended run can proceed, asks this.
+# Usage: priv_needs_password
+priv_needs_password() {
+    priv_is_root && return 1
+    local how; how="$(priv_how)" || return 0
+    case "$how" in
+        sudo) sudo -n true 2>/dev/null && return 1 ;;
+        doas) doas -n true 2>/dev/null && return 1 ;;
+    esac
+    return 0
+}
+
+#[pub]
+# Run one command as root, then return.
+#
+# The first argument says what it is for, in words, so the log and the prompt
+# both name the thing rather than the mechanism. Everything after it is the
+# command and its arguments, passed through without a shell, so nothing here
+# has to think about quoting and a caller cannot accidentally build one string
+# out of a path with a space in it.
+#
+# Returns whatever the command returned. Refuses, without running anything,
+# when there is no way to elevate, or when a password would be needed and
+# there is no terminal to type it on: a prompt nobody can answer is a program
+# that hangs, and the machines this runs on are often being fixed over a pipe.
+# Usage: priv_run "mount the stick" mount /dev/sda2 /mnt
+priv_run() {
+    local what="${1:-a privileged step}"; shift || true
+    (( $# > 0 )) || { log_error "priv_run: nothing to run"; return 2; }
+
+    if priv_is_root; then
+        "$@"
+        return $?
+    fi
+
+    local how
+    how="$(priv_how)" || {
+        log_error "${what}: this needs root and there is no sudo or doas here"
+        return 2
+    }
+
+    if priv_needs_password && ! _priv_can_prompt; then
+        log_error "${what}: this needs root, and there is no terminal to ask for a password on"
+        return 2
+    fi
+
+    # Said before the prompt appears, so an unexpected password request has a
+    # sentence beside it explaining what asked for it.
+    if priv_needs_password; then
+        log_info "${what}: asking for your password for this one step"
+    fi
+
+    case "$how" in
+        sudo) sudo -- "$@" ;;
+        doas) doas -- "$@" ;;
+        *)    "$@" ;;
+    esac
+}
+
+# Is there a terminal a password could be typed on?
+_priv_can_prompt() {
+    [[ -t 0 || -t 1 || -t 2 ]] && return 0
+    # An askpass helper is a terminal by another name.
+    [[ -n "${SUDO_ASKPASS:-}" ]] && return 0
+    return 1
+}
+
+#[pub]
+# Give a file back to the person after something elevated made it.
+#
+# The other half of the split this module is about. A file root wrote into a
+# place the person owns is a file they cannot change afterwards, and the
+# symptom arrives much later than the cause.
+# Usage: priv_return <path>...
+priv_return() {
+    local u; u="$(priv_user)"
+    [[ -n "$u" && "$u" != "root" ]] || return 0
+    priv_is_root || return 0
+    local p
+    for p in "$@"; do
+        [[ -e "$p" ]] || continue
+        chown -R "$u" "$p" 2>/dev/null || true
+    done
+}

--- a/tests/priv_test.sh
+++ b/tests/priv_test.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# Tests for doing one thing as root and then not being root.
+#
+# The failure this module exists to prevent, from the machine it was written
+# on: a tool needed root to mount a partition, got it by being started under
+# sudo, and then kept going. It ended with two histories,
+# `~/.local/state/<tool>/journal` owned by the person and a second one owned by
+# root, and the person could no longer write the second. Nothing was
+# misconfigured. It asked for root for a reason and then kept it.
+
+use test
+use priv
+
+_priv_reset() { PRIV_USER=""; PRIV_UID=""; PRIV_HOME=""; }
+
+# --- who this is ---------------------------------------------------------------
+
+#[test]
+it_knows_who_started_this() {
+    _priv_reset
+    assert_eq "$(priv_user)" "$(id -un)"
+    assert_eq "$(priv_uid)"  "$(id -u)"
+    _priv_reset
+}
+
+#[test]
+it_answers_with_the_person_not_root_when_run_under_sudo() {
+    # The case this module is trying to make unnecessary, and the one it still
+    # has to answer correctly while it exists.
+    _priv_reset
+    id() { case "$1" in -u) printf '0' ;; -un) printf 'root' ;; *) builtin command id "$@" ;; esac; }
+    SUDO_USER="somebody" SUDO_UID="1234" _priv_learn_user
+    local u="$PRIV_USER" i="$PRIV_UID"
+    unset -f id
+    _priv_reset
+    assert_eq "$u" "somebody"
+    assert_eq "$i" "1234"
+}
+
+#[test]
+it_finds_a_home_without_reading_the_environment() {
+    # `$HOME` is exactly what is wrong inside something that elevated, so the
+    # answer comes from the password database instead.
+    local me; me="$(id -un)"
+    local h; h="$(_priv_home_of "$me")"
+    assert_ne "$h" ""
+    assert_eq "$h" "$HOME"
+}
+
+#[test]
+it_fails_to_find_a_home_for_somebody_who_does_not_exist() {
+    # The control. A lookup that answers for every name would answer wrongly
+    # for the one that matters.
+    assert_fails _priv_home_of "no-such-user-here-at-all"
+}
+
+#[test]
+it_refuses_to_look_up_an_empty_name() {
+    assert_fails _priv_home_of ""
+}
+
+# --- how it would ask ----------------------------------------------------------
+
+#[test]
+it_says_how_it_would_ask() {
+    local how; how="$(priv_how)"
+    # On any machine this runs on: already root, or one of the two askers.
+    case "$how" in already|sudo|doas) assert_ok true ;; *) assert_ok false ;; esac
+}
+
+#[test]
+it_says_it_cannot_ask_when_neither_asker_is_there() {
+    priv_is_root() { return 1; }
+    command() {
+        case "$2" in sudo|doas) return 1 ;; esac
+        builtin command "$@"
+    }
+    local rc=0
+    priv_how >/dev/null 2>&1 || rc=$?
+    unset -f priv_is_root command
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_prefers_sudo_where_both_are_present() {
+    # Not a preference anybody should care about, but it has to be one thing
+    # rather than whichever the loop reached first on that machine.
+    priv_is_root() { return 1; }
+    command() {
+        case "$2" in sudo|doas) return 0 ;; esac
+        builtin command "$@"
+    }
+    local how; how="$(priv_how)"
+    unset -f priv_is_root command
+    assert_eq "$how" "sudo"
+}
+
+#[test]
+it_needs_no_password_when_it_is_already_root() {
+    priv_is_root() { return 0; }
+    local rc=0
+    priv_needs_password || rc=$?
+    unset -f priv_is_root
+    assert_ne "$rc" "0"
+}
+
+# --- running the one thing -----------------------------------------------------
+
+#[test]
+it_runs_the_command_directly_when_already_root() {
+    # No asking where nothing needs to be asked, or every step prompts for a
+    # password that was never required.
+    priv_is_root() { return 0; }
+    local asked=0
+    sudo() { asked=1; return 0; }
+    local out; out="$(priv_run "a thing" printf 'ran')"
+    unset -f priv_is_root sudo
+    assert_eq "$out" "ran"
+    assert_eq "$asked" "0"
+}
+
+#[test]
+it_passes_the_command_through_without_a_shell() {
+    # Arguments, not a string. A path with a space in it is still one path, and
+    # a caller must never have to think about quoting to use this.
+    priv_is_root() { return 0; }
+    local out; out="$(priv_run "a thing" printf '%s|' 'one two' 'three')"
+    unset -f priv_is_root
+    assert_eq "$out" "one two|three|"
+}
+
+#[test]
+it_returns_what_the_command_returned() {
+    priv_is_root() { return 0; }
+    local rc=0
+    priv_run "a thing" false || rc=$?
+    unset -f priv_is_root
+    assert_eq "$rc" "1"
+}
+
+#[test]
+it_asks_for_one_command_and_not_for_a_shell() {
+    # The whole distinction. What is elevated is this command, and the caller
+    # is the same user after it as before.
+    priv_is_root() { return 1; }
+    priv_how() { printf 'sudo'; }
+    priv_needs_password() { return 1; }
+    local got=""
+    sudo() { got="$*"; }
+    priv_run "mount the stick" mount /dev/sdz2 /mnt/stick
+    unset -f priv_is_root priv_how priv_needs_password sudo
+    assert_eq "$got" "-- mount /dev/sdz2 /mnt/stick"
+    assert_fails grep -q ' -s\| bash\| sh ' <<<"$got"
+}
+
+#[test]
+it_refuses_when_there_is_no_way_to_ask() {
+    priv_is_root() { return 1; }
+    priv_how() { return 1; }
+    local rc=0 out
+    out="$(priv_run "a thing" true 2>&1)" || rc=$?
+    unset -f priv_is_root priv_how
+    assert_eq "$rc" "2"
+    assert_contains "$out" "a thing"
+}
+
+#[test]
+it_refuses_rather_than_hanging_on_a_prompt_nobody_can_answer() {
+    # These machines are often being fixed over a pipe. A password prompt with
+    # no terminal behind it is a program that stops forever.
+    priv_is_root() { return 1; }
+    priv_how() { printf 'sudo'; }
+    priv_needs_password() { return 0; }
+    _priv_can_prompt() { return 1; }
+    local ran=0
+    sudo() { ran=1; }
+    local rc=0
+    priv_run "a thing" true >/dev/null 2>&1 || rc=$?
+    unset -f priv_is_root priv_how priv_needs_password _priv_can_prompt sudo
+    assert_eq "$rc" "2"
+    assert_eq "$ran" "0"
+}
+
+#[test]
+it_runs_when_there_is_a_terminal_to_ask_on() {
+    # The control for the refusal above.
+    priv_is_root() { return 1; }
+    priv_how() { printf 'sudo'; }
+    priv_needs_password() { return 0; }
+    _priv_can_prompt() { return 0; }
+    local ran=0
+    sudo() { ran=1; }
+    priv_run "a thing" true >/dev/null 2>&1
+    unset -f priv_is_root priv_how priv_needs_password _priv_can_prompt sudo
+    assert_eq "$ran" "1"
+}
+
+#[test]
+it_says_what_it_is_asking_for_before_the_prompt_appears() {
+    # An unexpected password request wants a sentence beside it naming what
+    # asked, or somebody types their password into a mystery.
+    priv_is_root() { return 1; }
+    priv_how() { printf 'sudo'; }
+    priv_needs_password() { return 0; }
+    _priv_can_prompt() { return 0; }
+    sudo() { return 0; }
+    local out; out="$(priv_run "mount the stick" true 2>&1)"
+    unset -f priv_is_root priv_how priv_needs_password _priv_can_prompt sudo
+    assert_contains "$out" "mount the stick"
+}
+
+#[test]
+it_refuses_a_call_with_nothing_to_run() {
+    local rc=0
+    priv_run "a thing" >/dev/null 2>&1 || rc=$?
+    assert_eq "$rc" "2"
+}
+
+# --- giving the file back ------------------------------------------------------
+
+#[test]
+it_gives_a_file_back_to_the_person() {
+    # The other half of the split. A file root wrote where the person keeps
+    # theirs is a file they cannot change, and the symptom arrives much later
+    # than the cause.
+    priv_is_root() { return 0; }
+    priv_user() { printf 'somebody'; }
+    local got=""
+    chown() { got="$*"; return 0; }
+    local d; d="$(mktemp -d)"; : > "$d/f"
+    priv_return "$d/f"
+    unset -f priv_is_root priv_user chown
+    rm -rf "$d"
+    assert_contains "$got" "somebody"
+}
+
+#[test]
+it_does_not_give_anything_back_when_it_was_never_root() {
+    priv_is_root() { return 1; }
+    priv_user() { printf 'somebody'; }
+    local called=0
+    chown() { called=1; }
+    local d; d="$(mktemp -d)"; : > "$d/f"
+    priv_return "$d/f"
+    unset -f priv_is_root priv_user chown
+    rm -rf "$d"
+    assert_eq "$called" "0"
+}
+
+#[test]
+it_does_not_give_anything_back_to_root() {
+    # Nothing to hand over when root is who started it.
+    priv_is_root() { return 0; }
+    priv_user() { printf 'root'; }
+    local called=0
+    chown() { called=1; }
+    local d; d="$(mktemp -d)"; : > "$d/f"
+    priv_return "$d/f"
+    unset -f priv_is_root priv_user chown
+    rm -rf "$d"
+    assert_eq "$called" "0"
+}
+
+#[test]
+it_ignores_a_path_that_is_not_there() {
+    priv_is_root() { return 0; }
+    priv_user() { printf 'somebody'; }
+    local called=0
+    chown() { called=1; }
+    priv_return "/no/such/path/at/all"
+    unset -f priv_is_root priv_user chown
+    assert_eq "$called" "0"
+}


### PR DESCRIPTION
Elevation is a step, not a mode. `priv_run` takes one command, runs that as root, and returns with the caller unchanged.

The failure it prevents is quiet and it is not one tool's. A program that needs root for one thing, gets it by being started under `sudo`, and then keeps going writes the user's own files as root. It happened while this was being written, and the evidence is on the machine:

```
~/.local/state/hulilupteri/journal   orgrinrt  22 lines
/run/hulilupteri/home/journal        root      10 lines   <- test -w says no
```

Two histories of one tool, split by which user happened to run it, and the person can no longer write the second. Nothing was misconfigured. It asked for root for a reason and then kept it, which is the whole of the defect.

- `priv_run "what this is for" cmd args...` runs one command as root. The command goes through as arguments and never as a string, so a path with a space in it is one path and a caller never thinks about quoting
- `priv_user`, `priv_uid` and `priv_user_home` answer about the person whatever has elevated since, reading the password database rather than `$HOME`, because `$HOME` is exactly what is wrong inside something that elevated. `SUDO_USER` is honoured, since that case has to be answered correctly while it still exists
- `sudo -n` decides whether a password is needed before one is asked for, and a caller with no terminal to type on is refused rather than left on a prompt nobody can answer. These machines are often being fixed over a pipe
- what is being elevated is named, in words, before the prompt appears, so an unexpected password request has a sentence beside it explaining what asked
- `priv_return` hands a file back afterwards, which is the other half of the same split
- `doas` as well as `sudo`, because a machine that chose one usually lacks the other

## Test plan

`./test` and `./check`. `tests/priv_test.sh` drives both directions of every branch: already root, no way to ask, a password needed with no terminal, a password needed with one. The tests that matter most are the negatives, that nothing is elevated when there is no way to ask and that what reaches `sudo` is one command rather than a shell.