### PR TITLE
fix: resolve to an interpreter that can run the caller

### DIFF
--- a/find-nutshell
+++ b/find-nutshell
@@ -49,17 +49,28 @@ _nutshell_root_of() {
     return 1
 }
 
-# Find an interpreter. Sets NUTSHELL_INIT and NUTSHELL_FROM.
+# Find an interpreter that satisfies the caller. Sets NUTSHELL_INIT and
+# NUTSHELL_FROM.
 #
 # `<vendored-root>` is the project root, and the vendored copy is looked for at
-# `<root>/lib/nutshell/init`.
+# `<root>/lib/nutshell/init`. `<minimum>` is the oldest version the caller can
+# use, and a candidate older than it is skipped rather than taken.
+#
+# Skipped rather than taken is the whole of it. Preferring an installed
+# interpreter is right; preferring one that cannot run the caller is not, and
+# taking it and failing afterwards is how a tool ends up reporting a missing
+# function instead of a version. This is what rustup does for cargo: resolve to
+# something that satisfies the requirement, not to whichever came first.
 nutshell_find() {
-    local root="${1:-}" cand bin
+    local root="${1:-}" want="${2:-}" cand bin
 
     # 1. What the caller named. An override exists so somebody working on
     #    nutshell itself can point a tool at their checkout.
     if [[ -n "${NUTSHELL_HOME:-}" ]]; then
         if cand="$(_nutshell_root_of "${NUTSHELL_HOME}/init")"; then
+            # What the caller named is taken even when it is too old. An
+            # override that is quietly ignored is worse than one that fails,
+            # and somebody working on nutshell itself needs it honoured.
             NUTSHELL_INIT="$cand"; NUTSHELL_FROM="NUTSHELL_HOME"
             return 0
         fi
@@ -81,8 +92,14 @@ nutshell_find() {
             seen=$(( seen + 1 ))
         done
         if cand="$(_nutshell_root_of "$(cd "$(dirname "$bin")/.." && pwd)/init")"; then
-            NUTSHELL_INIT="$cand"; NUTSHELL_FROM="installed"
-            return 0
+            if _nutshell_satisfies "$cand" "$want"; then
+                NUTSHELL_INIT="$cand"; NUTSHELL_FROM="installed"
+                return 0
+            fi
+            # Said out loud. Silently falling through to the vendored copy
+            # would hide exactly the version skew this is here to surface.
+            printf 'nutshell: the installed one at %s is %s and this needs %s; using the vendored copy\n' \
+                "$cand" "$(_nutshell_version_of "$cand")" "$want" >&2
         fi
     fi
 
@@ -95,6 +112,47 @@ nutshell_find() {
     printf 'nutshell: no interpreter found. Install one, set NUTSHELL_HOME, or run:\n' >&2
     printf '  git submodule update --init\n' >&2
     return 1
+}
+
+# The version an interpreter reports, without loading it. Reading the file
+# rather than sourcing it, because a candidate that is about to be rejected must
+# not be allowed to run first.
+_nutshell_version_of() {
+    local init="$1" line
+    [[ -r "$init" ]] || return 1
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        case "$line" in
+            *NUTSHELL_VERSION=*)
+                line="${line#*NUTSHELL_VERSION=}"
+                # The quotes come off first: trimming at the first character
+                # that is not a digit or a dot would trim at the opening quote
+                # and answer with nothing.
+                line="${line#[\"\']}"
+                line="${line%%[!0-9.]*}"
+                [[ -n "$line" ]] || continue
+                printf '%s' "$line"; return 0 ;;
+        esac
+    done < "$init"
+    return 1
+}
+
+# Is this candidate new enough? No minimum means anything will do.
+_nutshell_satisfies() {
+    local init="$1" want="${2:-}" have
+    [[ -n "$want" ]] || return 0
+    have="$(_nutshell_version_of "$init")" || return 1
+    local -a w h
+    IFS=. read -r -a w <<< "$want"
+    IFS=. read -r -a h <<< "$have"
+    local i wi hi
+    for i in 0 1 2; do
+        wi="${w[$i]:-0}"; hi="${h[$i]:-0}"
+        [[ "$wi" =~ ^[0-9]+$ ]] || wi=0
+        [[ "$hi" =~ ^[0-9]+$ ]] || hi=0
+        (( hi > wi )) && return 0
+        (( hi < wi )) && return 1
+    done
+    return 0
 }
 
 # Refuse an interpreter older than the tool needs.

--- a/init
+++ b/init
@@ -26,7 +26,7 @@ _NUTSHELL_ROOT="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 
 # Export for use by modules
 export NUTSHELL_ROOT="${_NUTSHELL_ROOT}"
-export NUTSHELL_VERSION="0.3.0"
+export NUTSHELL_VERSION="0.4.0"
 
 # Script identity belongs to the interpreter invocation, not to ancestry. The
 # interpreter exports NUTSHELL_SCRIPT and NUTSHELL_SCRIPT_DIR after this file

--- a/tests/find_test.sh
+++ b/tests/find_test.sh
@@ -170,3 +170,102 @@ it_finds_the_interpreter_with_nothing_on_the_path_at_all() {
     rm -rf "$root"; _reset
     assert_eq "$from" "vendored"
 }
+
+# --- resolving to something that can actually run the caller -------------------
+#
+# Both copies on the machine this was written on reported `0.3.0` while only one
+# had the feature the caller needed, so a floor of `0.3.0` passed against an
+# interpreter that could not run it. A version that does not move with the code
+# is not a version, and preferring an installed one that cannot run the caller
+# is not a preference worth having.
+
+#[test]
+it_reads_a_version_without_running_the_interpreter() {
+    # Read rather than sourced: a candidate about to be rejected must not be
+    # given the chance to run first.
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/n" "1.2.3"
+    local v; v="$(_nutshell_version_of "$d/n/init")"
+    rm -rf "$d"
+    assert_eq "$v" "1.2.3"
+}
+
+#[test]
+it_takes_the_quotes_off_the_version() {
+    # Trimming at the first character that is not a digit or a dot trims at the
+    # opening quote and answers with nothing.
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/n"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$d/n/init"
+    local v; v="$(_nutshell_version_of "$d/n/init")"
+    rm -rf "$d"
+    assert_eq "$v" "0.4.0"
+}
+
+#[test]
+it_skips_an_installed_one_that_is_too_old() {
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.3.0"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
+    PATH="$d/installed/bin:$PATH" nutshell_find "$root" "0.4.0" 2>/dev/null
+    local from="$NUTSHELL_FROM"
+    rm -rf "$d" "$root"; _reset
+    assert_eq "$from" "vendored"
+}
+
+#[test]
+it_says_out_loud_when_it_skips_the_installed_one() {
+    # Silently falling through would hide exactly the version skew this exists
+    # to surface.
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.3.0"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
+    local out
+    out="$(PATH="$d/installed/bin:$PATH" nutshell_find "$root" "0.4.0" 2>&1)"
+    rm -rf "$d" "$root"; _reset
+    assert_contains "$out" "0.3.0"
+    assert_contains "$out" "0.4.0"
+}
+
+#[test]
+it_still_prefers_an_installed_one_that_is_new_enough() {
+    # The control. Skipping the too-old must not stop it preferring the rest.
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.5.0"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
+    PATH="$d/installed/bin:$PATH" nutshell_find "$root" "0.4.0"
+    local from="$NUTSHELL_FROM"
+    rm -rf "$d" "$root"; _reset
+    assert_eq "$from" "installed"
+}
+
+#[test]
+it_prefers_an_installed_one_when_no_minimum_is_named() {
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.1.0"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "9.9.9"
+    PATH="$d/installed/bin:$PATH" nutshell_find "$root"
+    local from="$NUTSHELL_FROM"
+    rm -rf "$d" "$root"; _reset
+    assert_eq "$from" "installed"
+}
+
+#[test]
+it_honours_a_named_home_even_when_it_is_too_old() {
+    # An override quietly ignored is worse than one that fails, and somebody
+    # working on nutshell itself needs theirs honoured.
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/named" "0.0.1"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "9.9.9"
+    NUTSHELL_HOME="$d/named" nutshell_find "$root" "0.4.0"
+    local from="$NUTSHELL_FROM"
+    rm -rf "$d" "$root"; _reset
+    assert_eq "$from" "NUTSHELL_HOME"
+}
+
+#[test]
+it_compares_the_pieces_as_numbers_when_choosing_too() {
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/n" "0.10.0"
+    assert_ok    _nutshell_satisfies "$d/n/init" "0.9.0"
+    assert_fails _nutshell_satisfies "$d/n/init" "0.11.0"
+    rm -rf "$d"
+}


### PR DESCRIPTION
Found by wiring a consumer onto `find-nutshell` and watching it pick the wrong one.

Both nutshell copies on this machine report `0.3.0`, and only one has the feature the caller needs. The installed interpreter on PATH tracks `main`; the repositories develop against `dev`. So `find-nutshell` correctly preferred the installed one, which lacks `extern_resolve_ref` entirely, and `nutshell_at_least "0.3.0"` passed against it. The floor could not see the skew it exists to catch.

**A version that does not move with the code is not a version.** The pin resolution, `find-nutshell` and `priv` are all new public surface, so this is `0.4.0`.

**`nutshell_find` takes the minimum and skips a candidate older than it**, rather than taking it and failing afterwards. That is what rustup does for cargo: resolve to something that satisfies the requirement, not to whichever came first. Preferring an installed interpreter is right; preferring one that cannot run the caller is not.

- it says so when it skips one, because silently falling through to the vendored copy hides exactly the skew this exists to surface
- what the caller named in `NUTSHELL_HOME` is honoured whatever its version: an override quietly ignored is worse than one that fails, and somebody working on nutshell itself needs theirs taken
- the version is read out of the candidate rather than sourced from it, since one about to be rejected must not be given the chance to run first

## Test plan

`./test`. Nine new tests cover the parse, the skip, the announcement, and the three controls that matter: an installed one new enough is still preferred, no minimum still prefers installed, and `0.10.0` satisfies `0.9.0` rather than failing a text compare.