### PR TITLE
feat: keep versions side by side and fetch the one that is asked for

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,36 @@ Optionally, link the interpreter onto PATH so standalone scripts can use the
 ./scripts/lib/nutshell/install
 ```
 
+### The store
+
+Fetched dependencies live in one place shared by every project on the machine,
+keyed by url and commit, so two projects on the same commit of the same library
+have one copy of it between them and neither carries a dependency tree of its
+own.
+
+The interpreter is one of those dependencies rather than a special case.
+Versions sit side by side, a tool asks for the one it needs, and a version that
+is not on the machine yet is fetched at its tag rather than being a failure. A
+machine carrying four of them is the ordinary state.
+
+```
+${NUTSHELL_STORE:-~/.local/share/nutshell}/
+  externs/       one directory per url and commit
+  toolchains/    one directory per version
+```
+
+`NUTSHELL_STORE` moves the root, `NUTSHELL_TOOLCHAINS` just the toolchains, and
+`NUTSHELL_REMOTE` says where a fetch goes. Under the data directory and not the
+cache directory, because a cache is something a cleaner is entitled to delete
+and this is where every project's dependencies actually live.
+
+A tool resolves in this order: `NUTSHELL_HOME` if it is set, then an installed
+interpreter if it satisfies what the tool asked for, then the store, then a
+fetch into the store, then whatever the project has vendored. One shared
+interpreter that everything uses is still the good state; the store is for the
+tools that cannot use it, and the vendored copy is the last resort for a
+machine with no network.
+
 ---
 
 ## Quick Start
@@ -396,8 +426,8 @@ Declared in the manifest because a script that fetches its own dependencies
 decides for the whole project where code comes from, and does it somewhere
 nobody looks. One file answers "what does this project pull in".
 
-Resolution is cached globally by url and ref, so several projects naming the
-same ref share one checkout and the second pays nothing.
+Resolution goes through the store, so several projects naming the same commit
+share one checkout and the second pays nothing.
 
 `nut.lock` records the commit each dependency resolved to, and is written on
 first resolution and obeyed from then on. `ref = "main"` names a branch, and a

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ ${NUTSHELL_STORE:-~/.local/share/nutshell}/
 cache directory, because a cache is something a cleaner is entitled to delete
 and this is where every project's dependencies actually live.
 
+The store used to sit under the cache directory. Nothing migrates it: what was
+there is reproducible, so the first resolution after upgrading fetches into the
+new place and the old directory is left for you to delete. It is
+`${XDG_CACHE_HOME:-~/.cache}/nutshell` on Linux and
+`~/Library/Caches/nutshell` on macOS.
+
 A tool resolves in this order: `NUTSHELL_HOME` if it is set, then an installed
 interpreter if it satisfies what the tool asked for, then the store, then a
 fetch into the store, then whatever the project has vendored. One shared

--- a/README.md
+++ b/README.md
@@ -44,15 +44,26 @@ is not on the machine yet is fetched at its tag rather than being a failure. A
 machine carrying four of them is the ordinary state.
 
 ```
-${NUTSHELL_STORE:-~/.local/share/nutshell}/
+<store>/
   externs/       one directory per url and commit
   toolchains/    one directory per version
+  toolchains/branches/<ref>/<revision>/
 ```
+
+The store is `${XDG_DATA_HOME:-~/.local/share}/nutshell` on Linux and
+`~/Library/Application Support/nutshell` on macOS. Both are where that platform
+puts application data, which is the point: it is not the cache directory.
 
 `NUTSHELL_STORE` moves the root, `NUTSHELL_TOOLCHAINS` just the toolchains, and
 `NUTSHELL_REMOTE` says where a fetch goes. Under the data directory and not the
 cache directory, because a cache is something a cleaner is entitled to delete
 and this is where every project's dependencies actually live.
+
+A pin that names a version gets a directory named for that version, and one
+that names a branch gets a directory named for the revision that branch
+resolved to. The second is what makes the store safe to share: a revision
+directory is written once and never replaced, so somebody else's push cannot
+delete the tree a running interpreter is reading out of.
 
 The store used to sit under the cache directory. Nothing migrates it: what was
 there is reproducible, so the first resolution after upgrading fetches into the
@@ -60,12 +71,20 @@ new place and the old directory is left for you to delete. It is
 `${XDG_CACHE_HOME:-~/.cache}/nutshell` on Linux and
 `~/Library/Caches/nutshell` on macOS.
 
-A tool resolves in this order: `NUTSHELL_HOME` if it is set, then an installed
-interpreter if it satisfies what the tool asked for, then the store, then a
-fetch into the store, then whatever the project has vendored. One shared
-interpreter that everything uses is still the good state; the store is for the
-tools that cannot use it, and the vendored copy is the last resort for a
-machine with no network.
+A pin that names a version resolves in this order: `NUTSHELL_HOME` if it is
+set, then an installed interpreter if it satisfies what the tool asked for,
+then the store, then a fetch into the store, then whatever the project has
+vendored. One shared interpreter that everything uses is still the good state;
+the store is for the tools that cannot use it, and the vendored copy is the
+last resort for a machine with no network.
+
+A pin that names a branch is a different question and takes a different route:
+`NUTSHELL_HOME`, then the branch's head, then vendored. It does not consult the
+installed interpreter or the version store, because neither can answer it. A
+branch pin is not a floor, it is an identity: `dev` means the head of dev
+today, and nothing already on the machine can be assumed to be that. The remote
+is asked at most once an hour, and when it cannot be reached the last known
+revision runs and says which one it is.
 
 ---
 

--- a/check
+++ b/check
@@ -200,8 +200,19 @@ _run_check() {
     output=$("$check_script" 2>&1)
     exit_code=$?
     
-    if [[ $exit_code -eq 0 ]]; then
-        if echo "$output" | grep -q "⚠\|warning\|WARNING"; then
+    # 2 means warnings and no failures, which is what `exit_with_status`
+    # promises. The glyph grep below it is the fallback for a custom check that
+    # does not use the framework and so cannot say 2.
+    #
+    # It used to be the only mechanism, and it is not one: it reads tens of
+    # kilobytes of a child's stdout, it needs quiet mode to have left the line
+    # in, and it needs whichever `grep` is installed to read the pattern the
+    # same way. A check reporting 23 warnings was coming out as a clean pass.
+    if [[ $exit_code -eq 2 ]]; then
+        echo -e "  ${YELLOW}⚠${NC} ${check_name}"
+        ((WARNED_CHECKS++))
+    elif [[ $exit_code -eq 0 ]]; then
+        if printf '%s' "$output" | grep -q '⚠'; then
             echo -e "  ${YELLOW}⚠${NC} ${check_name}"
             ((WARNED_CHECKS++))
         else
@@ -220,7 +231,8 @@ _run_check() {
     # Truncating silently made three runs of the same check look like three
     # different answers, and cost an afternoon to work out that they were the
     # same answer shown five lines at a time. Say how many are not shown.
-    if [[ $exit_code -ne 0 ]]; then
+    # A 2 is warnings, not a failure, and there is nothing to explain.
+    if [[ $exit_code -ne 0 && $exit_code -ne 2 ]]; then
         local failures shown total
         failures="$(echo "$output" | grep -E "^\s*(✗|FAIL|ERROR|\[FAIL\]|\[ERROR\])")"
 

--- a/check
+++ b/check
@@ -223,9 +223,24 @@ _run_check() {
     if [[ $exit_code -ne 0 ]]; then
         local failures shown total
         failures="$(echo "$output" | grep -E "^\s*(✗|FAIL|ERROR|\[FAIL\]|\[ERROR\])")"
+
+        # A check that failed and said nothing is worse than one that passed
+        # wrongly, because there is no thread to pull. It happens because the
+        # quiet mode this runner sets suppresses the child's own report, so
+        # ask again with the report turned on rather than leaving the reader
+        # with a bare cross.
+        if [[ -z "$failures" ]]; then
+            failures="$(NUTSHELL_CHECK_QUIET=0 "$check_script" 2>&1 \
+                | grep -E "^\s*(✗|FAIL|ERROR|\[FAIL\]|\[ERROR\])")"
+        fi
+
         total=$(printf '%s' "$failures" | grep -c . || true)
         shown=5
-        printf '%s' "$failures" | head -"$shown" | sed 's/^/      /'
+        if [[ -z "$failures" ]]; then
+            echo "      it failed and printed nothing; run ${check_script#"${NUTSHELL_ROOT}"/} to see why"
+        else
+            printf '%s' "$failures" | head -"$shown" | sed 's/^/      /'
+        fi
         if [[ "$total" -gt "$shown" ]]; then
             echo "      ... and $((total - shown)) more; run ${check_script#"${NUTSHELL_ROOT}"/} to see them"
         fi

--- a/check
+++ b/check
@@ -193,12 +193,27 @@ _run_check() {
     fi
     
     ((TOTAL_CHECKS++))
-    
+
     # Run the check
     local output
     local exit_code
-    output=$("$check_script" 2>&1)
-    exit_code=$?
+
+    # Sourced in a subshell of this process rather than started as one of its
+    # own. Eight checks meant eight nutshell startups and eight cold caches:
+    # each one re-read the same two dozen files, re-parsed the same config and
+    # re-walked the same attributes. A subshell inherits all of it and cannot
+    # write back, so the checks still cannot see each other's variables and
+    # `main` in one is not `main` in the next.
+    #
+    # A check that cannot be sourced is still run the old way, since a custom
+    # check is somebody else's file and may not be a nutshell script at all.
+    if [[ "${NUT_CHECK_ISOLATED:-0}" != "1" ]] && head -1 "$check_script" | grep -q 'env nutshell'; then
+        output=$( set +e; . "$check_script" 2>&1 )
+        exit_code=$?
+    else
+        output=$("$check_script" 2>&1)
+        exit_code=$?
+    fi
     
     # 2 means warnings and no failures, which is what `exit_with_status`
     # promises. The glyph grep below it is the fallback for a custom check that
@@ -263,6 +278,13 @@ _run_builtin_checks() {
     echo ""
     echo -e "${BOLD}Built-in Checks${NC}"
     echo ""
+
+    # Once, here, so every check below inherits it rather than building its own.
+    use srcfile 2>/dev/null || true
+    local f
+    while IFS= read -r f; do
+        [[ -n "$f" ]] && nut_load_file "$f" 2>/dev/null
+    done < <(get_lib_files 2>/dev/null)
     
     for check in "${NUTSHELL_ROOT}"/examples/checks/check_*.sh; do
         [[ ! -f "$check" ]] && continue

--- a/check
+++ b/check
@@ -208,7 +208,11 @@ _run_check() {
     # A check that cannot be sourced is still run the old way, since a custom
     # check is somebody else's file and may not be a nutshell script at all.
     if [[ "${NUT_CHECK_ISOLATED:-0}" != "1" ]] && head -1 "$check_script" | grep -q 'env nutshell'; then
-        output=$( set +e; . "$check_script" 2>&1 )
+        # Which file this check is, so the cache can notice it changing. A
+        # check whose own source moved has to read everything again, and
+        # without this the cache would keep answering with the old one's
+        # opinion.
+        output=$( set +e; NUT_CACHE_CHECKER="$check_script" . "$check_script" 2>&1 )
         exit_code=$?
     else
         output=$("$check_script" 2>&1)
@@ -281,6 +285,7 @@ _run_builtin_checks() {
 
     # Once, here, so every check below inherits it rather than building its own.
     use srcfile 2>/dev/null || true
+    use checkcache 2>/dev/null || true
     local f
     while IFS= read -r f; do
         [[ -n "$f" ]] && nut_load_file "$f" 2>/dev/null

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -448,3 +448,75 @@ asked-for version is not there, and both externs and toolchains under one store
 root. The externs moved from the cache directory to the data directory in the
 same change, because a cache is something a cleaner may delete at any moment
 and this is where every project's dependencies actually live.
+
+## renki-sh, or generating shell from the Rust
+
+> You know I feel more and more stern about us doing renki-sh or make nutshell
+> build a copy of the rust one natively and use that. It's no sense to reinvent
+> the wheel here. Nutshells idea is platform agnostic form that should
+> technically run anywhere with posix compliant or close enough shell and
+> utils. So this is why I have been and still am hesitant to introduce rust
+> into the mix. But if generating the bash-y version isn't likely to work from
+> the rust source, I don't know what to say here. It's just redundancy to
+> reinvent this specific wheel here
+
+**Two intents, and they are both mandates.** One: nutshell stays runnable on a
+POSIX-ish shell with no Rust anywhere in its chain. Two: the pin and lock
+semantics are not to be invented twice and left to drift apart. The vehicles
+offered, a `renki-sh` subdirectory and Rust attribute macros emitting shell, are
+proposals rather than either intent.
+
+### What the overlap actually is
+
+Counting non-comment lines, renki is 1500 of source across ten modules. What
+touches this problem at all:
+
+| module | lines | overlaps |
+| --- | --- | --- |
+| `pin.rs` | 171 | branch to rev via `git ls-remote`, TTL cached |
+| `manifest.rs` | 72 | the pin schema, a TOML shape |
+| `discover.rs` | 132 | walk up for the config file |
+| `cache.rs` | 147 | key to directory, payload is a cargo build |
+
+`tool.rs`, `engine.rs`, `registry.rs` and `selfupdate.rs`, 940 lines between
+them, are about cargo, crates.io, Rust toolchains and keeping a launcher binary
+current. None of it has a nutshell counterpart. Of the four above, `cache.rs`
+produces `cargo install` argument lists and `pin.rs` produces build attempts, so
+the shared part of each is smaller than its line count.
+
+The shared idea is about a hundred lines: branch resolves to its head, a rev or
+tag is held by the lock, resolution is cached with a TTL, the manifest is found
+by walking up. `lib/extern.sh` is 311 lines and already implements it.
+
+### On generating the shell from the Rust
+
+It does not pay, and the reason is not effort. The annotated functions would
+have to avoid generics, traits, iterators, `?`, `Result`, borrows, `PathBuf`,
+`SystemTime` and everything else in `std` with no shell counterpart. What
+remains is not Rust: it is a small language written inside Rust, compiled by a
+backend nobody else maintains, and every future edit to those functions has to
+stay inside a subset the compiler enforces nowhere. That is a compiler backend
+built to avoid a hundred lines of shell.
+
+### What to do instead: share the spec, not the code
+
+The redundancy that costs anything is semantic, not textual. Two
+implementations of one spec is ordinary. Two implementations that quietly
+disagree about what a branch pin means is the failure, and it is invisible until
+somebody's build resolves differently on two machines.
+
+So: the pin semantics get written down once, in renki, as prose plus a
+table-driven fixture set. Inputs to expected resolution, including the awkward
+ones: an annotated tag that has to peel, a branch head that moved since the
+lock, a TTL that has expired with no network, a rev pin the lock holds back, a
+tag that moved under a lock. Renki reads the fixtures in a Rust test; nutshell
+reads the same file in a shell test. Divergence is a red test in whichever one
+drifted, on the day it drifts.
+
+No Rust in nutshell's chain, no codegen backend, and the part with the real
+value, the settled semantics and the edge cases somebody had to think of once,
+is shared as data rather than copied as prose in two languages.
+
+A `renki-sh` subdirectory remains reasonable on top of that if a Rust project
+ever wants the launcher half in shell. It is a second consumer of the same
+fixtures, not a way of avoiding the second implementation.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -520,3 +520,61 @@ is shared as data rather than copied as prose in two languages.
 A `renki-sh` subdirectory remains reasonable on top of that if a Rust project
 ever wants the launcher half in shell. It is a second consumer of the same
 fixtures, not a way of avoiding the second implementation.
+
+## The git ref is the version, and the constant in `init` is the parallel system
+
+> okay the problem is that you have invented a parallel disjoint system from the
+> git we target here. you have some env var / const-like for the version, but
+> that is redundant. The git tag *is* the version. If none, then its version is
+> the commit hash
+
+> you should let the nut.toml version pin handle the fetch. No reason to pin a
+> version while we are actively developing. Just pin to dev and it keeps always
+> up-to-date with latest dev, that's what we want
+
+**The intent: identity comes from git and from nowhere else.** A tag is the
+version; with no tag the commit hash is the version. A pin is a git ref, and a
+branch pin means that branch's head, always. Nothing declares a version about
+itself in a file.
+
+### What this falsifies
+
+Named before what it enables, because a closed gap reads as progress while a
+falsified claim announces nothing.
+
+- **`init:29`'s `NUTSHELL_VERSION`.** A constant somebody has to remember to
+  bump, which is why `main` says 0.2.0, `dev` says 0.4.0, and neither is a fact
+  about the code. It goes.
+- **`find-nutshell:_nutshell_version_of`.** Reads that constant out of `init`
+  without sourcing it. The whole function exists to serve the constant.
+- **The store's name-equals-contents invariant.** `nutshell_toolchains` skips a
+  directory whose `init` disagrees with its directory name. With git as the
+  identity there is nothing to disagree: the directory is a checkout and
+  `git -C dir describe --tags --always` says what it is.
+- **`_nutshell_num` and the prerelease ordering.** Already unreachable, as the
+  review found. Under git identity the question is whether a ref resolves, not
+  how a suffix sorts.
+- **`nutshell_at_least`, and `HULI_NEEDS_NUTSHELL` as a floor.** A floor is a
+  statement about the constant. A consumer pins a ref; if it needs a specific
+  tag it names that tag.
+- **`_nutshell_fetch`'s `--branch "$want"` with a version-shaped want.** Right
+  by accident, because tags here are bare. It should be resolving a ref.
+
+### What it should be instead
+
+The pin lives in `nut.toml` beside every other dependency, one shape for all of
+them, `git` and `ref`. `ref` is a branch, a tag or a commit. A branch is
+resolved with `git ls-remote`, TTL cached, which `lib/extern.sh` already does
+for externs in `extern_resolve_ref`; the interpreter stops being the exception
+that has its own arrangement.
+
+The store is keyed by the resolved commit, not by a version string, which is
+also what makes two consumers on one commit share a checkout. `nutshell --version`
+answers from `git describe --tags --always --dirty` in its own checkout.
+
+**Interim state, so the next reader is not misled.** `find-nutshell` on
+`feat/toolchains` now takes a branch ref as well as a version, and hulilupteri
+pins `dev` through it, so the working shape is already the right one. What is
+underneath it is still the constant: the version arm, the store's naming rule
+and `nutshell_at_least` are all live. This is a half-migration and it should not
+be described as anything else until the constant is gone.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -420,3 +420,31 @@ it, which is the whole of the defect.
 - give a caller the real user's home, name and id even while the one step runs,
   so nothing computes a path from `$HOME` at the wrong moment
 - say plainly when it cannot elevate, rather than falling back to trying anyway
+
+## The store, and versions coexisting
+
+> As for the versions of nutshell. We should have it similar as rustup or
+> pretty much any similar. Several versions can and will coexist on one machine
+> and instead of failing, we download the correct one and store it as a
+> "toolchain". Same as renki does. Unless this is how it works already. If so,
+> I don't understand how the versions can give so much trouble?
+
+> Really seems to me we should keep the libs anything depends on centrally too
+> like pnpm or yarn2. Nutshell itself just as one of them.
+
+**The intent: one central store, versions coexist, a missing one is a download
+rather than a failure, and the interpreter is an entry in that store like
+anything else.** The rustup and renki comparisons are the shape being asked
+for, not a requirement to copy either.
+
+It was not how it worked. Externs were already central and content-addressed;
+the interpreter was the exception, resolved by picking from what the machine
+happened to have and never fetching. That is the whole of the version trouble:
+`0.4.0` exists only on `dev`, nothing has tagged it, so no amount of resolving
+could find it and the fallback to the vendored copy fired every run.
+
+Settled by this work: a toolchain store keyed by version, a fetch when the
+asked-for version is not there, and both externs and toolchains under one store
+root. The externs moved from the cache directory to the data directory in the
+same change, because a cache is something a cleaner may delete at any moment
+and this is where every project's dependencies actually live.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -560,21 +560,49 @@ falsified claim announces nothing.
 - **`_nutshell_fetch`'s `--branch "$want"` with a version-shaped want.** Right
   by accident, because tags here are bare. It should be resolving a ref.
 
-### What it should be instead
+### What it should be instead: renki's model, read rather than paraphrased
 
-The pin lives in `nut.toml` beside every other dependency, one shape for all of
-them, `git` and `ref`. `ref` is a branch, a tag or a commit. A branch is
-resolved with `git ls-remote`, TTL cached, which `lib/extern.sh` already does
-for externs in `extern_resolve_ref`; the interpreter stops being the exception
-that has its own arrangement.
+`renki/src/manifest.rs` and `renki/src/pin.rs`. Four points, each of which I got
+wrong by designing from the header instead of the code.
 
-The store is keyed by the resolved commit, not by a version string, which is
-also what makes two consumers on one commit share a checkout. `nutshell --version`
-answers from `git describe --tags --always --dirty` in its own checkout.
+**1. Four reference forms, and the config says which by which key it used.**
+`manifest.rs:63-71` is `Reference::{Version, Rev, Tag, Branch}`, and its own doc
+says they are not interchangeable: a version is immutable and maps to both a
+release and a tag, a rev and a tag are immutable and git-only, a branch moves
+and is the only one that has to be re-resolved. `Header::parse` at `:113-121`
+reads four separate keys, ordered most specific first, so a config carrying more
+than one has a defined answer. **There is no shape sniffing.** A tag named `dev`
+and a branch named `dev` are different pins because they came from different
+keys, and asking whether a string looks like a version is the invented system.
+
+**2. Everything resolves to something immutable, and that is the cache key.**
+`pin.rs:84-146` produces `key_rev`: `v:<version>` for a version, the bare sha
+for a rev, `tag:<t>` for a tag, and for a branch **the sha it currently points
+at**. `Resolved::git_ref` at `:72` says it outright: "a branch has already
+become the rev it pointed at". A store keyed by a branch name, or by a version
+string, is keyed by something that moves.
+
+**3. Two caches, two jobs.** The branch-head resolution is cached with a TTL
+(`resolve_branch`, `branch_resolution_path`, `fresh_resolution`); the built
+artifact is cached under the resolved sha. Conflating them is what makes a
+branch pin either never refresh or refetch on every run.
+
+**4. Offline uses the last known revision and names it.** `resolve_branch`
+falls back to `any_resolution` and prints the revision it is running from,
+because a stale head is very probably still built and sitting in the cache, and
+running from it beats refusing to run.
+
+For nutshell that means `nut.toml` carries `git` plus exactly one of `rev`,
+`tag`, `branch`, `version`, the same four keys, for the interpreter and for
+every extern alike. The store is keyed by the resolved commit. `NUTSHELL_VERSION`
+is deleted and `nutshell --version` answers from `git describe --tags --always`
+in its own checkout.
 
 **Interim state, so the next reader is not misled.** `find-nutshell` on
-`feat/toolchains` now takes a branch ref as well as a version, and hulilupteri
-pins `dev` through it, so the working shape is already the right one. What is
-underneath it is still the constant: the version arm, the store's naming rule
-and `nutshell_at_least` are all live. This is a half-migration and it should not
-be described as anything else until the constant is gone.
+`feat/toolchains` takes a branch and hulilupteri pins `dev` through it, so a
+consumer tracking a moving branch works today. Underneath it is still the
+invented system, and every one of the four points above is unimplemented: one
+key rather than four, shape sniffing rather than the key deciding, the store
+keyed by a branch name rather than by the sha it resolved to, and one cache
+doing both jobs. Treat `_nutshell_is_version` and `_nutshell_branch` as scaffolding
+that proved the consumer end, not as the design.

--- a/examples/checks/check_function_duplication.sh
+++ b/examples/checks/check_function_duplication.sh
@@ -139,38 +139,55 @@ compare_full_names() {
     local threshold="$2"
     
     echo "$func_data" | awk -F'|' -v threshold="$threshold" '
-    # Levenshtein distance function
-    function levenshtein(s1, s2,    len1, len2, i, j, c1, c2, cost, d, del, ins, repl, min) {
+    # Levenshtein distance, abandoned as soon as it cannot matter.
+    #
+    # `maxd` is the largest distance the caller could still accept. Past that
+    # the exact number is not wanted, so the row is checked and the whole thing
+    # abandoned rather than filled in: the answer only has to be "more than
+    # maxd", and returning maxd+1 says that.
+    #
+    # It matters because this is the whole cost of the check. 440 names is
+    # about 96,000 pairs, and the length prune below leaves most of them, each
+    # paying a full matrix. At the default threshold of 0.85 a twenty-character
+    # name accepts three edits, so three rows of no hope is the answer and the
+    # remaining seventeen were being computed for nothing.
+    #
+    # One row is kept rather than the matrix. Nothing reads the interior, and
+    # an awk associative array of len1*len2 cells per pair was most of the
+    # memory traffic.
+    function levenshtein(s1, s2, maxd,    len1, len2, i, j, c1, cost, prev, cur, best, subst) {
         len1 = length(s1)
         len2 = length(s2)
-        
+
         if (s1 == s2) return 0
         if (len1 == 0) return len2
         if (len2 == 0) return len1
-        
-        # Initialize first row and column
-        for (i = 0; i <= len1; i++) d[i, 0] = i
-        for (j = 0; j <= len2; j++) d[0, j] = j
-        
+        if (maxd == "") maxd = len1 + len2
+        # A difference in length is already that many edits.
+        if (len1 - len2 > maxd || len2 - len1 > maxd) return maxd + 1
+
+        for (j = 0; j <= len2; j++) prev[j] = j
+
         for (i = 1; i <= len1; i++) {
             c1 = substr(s1, i, 1)
+            cur[0] = i
+            best = cur[0]
             for (j = 1; j <= len2; j++) {
-                c2 = substr(s2, j, 1)
-                cost = (c1 == c2) ? 0 : 1
-                
-                del = d[i-1, j] + 1
-                ins = d[i, j-1] + 1
-                repl = d[i-1, j-1] + cost
-                
-                min = del
-                if (ins < min) min = ins
-                if (repl < min) min = repl
-                d[i, j] = min
+                cost = (c1 == substr(s2, j, 1)) ? 0 : 1
+                subst = prev[j-1] + cost
+                cur[j] = prev[j] + 1
+                if (cur[j-1] + 1 < cur[j]) cur[j] = cur[j-1] + 1
+                if (subst < cur[j]) cur[j] = subst
+                if (cur[j] < best) best = cur[j]
             }
+            # Every path through this row already costs more than the caller
+            # can accept, and a row only ever grows.
+            if (best > maxd) return maxd + 1
+            for (j = 0; j <= len2; j++) prev[j] = cur[j]
         }
-        return d[len1, len2]
+        return prev[len2]
     }
-    
+
     # Quick check: can these strings possibly have similarity >= threshold?
     function can_meet_threshold(s1, s2, threshold,    len1, len2, maxlen, minlen) {
         len1 = length(s1)
@@ -181,12 +198,16 @@ compare_full_names() {
         return ((minlen / maxlen) >= threshold)
     }
     
-    function similarity(s1, s2,    len1, len2, maxlen, dist) {
+    function similarity(s1, s2, threshold,    len1, len2, maxlen, dist, maxd) {
         len1 = length(s1)
         len2 = length(s2)
         maxlen = (len1 > len2) ? len1 : len2
         if (maxlen == 0) return 1.0
-        dist = levenshtein(s1, s2)
+        # The largest distance that could still clear the threshold. Anything
+        # past it is rejected either way, so it does not have to be counted.
+        maxd = int(maxlen * (1.0 - threshold))
+        dist = levenshtein(s1, s2, maxd)
+        if (dist > maxd) return 0.0
         return 1.0 - (dist / maxlen)
     }
     
@@ -223,7 +244,7 @@ compare_full_names() {
                 # Early exit: if lengths are too different, skip expensive Levenshtein
                 if (!can_meet_threshold(names[i], names[j], threshold)) continue
                 
-                score = similarity(names[i], names[j])
+                score = similarity(names[i], names[j], threshold)
                 
                 if (score < threshold) continue
 
@@ -237,7 +258,7 @@ compare_full_names() {
                     t1 = tail_of(names[i]); t2 = tail_of(names[j])
                     if (length(t1) > 0 && length(t2) > 0) {
                         if (!can_meet_threshold(t1, t2, threshold)) continue
-                        if (similarity(t1, t2) < threshold) continue
+                        if (similarity(t1, t2, threshold) < threshold) continue
                     }
                 }
 
@@ -284,51 +305,40 @@ compare_stripped_names() {
     local threshold="$2"
     
     echo "$func_data" | awk -F'|' -v threshold="$threshold" '
-    function levenshtein(s1, s2,    len1, len2, i, j, c1, c2, cost, d, del, ins, repl, min) {
-        len1 = length(s1)
-        len2 = length(s2)
-        
+    # The same abandoned-early distance as the first pass. See there for why.
+    function levenshtein(s1, s2, maxd,    len1, len2, i, j, c1, cost, prev, cur, best, subst) {
+        len1 = length(s1); len2 = length(s2)
         if (s1 == s2) return 0
         if (len1 == 0) return len2
         if (len2 == 0) return len1
-        
-        for (i = 0; i <= len1; i++) d[i, 0] = i
-        for (j = 0; j <= len2; j++) d[0, j] = j
-        
+        if (maxd == "") maxd = len1 + len2
+        if (len1 - len2 > maxd || len2 - len1 > maxd) return maxd + 1
+        for (j = 0; j <= len2; j++) prev[j] = j
         for (i = 1; i <= len1; i++) {
             c1 = substr(s1, i, 1)
+            cur[0] = i; best = cur[0]
             for (j = 1; j <= len2; j++) {
-                c2 = substr(s2, j, 1)
-                cost = (c1 == c2) ? 0 : 1
-                
-                del = d[i-1, j] + 1
-                ins = d[i, j-1] + 1
-                repl = d[i-1, j-1] + cost
-                
-                min = del
-                if (ins < min) min = ins
-                if (repl < min) min = repl
-                d[i, j] = min
+                cost = (c1 == substr(s2, j, 1)) ? 0 : 1
+                subst = prev[j-1] + cost
+                cur[j] = prev[j] + 1
+                if (cur[j-1] + 1 < cur[j]) cur[j] = cur[j-1] + 1
+                if (subst < cur[j]) cur[j] = subst
+                if (cur[j] < best) best = cur[j]
             }
+            if (best > maxd) return maxd + 1
+            for (j = 0; j <= len2; j++) prev[j] = cur[j]
         }
-        return d[len1, len2]
+        return prev[len2]
     }
-    
-    function can_meet_threshold(s1, s2, threshold,    len1, len2, maxlen, minlen) {
-        len1 = length(s1)
-        len2 = length(s2)
-        maxlen = (len1 > len2) ? len1 : len2
-        minlen = (len1 < len2) ? len1 : len2
-        if (maxlen == 0) return 1
-        return ((minlen / maxlen) >= threshold)
-    }
-    
-    function similarity(s1, s2,    len1, len2, maxlen, dist) {
+
+    function similarity(s1, s2, threshold,    len1, len2, maxlen, dist, maxd) {
         len1 = length(s1)
         len2 = length(s2)
         maxlen = (len1 > len2) ? len1 : len2
         if (maxlen == 0) return 1.0
-        dist = levenshtein(s1, s2)
+        maxd = int(maxlen * (1.0 - threshold))
+        dist = levenshtein(s1, s2, maxd)
+        if (dist > maxd) return 0.0
         return 1.0 - (dist / maxlen)
     }
     
@@ -363,7 +373,7 @@ compare_stripped_names() {
                 # Early exit: if lengths are too different, skip expensive Levenshtein
                 if (!can_meet_threshold(stripped[i], stripped[j], threshold)) continue
                 
-                score = similarity(stripped[i], stripped[j])
+                score = similarity(stripped[i], stripped[j], threshold)
                 
                 if (score >= threshold) {
                     printf "WARN|%.3f|%s|%s|%s|%s|%s|%s\n", score, stripped[i], original[i], stripped[j], original[j], files[i], files[j]
@@ -395,7 +405,14 @@ test_full_name_duplication() {
     echo ""
     
     local results
-    results=$(compare_full_names "$func_data" "$SIMILARITY_THRESHOLD")
+    # An awk that will not parse prints nothing and exits non-zero, and this
+    # check then reported a clean pass. That is how a reserved word used as a
+    # variable name went unnoticed: the program never ran, so nothing was
+    # similar to anything. A comparison that could not be made is not a pass.
+    if ! results=$(compare_full_names "$func_data" "$SIMILARITY_THRESHOLD"); then
+        log_fail "the name comparison could not run"
+        return 1
+    fi
     
     local failures=0
     
@@ -443,7 +460,10 @@ test_stripped_name_duplication() {
     echo ""
     
     local results
-    results=$(compare_stripped_names "$stripped_data" "$SIMILARITY_THRESHOLD")
+    if ! results=$(compare_stripped_names "$stripped_data" "$SIMILARITY_THRESHOLD"); then
+        log_fail "the stripped-name comparison could not run"
+        return 1
+    fi
     
     local warnings=0
     

--- a/examples/checks/check_public_api_docs.sh
+++ b/examples/checks/check_public_api_docs.sh
@@ -63,71 +63,118 @@ load_config() {
 # DOCUMENTATION CHECKING FUNCTIONS
 # =============================================================================
 
+# The file, once, as an array of lines.
+#
+# The scan below walks backwards from a definition and used to run `sed -n Np`
+# for each line it looked at, plus an `echo | grep` to decide what the line
+# was. That is three processes per line of every docblock in the library, and
+# it is why this check took most of a minute. Bash can hold the file and match
+# a line itself, which also means this needs no `sed` and no `grep` and works
+# on a machine that has neither.
+declare -gA _PAD_LINES=()
+declare -gA _PAD_LOADED=()
+declare -gA _PAD_AT=()
+declare -g  PAD_DOCBLOCK=""
+
+_pad_load() {
+    local file="$1"
+    [[ -n "${_PAD_LOADED[$file]:-}" ]] && return 0
+    local -a lines=()
+    # `mapfile` is a bash builtin and needs nothing installed, but it arrived
+    # in bash 4 and this reads a file a checker has to read. The loop below is
+    # the same thing on any bash, and no external tool is involved either way.
+    if [[ "$(type -t mapfile)" == "builtin" ]]; then
+        mapfile -t lines < "$file" 2>/dev/null || return 1
+    else
+        local __l
+        while IFS= read -r __l || [[ -n "$__l" ]]; do lines+=("$__l"); done < "$file" \
+            || return 1
+    fi
+    local i line
+    for (( i = 0; i < ${#lines[@]}; i++ )); do
+        line="${lines[$i]}"
+        _PAD_LINES["${file}:$((i + 1))"]="$line"
+        # Where each function is defined, recorded on the one pass rather than
+        # searched for per lookup. Searching was 440 functions times 376 lines
+        # of regex per file, which is the same shape as the greps it replaced.
+        if [[ "$line" =~ ^[[:space:]]*(function[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]*\( ]]; then
+            local n="${BASH_REMATCH[2]}"
+            [[ -n "${_PAD_AT["${file}:${n}"]:-}" ]] || _PAD_AT["${file}:${n}"]=$((i + 1))
+        fi
+    done
+    _PAD_LOADED[$file]="${#lines[@]}"
+    return 0
+}
+
+# One line of a loaded file, by number.
+_pad_line() { printf '%s' "${_PAD_LINES["${1}:${2}"]:-}"; }
+
+# Where a function is defined in a loaded file, or nothing.
+_pad_defined_at() {
+    local at="${_PAD_AT["${1}:${2}"]:-}"
+    [[ -n "$at" ]] || return 1
+    printf '%s' "$at"
+}
+
 # Extract the docblock before a function definition
 # Returns: the comment lines before the function (if any)
 get_function_docblock() {
     local file="$1"
     local func_name="$2"
-    
-    # Find the line number of the function definition
+
+    PAD_DOCBLOCK=""
+    _pad_load "$file" || return 1
+
     local func_line
-    func_line=$(grep -n "^[[:space:]]*${func_name}[[:space:]]*()[[:space:]]*{" "$file" 2>/dev/null | head -1 | cut -d: -f1)
-    
-    if [[ -z "$func_line" ]]; then
-        # Try alternate syntax
-        func_line=$(grep -n "^[[:space:]]*function[[:space:]]\+${func_name}[[:space:]]*(" "$file" 2>/dev/null | head -1 | cut -d: -f1)
-    fi
-    
-    [[ -z "$func_line" ]] && return 1
+    func_line="${_PAD_AT["${file}:${func_name}"]:-}"
+    [[ -n "$func_line" ]] || return 1
     [[ "$func_line" -lt 2 ]] && return 1
-    
+
     # Look backwards from the function definition to find comment block
-    local start_line=$((func_line - 1))
-    local docblock=""
-    local current_line=$start_line
-    
+    local docblock="" current_line=$(( func_line - 1 )) line prev
+
     while [[ $current_line -gt 0 ]]; do
-        local line
-        line=$(sed -n "${current_line}p" "$file" 2>/dev/null)
-        
-        # If line is a comment, add to docblock
-        if echo "$line" | grep -qE '^[[:space:]]*#'; then
+        line="${_PAD_LINES["${file}:${current_line}"]}"
+
+        if [[ "$line" =~ ^[[:space:]]*# ]]; then
             docblock="${line}"$'\n'"${docblock}"
-            current_line=$((current_line - 1))
-        # If line is blank, might be part of docblock, continue
+            current_line=$(( current_line - 1 ))
         elif [[ -z "${line// /}" ]]; then
-            # Check if previous line is also blank or non-comment
-            local prev_line
-            prev_line=$(sed -n "$((current_line - 1))p" "$file" 2>/dev/null)
-            if echo "$prev_line" | grep -qE '^[[:space:]]*#'; then
-                current_line=$((current_line - 1))
+            # A blank line is part of the block only when a comment is above it.
+            prev="${_PAD_LINES["${file}:$(( current_line - 1 ))"]:-}"
+            if [[ "$prev" =~ ^[[:space:]]*# ]]; then
+                current_line=$(( current_line - 1 ))
             else
                 break
             fi
         else
-            # Non-comment, non-blank line - stop
             break
         fi
     done
-    
-    echo "$docblock"
+
+    PAD_DOCBLOCK="$docblock"
+    printf '%s\n' "$docblock"
 }
 
 # Check if docblock contains an element
 docblock_has_element() {
-    local docblock="$1"
-    local element="$2"
-    
-    # Use grep -F for literal string matching (handles special chars like ->)
-    # Use -- to prevent element from being interpreted as options
-    echo "$docblock" | grep -qiF -- "$element"
+    local docblock="$1" element="$2"
+    # Literal and case-insensitive, the way `grep -qiF` was, without the two
+    # processes. `->` and the other markers carry characters a pattern would
+    # read as its own, so the needle is lowered and compared as text.
+    local hay="${docblock,,}" needle="${element,,}"
+    [[ "$hay" == *"$needle"* ]]
 }
 
 # Count comment lines in docblock
 count_doc_lines() {
-    local docblock="$1"
-    
-    echo "$docblock" | grep -cE '^[[:space:]]*#' || echo "0"
+    local docblock="$1" line n=0
+    # Counted here rather than through `echo | grep -c`, which is two processes
+    # per public function for a string this shell is already holding.
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*# ]] && n=$(( n + 1 ))
+    done <<< "$docblock"
+    printf '%s' "$n"
 }
 
 # Find all functions marked with public API annotation
@@ -144,9 +191,13 @@ find_public_api_functions() {
     name="$(attr_name_of "$PUBLIC_API_ANNOTATION")" || return
     name="${name%%$'\t'*}"
 
+    _pad_load "$file" || return
     while IFS= read -r func_name; do
         [[ -z "$func_name" ]] && continue
-        func_line=$(grep -n "^[[:space:]]*${func_name}[[:space:]]*()[[:space:]]*{" "$file" 2>/dev/null | head -1 | cut -d: -f1)
+        # Out of the loaded file rather than a `grep | head | cut`, which is
+        # three processes per public function and answers a question the file
+        # already in memory can answer.
+        func_line="$(_pad_defined_at "$file" "$func_name")" || func_line=0
         echo "${func_name}|${func_line:-0}|${rel_path}"
     done < <(attr_find "$file" "$name")
 }
@@ -189,6 +240,12 @@ test_public_api_docs() {
         
         # Find all public API functions in this file
         local public_functions
+        # Loaded here, in this shell, before anything reads it through a
+        # command substitution. A substitution is a subshell: it inherits what
+        # is already loaded and throws away anything it loads itself, so the
+        # cache below was being rebuilt once per function rather than once per
+        # file. That was most of this check's time.
+        _pad_load "$file" || true
         public_functions=$(find_public_api_functions "$file")
         
         while IFS='|' read -r func_name func_line func_file; do
@@ -197,7 +254,8 @@ test_public_api_docs() {
             
             # Get the docblock for this function
             local docblock
-            docblock=$(get_function_docblock "$file" "$func_name")
+            get_function_docblock "$file" "$func_name"
+            docblock="$PAD_DOCBLOCK"
             
             local has_error=0
             local has_warn=0

--- a/examples/checks/check_trivial_wrappers.sh
+++ b/examples/checks/check_trivial_wrappers.sh
@@ -134,77 +134,53 @@ count_global_usages() {
 # Extract meaningful code lines from a function body
 # Excludes: comments, blank lines, local declarations, opening/closing braces
 get_meaningful_lines() {
-    local file="$1"
-    local func_name="$2"
-    
-    # Find the line number where the function starts
-    local func_line
-    func_line=$(grep -n "^[[:space:]]*${func_name}[[:space:]]*()[[:space:]]*{" "$file" 2>/dev/null | head -1 | cut -d: -f1)
-    
-    if [[ -z "$func_line" ]]; then
-        # Try alternate syntax: function name() or function name ()
-        func_line=$(grep -n "^[[:space:]]*function[[:space:]]\+${func_name}[[:space:]]*(" "$file" 2>/dev/null | head -1 | cut -d: -f1)
-    fi
-    
-    [[ -z "$func_line" ]] && return
-    
-    # Find the closing brace - simple heuristic: next line starting with }
-    # This works for most well-formatted shell functions
-    local end_line
-    end_line=$(tail -n "+$((func_line + 1))" "$file" | grep -n "^}" | head -1 | cut -d: -f1)
-    
-    if [[ -z "$end_line" ]]; then
-        # Fallback: look for } at start of line with possible whitespace
-        end_line=$(tail -n "+$((func_line + 1))" "$file" | grep -n "^[[:space:]]*}[[:space:]]*$" | head -1 | cut -d: -f1)
-    fi
-    
-    [[ -z "$end_line" ]] && return
-    
-    # Adjust end_line to be absolute (it's relative to func_line+1)
-    end_line=$((func_line + end_line))
-    
-    # Extract lines between func start and end, filter out non-meaningful lines
-    sed -n "$((func_line + 1)),$((end_line - 1))p" "$file" 2>/dev/null | \
-        grep -v '^[[:space:]]*#' | \
-        grep -v '^[[:space:]]*$' | \
-        grep -v '^[[:space:]]*local[[:space:]]' | \
-        grep -v '^[[:space:]]*readonly[[:space:]]' | \
-        grep -v '^[[:space:]]*return[[:space:]]*$' | \
-        grep -v '^[[:space:]]*return[[:space:]]\+\$?' | \
-        grep -v '^[[:space:]]*}[[:space:]]*$'
+    local -a __body=()
+    nut_body_of "$1" "$2" __body || return
+    (( ${#__body[@]} > 0 )) && printf '%s\n' "${__body[@]}"
+    return 0
 }
 
 # Count meaningful lines in a function
 count_meaningful_lines() {
-    local file="$1"
-    local func_name="$2"
-    
-    get_meaningful_lines "$file" "$func_name" | wc -l | tr -d ' '
+    local -a __body=()
+    nut_body_of "$1" "$2" __body || { printf '0'; return; }
+    printf '%s' "${#__body[@]}"
 }
 
 # Count unique variables used in function body
 count_variables_used() {
-    local file="$1"
-    local func_name="$2"
-    
-    get_meaningful_lines "$file" "$func_name" | \
-        grep -oE '\$\{?[a-zA-Z_][a-zA-Z0-9_]*' | \
-        sed 's/[${}]//g' | \
-        sort -u | \
-        wc -l | \
-        tr -d ' '
+    local -a __body=()
+    nut_body_of "$1" "$2" __body || { printf '0'; return; }
+    # A five-stage pipeline per function, in the shell instead. `grep -oE`,
+    # `sed`, `sort -u`, `wc` and `tr` is five processes to count distinct names
+    # in a handful of lines the shell is already holding.
+    local -A seen=()
+    local line rest name
+    for line in "${__body[@]}"; do
+        rest="$line"
+        while [[ "$rest" =~ \$\{?([a-zA-Z_][a-zA-Z0-9_]*) ]]; do
+            name="${BASH_REMATCH[1]}"
+            seen["$name"]=1
+            rest="${rest#*"${BASH_REMATCH[0]}"}"
+        done
+    done
+    printf '%s' "${#seen[@]}"
 }
 
 # Count tokens (complexity indicator) in function body
 count_tokens() {
-    local file="$1"
-    local func_name="$2"
-    
-    get_meaningful_lines "$file" "$func_name" | \
-        tr -s '[:space:]' '\n' | \
-        grep -v '^$' | \
-        wc -l | \
-        tr -d ' '
+    local -a __body=()
+    nut_body_of "$1" "$2" __body || { printf '0'; return; }
+    # Word splitting is the shell's own job; `tr | grep | wc | tr` is four
+    # processes to ask it.
+    local line n=0
+    local -a words=()
+    for line in "${__body[@]}"; do
+        # shellcheck disable=SC2206
+        words=($line)
+        n=$(( n + ${#words[@]} ))
+    done
+    printf '%s' "$n"
 }
 
 # Analyze a single function for trivial wrapper status
@@ -310,6 +286,7 @@ test_trivial_wrappers() {
         local file_issues=""
         
         # In this shell, before anything reads it from a subshell.
+        nut_load_file "$file" || true
         tw_load_exemptions "$file"
 
         # Get all functions in this file

--- a/examples/checks/check_trivial_wrappers.sh
+++ b/examples/checks/check_trivial_wrappers.sh
@@ -93,42 +93,99 @@ has_exempt_annotation() {
     [[ -n "${_TW_EXEMPT["${file}:${func_name}"]:-}" ]]
 }
 
+# How often every name appears, everywhere, counted once for the whole run.
+#
+# This was a `grep -c` per file per function. On 24 files and 440 functions
+# that is 10,560 greps, and `analyze_function` runs in a command substitution,
+# so nothing it worked out ever survived the return. Built here instead, in the
+# shell that runs the loop, once.
+#
+# Counts are lines-containing rather than occurrences, because that is what
+# `grep -c` gave and the thresholds were chosen against it.
+#
+# awk where there is one and the shell where there is not. This check needs awk
+# elsewhere already, so it is not a new dependency; the fallback is here so a
+# machine without it gets a slow answer rather than no answer.
+declare -gA _TW_LOCAL=()
+declare -gA _TW_GLOBAL=()
+declare -gi _TW_USAGE_DONE=0
+_TW_SEP=$'\034'
+
+_tw_count_with_awk() {
+    local key n
+    while IFS=$'\t' read -r key n; do
+        [[ -n "$key" ]] || continue
+        case "$key" in
+            G*) _TW_GLOBAL["${key#G}"]=$n ;;
+            L*) _TW_LOCAL["${key#L}"]=$n ;;
+        esac
+    done < <(get_script_files | tr '\n' '\0' | xargs -0 awk '
+        FNR == 1 { delete seen }
+        {
+            delete seen
+            line = $0
+            while (match(line, /[A-Za-z_][A-Za-z0-9_]*/)) {
+                seen[substr(line, RSTART, RLENGTH)] = 1
+                line = substr(line, RSTART + RLENGTH)
+            }
+            for (w in seen) { g[w]++; l[FILENAME "\034" w]++ }
+        }
+        END {
+            for (w in g) printf "G%s\t%d\n", w, g[w]
+            for (k in l) printf "L%s\t%d\n", k, l[k]
+        }' 2>/dev/null)
+}
+
+_tw_count_in_shell() {
+    local file line rest name n i
+    local -A onthisline=()
+    while IFS= read -r file; do
+        [[ -n "$file" ]] || continue
+        nut_load_file "$file" || continue
+        n="$(nut_file_lines "$file")"
+        for (( i = 1; i <= n; i++ )); do
+            line="$(nut_file_line "$file" "$i")"
+            onthisline=()
+            rest="$line"
+            while [[ "$rest" =~ ([A-Za-z_][A-Za-z0-9_]*) ]]; do
+                name="${BASH_REMATCH[1]}"
+                onthisline["$name"]=1
+                rest="${rest#*"$name"}"
+            done
+            for name in "${!onthisline[@]}"; do
+                _TW_GLOBAL["$name"]=$(( ${_TW_GLOBAL["$name"]:-0} + 1 ))
+                _TW_LOCAL["${file}${_TW_SEP}${name}"]=$(( ${_TW_LOCAL["${file}${_TW_SEP}${name}"]:-0} + 1 ))
+            done
+        done
+    done < <(get_script_files)
+}
+
+tw_load_usages() {
+    (( _TW_USAGE_DONE == 1 )) && return 0
+    _TW_USAGE_DONE=1
+    if command -v awk >/dev/null 2>&1 && command -v xargs >/dev/null 2>&1; then
+        _tw_count_with_awk
+    fi
+    # Nothing came back, so either there was no awk or it could not run. A
+    # count of zero everywhere would exempt every function in the library.
+    (( ${#_TW_GLOBAL[@]} == 0 )) && _tw_count_in_shell
+    return 0
+}
+
 # Count usages of a function in a specific file (excluding the definition)
 count_local_usages() {
-    local file="$1"
-    local func_name="$2"
-    
-    local count
-    count=$(grep -c "\b${func_name}\b" "$file" 2>/dev/null || echo "0")
-    count="${count//[^0-9]/}"
-    [[ -z "$count" ]] && count=0
-    
-    # Subtract 1 for the definition itself
-    count=$((count - 1))
-    [[ $count -lt 0 ]] && count=0
-    
-    echo "$count"
+    local count="${_TW_LOCAL["${1}${_TW_SEP}${2}"]:-0}"
+    count=$(( count - 1 ))
+    (( count < 0 )) && count=0
+    printf '%s' "$count"
 }
 
 # Count usages of a function across all files
 count_global_usages() {
-    local func_name="$1"
-    
-    local total=0
-    local file count
-    
-    while IFS= read -r file; do
-        count=$(grep -c "\b${func_name}\b" "$file" 2>/dev/null || echo "0")
-        count="${count//[^0-9]/}"
-        [[ -z "$count" ]] && count=0
-        total=$((total + count))
-    done < <(get_script_files)
-    
-    # Subtract 1 for the definition
-    total=$((total - 1))
-    [[ $total -lt 0 ]] && total=0
-    
-    echo "$total"
+    local total="${_TW_GLOBAL["${1:-}"]:-0}"
+    total=$(( total - 1 ))
+    (( total < 0 )) && total=0
+    printf '%s' "$total"
 }
 
 # Extract meaningful code lines from a function body
@@ -185,6 +242,22 @@ count_tokens() {
 
 # Analyze a single function for trivial wrapper status
 # Returns: pass, warn, or fail
+declare -g TW_STATUS="" TW_DETAILS=""
+
+# One place that splits "status:details" into the two globals.
+_tw_set() {
+    TW_STATUS="${1%%:*}"
+    TW_DETAILS="${1#*:}"
+    return 0
+}
+
+
+# Sets TW_STATUS and TW_DETAILS rather than printing them.
+#
+# It was read through a command substitution, which is a fork, once per
+# function: 386 of them on this library and most of what the check still cost
+# after the pipelines came out. Nothing about the analysis needed a subshell;
+# it needed a return value with two parts in it.
 analyze_function() {
     local file="$1"
     local func_name="$2"
@@ -195,13 +268,13 @@ analyze_function() {
     
     # Not a trivial wrapper if more than MAX_LINES
     if [[ $line_count -gt $MAX_LINES ]]; then
-        echo "pass:not_trivial"
+        _tw_set "pass:not_trivial"
         return
     fi
     
     # Check for exempt annotation
     if has_exempt_annotation "$file" "$func_name"; then
-        echo "pass:annotated"
+        _tw_set "pass:annotated"
         return
     fi
     
@@ -213,32 +286,32 @@ analyze_function() {
     
     # Check ergonomic passes (ANY of these = pass)
     if [[ $local_usages -ge $LOCAL_USAGE_THRESHOLD ]]; then
-        echo "pass:local_usage"
+        _tw_set "pass:local_usage"
         return
     fi
     
     if [[ $global_usages -ge $GLOBAL_USAGE_THRESHOLD ]]; then
-        echo "pass:global_usage"
+        _tw_set "pass:global_usage"
         return
     fi
     
     if [[ $var_count -ge $MIN_VARS_FOR_ERGONOMIC ]]; then
-        echo "pass:ergonomic_vars"
+        _tw_set "pass:ergonomic_vars"
         return
     fi
     
     if [[ $token_count -ge $TOKEN_COMPLEXITY_PASS ]]; then
-        echo "pass:complex"
+        _tw_set "pass:complex"
         return
     fi
     
     # Warn vs fail based on token complexity
     if [[ $token_count -ge $TOKEN_COMPLEXITY_WARN ]]; then
-        echo "warn:${line_count}:${local_usages}:${global_usages}:${var_count}:${token_count}"
+        _tw_set "warn:${line_count}:${local_usages}:${global_usages}:${var_count}:${token_count}"
         return
     fi
     
-    echo "fail:${line_count}:${local_usages}:${global_usages}:${var_count}:${token_count}"
+    _tw_set "fail:${line_count}:${local_usages}:${global_usages}:${var_count}:${token_count}"
 }
 
 # Get the first meaningful line of a function (for display)
@@ -288,6 +361,7 @@ test_trivial_wrappers() {
         # In this shell, before anything reads it from a subshell.
         nut_load_file "$file" || true
         tw_load_exemptions "$file"
+        tw_load_usages
 
         # Get all functions in this file
         local functions
@@ -296,11 +370,9 @@ test_trivial_wrappers() {
         while IFS= read -r func_name; do
             [[ -z "$func_name" ]] && continue
             
-            local result
-            result=$(analyze_function "$file" "$func_name")
-            
-            local status="${result%%:*}"
-            local details="${result#*:}"
+            analyze_function "$file" "$func_name"
+            local status="$TW_STATUS"
+            local details="$TW_DETAILS"
             
             case "$status" in
                 pass)

--- a/examples/checks/check_trivial_wrappers.sh
+++ b/examples/checks/check_trivial_wrappers.sh
@@ -358,6 +358,27 @@ test_trivial_wrappers() {
         local file_has_issues=0
         local file_issues=""
         
+        # What this file contributed last time, if nothing that could change
+        # it has changed. One read for the whole file rather than one per
+        # function: a lookup that forks costs more than the work it saves, and
+        # the first attempt at this was measurably slower than no cache.
+        local __blob __kind __text
+        if nut_cache_hit "trivial_wrappers" "$file" 2>/dev/null \
+           && __blob="$(nut_cache_read "trivial_wrappers" "$file" 2>/dev/null)"; then
+            while IFS= read -r __line; do
+                [[ -n "$__line" ]] || continue
+                __kind="${__line%%$'\t'*}"; __text="${__line#*$'\t'}"
+                case "$__kind" in
+                    E) errors+=("$__text"); error_count=$((error_count + 1))
+                       wrapper_count=$((wrapper_count + 1)) ;;
+                    W) warnings+=("$__text"); warn_count=$((warn_count + 1))
+                       wrapper_count=$((wrapper_count + 1)) ;;
+                esac
+            done <<< "$__blob"
+            continue
+        fi
+
+
         # In this shell, before anything reads it from a subshell.
         nut_load_file "$file" || true
         tw_load_exemptions "$file"
@@ -366,7 +387,8 @@ test_trivial_wrappers() {
         # Get all functions in this file
         local functions
         functions=$(extract_functions "$file")
-        
+        local __record=""
+
         while IFS= read -r func_name; do
             [[ -z "$func_name" ]] && continue
             
@@ -396,6 +418,7 @@ test_trivial_wrappers() {
                     fi
                     
                     warnings+=("${func_name}() - ${lines} line(s), ${local_use} local / ${global_use} global usages, ${vars} vars, ${tokens} tokens")
+                    __record+="W"$'\t'"${func_name}() - ${lines} line(s), ${local_use} local / ${global_use} global usages, ${vars} vars, ${tokens} tokens"$'\n' 
                     ;;
                 fail)
                     wrapper_count=$((wrapper_count + 1))
@@ -415,10 +438,13 @@ test_trivial_wrappers() {
                     fi
                     
                     errors+=("${func_name}() - ${lines} line(s), ${local_use} local / ${global_use} global usages, ${vars} vars, ${tokens} tokens")
+                    __record+="E"$'\t'"${func_name}() - ${lines} line(s), ${local_use} local / ${global_use} global usages, ${vars} vars, ${tokens} tokens"$'\n' 
                     ;;
             esac
         done <<< "$functions"
-        
+
+        nut_cache_write "trivial_wrappers" "$file" "$__record" 2>/dev/null || true
+
         if [[ -n "$file_issues" ]] && [[ "$QUIET_MODE" != "1" ]]; then
             echo -e "$file_issues"
         fi

--- a/examples/checks/check_trivial_wrappers.sh
+++ b/examples/checks/check_trivial_wrappers.sh
@@ -58,15 +58,39 @@ load_config() {
 # FUNCTION ANALYSIS
 # =============================================================================
 
+# Which functions in a file carry an exempting annotation.
+#
+# Built once per file, in the shell that runs the loop. `analyze_function` is
+# called through a command substitution, which is a subshell: anything it works
+# out is thrown away when it returns, so asking per function meant walking the
+# whole file per function, twice, and that was most of this check's time.
+declare -gA _TW_EXEMPT=()
+declare -gA _TW_EXEMPT_DONE=()
+
+tw_load_exemptions() {
+    local file="$1"
+    [[ -n "${_TW_EXEMPT_DONE[$file]:-}" ]] && return 0
+    _TW_EXEMPT_DONE[$file]=1
+    local marker name fn
+    for marker in "$(cfg_get_or "annotations.public_api" "#[pub]")" \
+                  "$(cfg_get_or "annotations.allow_trivial_wrapper_ergonomics" "DISABLED_ANNOTATION")"; do
+        [[ -n "$marker" ]] || continue
+        name="$(attr_name_of "$marker")" || continue
+        name="${name%%$'\t'*}"
+        [[ -n "$name" ]] || continue
+        while IFS= read -r fn; do
+            [[ -n "$fn" ]] && _TW_EXEMPT["${file}:${fn}"]=1
+        done < <(attr_find "$file" "$name" 2>/dev/null)
+    done
+    return 0
+}
+
 # Check if a function has an exempting annotation
-# Uses annotation patterns from config
 # Returns 0 if exempt, 1 if not
 has_exempt_annotation() {
-    local file="$1"
-    local func_name="$2"
-    
-    # Use the framework's has_trivial_wrapper_exemption which reads from config
-    has_trivial_wrapper_exemption "$file" "$func_name"
+    local file="$1" func_name="$2"
+    [[ -n "${_TW_EXEMPT_DONE[$file]:-}" ]] || return 1
+    [[ -n "${_TW_EXEMPT["${file}:${func_name}"]:-}" ]]
 }
 
 # Count usages of a function in a specific file (excluding the definition)
@@ -285,6 +309,9 @@ test_trivial_wrappers() {
         local file_has_issues=0
         local file_issues=""
         
+        # In this shell, before anything reads it from a subshell.
+        tw_load_exemptions "$file"
+
         # Get all functions in this file
         local functions
         functions=$(extract_functions "$file")

--- a/find-nutshell
+++ b/find-nutshell
@@ -14,10 +14,15 @@
 # keyed by version, one resolution step in front of it, and a fetch when the
 # asked-for one is not there yet.
 #
-# The order: what the caller named, then what is installed if it satisfies,
-# then the store, then a fetch into the store, then whatever is vendored. Only
-# the last of those is a compromise, and it is there for the machine with no
-# network that this tool is usually rescuing.
+# The order for a version pin: what the caller named, then what is installed if
+# it satisfies, then the store, then a fetch into the store, then whatever is
+# vendored. Only the last of those is a compromise, and it is there for the
+# machine with no network that this tool is usually rescuing.
+#
+# A branch pin takes a different route and it is stated here because the two
+# get conflated: what the caller named, then the branch's head, then vendored.
+# Neither the installed interpreter nor the version store can answer a branch
+# pin, so neither is consulted. Why, at `nutshell_find`.
 #
 # Preferring an installed interpreter over the store is deliberate. One shared
 # nutshell that everything uses is the good state; the store exists for the
@@ -77,6 +82,16 @@ nutshell_find() {
     # remote cannot be reached. This is the shape op settled on for every other
     # dependency, and the interpreter is not an exception to it.
     if [[ -n "$want" ]] && ! _nutshell_is_version "$want"; then
+        # Said before anything is attempted, because the message at the bottom
+        # of this branch reports what could not be reached and nothing was.
+        # `feat/toolchains` is a legal branch name and is not a directory name
+        # here; the limit is real and it should not read as a network failure.
+        if ! _nutshell_safe_name "$want"; then
+            printf 'nutshell: %s cannot name a toolchain directory, so it cannot be pinned\n' \
+                "$want" >&2
+            printf '  a ref here is one path component: no slash, no leading dot, no space\n' >&2
+            return 1
+        fi
         # What the caller named still wins, before the remote is asked. An
         # override that is quietly ignored is worse than one that fails, and a
         # test suite that exports this must not be sent to the network by every

--- a/find-nutshell
+++ b/find-nutshell
@@ -136,23 +136,43 @@ nutshell_find() {
     return 1
 }
 
+#[pub]
+# The root both the toolchains and the externs sit under.
+#
+# The platform branch is spelled out here rather than taken from `lib/xdg.sh`,
+# which is the module that owns it. This file runs before nutshell exists and
+# cannot use a module, so the duplication is deliberate and the two are held
+# together by a test rather than by anybody remembering. Change one and the
+# suite says which other one to change.
+# Usage: nutshell_store_root -> a path
+nutshell_store_root() {
+    if [[ -n "${NUTSHELL_STORE:-}" ]]; then
+        printf '%s' "${NUTSHELL_STORE%/}"
+        return 0
+    fi
+    if [[ -n "${XDG_DATA_HOME:-}" ]]; then
+        printf '%s/nutshell' "${XDG_DATA_HOME%/}"
+        return 0
+    fi
+    case "$(uname -s 2>/dev/null)" in
+        Darwin) printf '%s/Library/Application Support/nutshell' "${HOME:-.}" ;;
+        *)      printf '%s/.local/share/nutshell' "${HOME:-.}" ;;
+    esac
+}
+
+#[pub]
 # Where toolchains live. One directory per version, each a checkout.
 #
-# Beside the externs, under one store root, because the interpreter is a
+# Beside the externs, under the one root, because the interpreter is a
 # dependency like any other and giving it its own arrangement is what let it
-# drift out of step in the first place. `NUTSHELL_TOOLCHAINS` names this
-# directory; `NUTSHELL_STORE` names the root both it and the externs sit under.
-nutshell_store() {
+# drift out of step in the first place.
+# Usage: nutshell_toolchain_dir -> a path
+nutshell_toolchain_dir() {
     if [[ -n "${NUTSHELL_TOOLCHAINS:-}" ]]; then
         printf '%s' "${NUTSHELL_TOOLCHAINS%/}"
         return 0
     fi
-    if [[ -n "${NUTSHELL_STORE:-}" ]]; then
-        printf '%s/toolchains' "${NUTSHELL_STORE%/}"
-        return 0
-    fi
-    printf '%s/nutshell/toolchains' \
-        "${XDG_DATA_HOME:-${HOME:-.}/.local/share}"
+    printf '%s/toolchains' "$(nutshell_store_root)"
 }
 
 #[pub]
@@ -165,7 +185,7 @@ nutshell_store() {
 # Usage: nutshell_toolchains -> prints versions
 nutshell_toolchains() {
     local store d v name
-    store="$(nutshell_store)"
+    store="$(nutshell_toolchain_dir)"
     [[ -d "$store" ]] || return 0
     for d in "$store"/*/; do
         [[ -f "${d}init" ]] || continue
@@ -203,7 +223,7 @@ _nutshell_num() {
 # The newest toolchain satisfying the caller, or nothing.
 _nutshell_in_store() {
     local want="${1:-}" store v cand
-    store="$(nutshell_store)"
+    store="$(nutshell_toolchain_dir)"
     [[ -d "$store" ]] || return 1
     while IFS= read -r v; do
         [[ -n "$v" ]] || continue
@@ -220,7 +240,7 @@ _nutshell_in_store() {
 # says which and falls through to whatever else the machine has.
 _nutshell_fetch() {
     local want="$1" store dir remote
-    store="$(nutshell_store)"
+    store="$(nutshell_toolchain_dir)"
     dir="${store}/${want}"
     remote="${NUTSHELL_REMOTE:-https://github.com/orgrinrt/nutshell.git}"
 

--- a/find-nutshell
+++ b/find-nutshell
@@ -153,7 +153,13 @@ nutshell_find() {
 
     # 4. Not there yet, so fetch it. A version that exists and is simply not on
     #    this machine is not a failure, it is a download.
-    if [[ -n "$want" ]] && cand="$(_nutshell_fetch "$want")"; then
+    #
+    #    A fetch that just failed is not retried until the window is out. The
+    #    ordinary standing case is a pin at a version nobody has tagged yet,
+    #    which resolves to vendored in the end; without this it pays a network
+    #    round trip and two lines of stderr on every run of every tool.
+    if [[ -n "$want" ]] && ! _nutshell_fetch_failed_recently "$want" \
+       && cand="$(_nutshell_fetch "$want")"; then
         NUTSHELL_INIT="$cand"; NUTSHELL_FROM="fetched"
         return 0
     fi
@@ -180,6 +186,37 @@ _nutshell_is_version() {
     [[ "${1:-}" =~ ^[0-9]+(\.[0-9]+)*$ ]]
 }
 
+# The revision this branch was last resolved to, or nothing.
+_nutshell_branch_head() {
+    local pointer="${1}/.head" sha=""
+    [[ -r "$pointer" ]] || return 1
+    read -r sha < "$pointer" 2>/dev/null
+    [[ "$sha" =~ ^[0-9a-f]{7,40}$ ]] || return 1
+    printf '%s' "$sha"
+}
+
+# Throw away revisions of this branch that nothing has touched for a day.
+#
+# The checkouts are keyed by revision and never overwritten, so they would
+# otherwise accumulate one directory per push. A day is long enough that
+# nothing can still be sourcing out of one: resolution takes milliseconds and
+# the window it resolves inside is an hour.
+_nutshell_branch_prune() {
+    local base="$1" keep="$2" d name
+    for d in "$base"/*/; do
+        [[ -d "$d" ]] || continue
+        name="${d%/}"; name="${name##*/}"
+        [[ "$name" == "$keep" ]] && continue
+        [[ "$name" =~ ^[0-9a-f]{7,40}$ ]] || continue
+        # `find -mtime +0` is a whole day, and it is the one age test that is
+        # in POSIX. A machine without find keeps the directory, which is the
+        # harmless way to be wrong here.
+        [[ -n "$(find "$base" -maxdepth 1 -name "$name" -mtime +0 2>/dev/null)" ]] \
+            && rm -rf "${d%/}"
+    done
+    return 0
+}
+
 # The head of a branch, as a checkout in the store, refreshed when it moves.
 #
 # Kept under `branches/` so it cannot collide with the version directories,
@@ -187,67 +224,92 @@ _nutshell_is_version() {
 # such invariant: the version inside it changes whenever the branch does, and
 # that is the point of pinning one.
 #
+# Under `branches/<ref>/` the checkouts are keyed by the revision they hold,
+# and `.head` names the one the branch last resolved to. That is what makes the
+# store safe to share: a revision directory is written once and never replaced,
+# so a fetch triggered by somebody else's push cannot delete the tree a running
+# interpreter is sourcing out of. It is also the shape the pin design calls for,
+# where a branch has already become the revision it pointed at before anything
+# is looked up.
+#
 # The remote is asked at most once an hour. A pin that means "the head" and
 # checks on every invocation turns a shell prompt into a network client; one
 # that never checks is not a branch pin at all.
 _nutshell_branch() {
-    local ref="$1" store dir stamp remote head now last
-    store="$(nutshell_toolchain_dir)/branches"
-    dir="${store}/${ref}"
-    stamp="${dir}.checked"
+    local ref="$1" base stamp remote head now last known
+    _nutshell_safe_name "$ref" || return 1
+    base="$(nutshell_toolchain_dir)/branches/${ref}"
+    stamp="${base}/.checked"
     remote="${NUTSHELL_REMOTE:-https://github.com/orgrinrt/nutshell.git}"
 
     now="$(date +%s 2>/dev/null)" || now=0
     last=0
     [[ -r "$stamp" ]] && read -r last < "$stamp" 2>/dev/null
     [[ "$last" =~ ^[0-9]+$ ]] || last=0
+    known="$(_nutshell_branch_head "$base")" || known=""
 
     # Inside the window, what is here is what the pin means.
-    if [[ -f "${dir}/init" ]] \
+    if [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]] \
        && (( now - last < ${NUTSHELL_BRANCH_TTL:-3600} )); then
-        printf '%s' "${dir}/init"
+        printf '%s' "${base}/${known}/init"
         return 0
     fi
 
     command -v git >/dev/null 2>&1 || {
-        [[ -f "${dir}/init" ]] && { printf '%s' "${dir}/init"; return 0; }
+        [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]] \
+            && { printf '%s' "${base}/${known}/init"; return 0; }
         return 1
     }
 
     head="$(git ls-remote "$remote" "refs/heads/${ref}" 2>/dev/null)"
     head="${head%%[[:space:]]*}"
-    if [[ -z "$head" ]]; then
+    if [[ ! "$head" =~ ^[0-9a-f]{7,40}$ ]]; then
         # Offline, or no such branch. What is already here is better than
-        # nothing, and stale is a thing this can say rather than pretend about.
-        if [[ -f "${dir}/init" ]]; then
-            printf 'nutshell: could not reach %s, using the %s already here\n' \
-                "$remote" "$ref" >&2
-            printf '%s' "${dir}/init"
+        # nothing, and the revision it is running from is named rather than
+        # pretended about.
+        if [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]]; then
+            printf 'nutshell: could not reach %s, running %s from %s\n' \
+                "$remote" "$ref" "${known:0:12}" >&2
+            printf '%s' "${base}/${known}/init"
             return 0
         fi
         return 1
     fi
 
-    if [[ -f "${dir}/init" ]] \
-       && [[ "$(git -C "$dir" rev-parse HEAD 2>/dev/null)" == "$head" ]]; then
-        mkdir -p "$store" 2>/dev/null && printf '%s\n' "$now" > "$stamp"
-        printf '%s' "${dir}/init"
+    # Already fetched, whether or not this process is the one that fetched it.
+    if [[ -f "${base}/${head}/init" ]]; then
+        mkdir -p "$base" 2>/dev/null \
+            && { printf '%s\n' "$now" > "$stamp"; printf '%s\n' "$head" > "${base}/.head"; }
+        printf '%s' "${base}/${head}/init"
         return 0
     fi
 
-    mkdir -p "$store" 2>/dev/null || return 1
-    local tmp="${dir}.fetching.$$"
+    mkdir -p "$base" 2>/dev/null || return 1
+    local tmp="${base}/.fetching.$$"
     rm -rf "$tmp"
     printf 'nutshell: %s moved, fetching\n' "$ref" >&2
     if ! git clone --quiet --depth 1 --branch "$ref" "$remote" "$tmp" 2>/dev/null; then
         rm -rf "$tmp"
-        [[ -f "${dir}/init" ]] && { printf '%s' "${dir}/init"; return 0; }
+        [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]] \
+            && { printf '%s' "${base}/${known}/init"; return 0; }
         return 1
     fi
-    rm -rf "$dir"
-    mv "$tmp" "$dir" || { rm -rf "$tmp"; return 1; }
+
+    # The clone is named by what it actually holds, not by what the remote said
+    # a moment ago. A branch that moved between the two would otherwise be
+    # stored under a revision it does not contain.
+    local got; got="$(git -C "$tmp" rev-parse HEAD 2>/dev/null)"
+    [[ "$got" =~ ^[0-9a-f]{7,40}$ ]] || got="$head"
+
+    if ! _nutshell_adopt "$tmp" "${base}/${got}"; then
+        [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]] \
+            && { printf '%s' "${base}/${known}/init"; return 0; }
+        return 1
+    fi
     printf '%s\n' "$now" > "$stamp"
-    printf '%s' "${dir}/init"
+    printf '%s\n' "$got" > "${base}/.head"
+    _nutshell_branch_prune "$base" "$got"
+    printf '%s' "${base}/${got}/init"
 }
 
 #[pub]
@@ -326,8 +388,16 @@ _nutshell_sort_versions() {
 }
 
 # One version field as a number. Anything from the first non-digit onward is
-# dropped, so a `0.4.0-rc1` sorts beside `0.4.0` instead of aborting the whole
-# listing on an arithmetic error.
+# dropped, so a malformed field cannot abort the whole listing on an arithmetic
+# error.
+#
+# It does not order prereleases and is not trying to. **The store is
+# release-only.** `nutshell_toolchains` skips a directory whose name is not what
+# the interpreter inside it reports, `_nutshell_version_of` reads that report as
+# digits and dots, and `_nutshell_fetch` refuses to store anything whose report
+# disagrees with the name asked for. So `0.4.0-rc1` cannot become a directory
+# here and there is nothing for an ordering to be wrong about. This is a guard
+# against a malformed name, and the tests say so.
 _nutshell_num() {
     local n="${1:-}"
     n="${n%%[!0-9]*}"
@@ -347,13 +417,65 @@ _nutshell_in_store() {
     return 1
 }
 
+# Is a name safe to build a store path out of?
+#
+# Everything under the store is named by something a caller supplied, and the
+# store is then written to and removed from. A ref carrying a slash or a dot
+# pair is not a directory name here, whatever git thinks of it.
+_nutshell_safe_name() {
+    local n="${1:-}"
+    [[ -n "$n" ]] || return 1
+    case "$n" in
+        */*|*..*|.*|*[[:space:]]*) return 1 ;;
+    esac
+    return 0
+}
+
+# Where a failed fetch is remembered, so the next run does not repeat it.
+_nutshell_fail_stamp() {
+    printf '%s/failed/%s' "$(nutshell_toolchain_dir)" "$1"
+}
+
+# Did fetching this fail recently enough that trying again is just noise?
+#
+# The window is the branch one, for the same reason: a pin that cannot be
+# satisfied is the standing state until somebody pushes a tag, and asking the
+# remote about it on every invocation turns a shell prompt into a network
+# client.
+_nutshell_fetch_failed_recently() {
+    local want="${1:-}" stamp now last
+    _nutshell_safe_name "$want" || return 1
+    stamp="$(_nutshell_fail_stamp "$want")"
+    [[ -r "$stamp" ]] || return 1
+    now="$(date +%s 2>/dev/null)" || return 1
+    last=0
+    read -r last < "$stamp" 2>/dev/null
+    [[ "$last" =~ ^[0-9]+$ ]] || return 1
+    (( now - last < ${NUTSHELL_FETCH_RETRY:-3600} ))
+}
+
+# Remember that fetching this failed, so the window above has something to read.
+_nutshell_remember_failure() {
+    local want="${1:-}" stamp now
+    _nutshell_safe_name "$want" || return 0
+    stamp="$(_nutshell_fail_stamp "$want")"
+    mkdir -p "${stamp%/*}" 2>/dev/null || return 0
+    now="$(date +%s 2>/dev/null)" || now=0
+    printf '%s\n' "$now" > "$stamp" 2>/dev/null || true
+}
+
 # Put a version in the store and print its root.
 #
 # Shallow, at the tag, from wherever the caller says nutshell lives. A failure
 # here is ordinary: no git, no network, or a version nobody has tagged yet. It
-# says which and falls through to whatever else the machine has.
+# says which, remembers it, and falls through to whatever else the machine has.
 _nutshell_fetch() {
     local want="$1" store dir remote
+    _nutshell_safe_name "$want" || {
+        printf 'nutshell: %s is not a name a toolchain can be stored under\n' \
+            "$want" >&2
+        return 1
+    }
     store="$(nutshell_toolchain_dir)"
     dir="${store}/${want}"
     remote="${NUTSHELL_REMOTE:-https://github.com/orgrinrt/nutshell.git}"
@@ -361,6 +483,7 @@ _nutshell_fetch() {
     command -v git >/dev/null 2>&1 || {
         printf 'nutshell: %s is not on this machine and there is no git to fetch it with\n' \
             "$want" >&2
+        _nutshell_remember_failure "$want"
         return 1
     }
 
@@ -374,6 +497,7 @@ _nutshell_fetch() {
     if ! git clone --quiet --depth 1 --branch "$want" "$remote" "$tmp" 2>/dev/null; then
         rm -rf "$tmp"
         printf 'nutshell: could not fetch %s from %s\n' "$want" "$remote" >&2
+        _nutshell_remember_failure "$want"
         return 1
     fi
 
@@ -384,12 +508,33 @@ _nutshell_fetch() {
     if [[ "$got" != "$want" ]]; then
         rm -rf "$tmp"
         printf 'nutshell: %s in %s reports itself as %s\n' "$want" "$remote" "${got:-nothing}" >&2
+        _nutshell_remember_failure "$want"
         return 1
     fi
 
-    rm -rf "$dir"
-    mv "$tmp" "$dir" || { rm -rf "$tmp"; return 1; }
+    _nutshell_adopt "$tmp" "$dir" || return 1
     printf '%s' "${dir}/init"
+}
+
+# Move a fetched copy into place, or keep the one that beat us to it.
+#
+# Whoever gets there first wins and the loser throws its own copy away. The
+# store is shared by every project on the machine and nothing locks it, so a
+# second process fetching the same thing must not remove the directory a
+# running interpreter is sourcing out of. It does not have to: both copies hold
+# the same commit, so adopting the one already there is the same answer.
+#
+# `mv` onto a name that does not exist is a rename and atomic. Onto a directory
+# that does exist it moves the source *inside* it, which is the whole reason
+# this is a function: the check and the rename are not one step, so a loser can
+# still land its copy at `<dir>/<scratch>` and that gets cleaned up here.
+_nutshell_adopt() {
+    local tmp="$1" dir="$2" leaf="${1##*/}"
+    if [[ ! -e "$dir" ]]; then
+        mv "$tmp" "$dir" 2>/dev/null
+    fi
+    rm -rf "${dir}/${leaf}" "$tmp" 2>/dev/null
+    [[ -f "${dir}/init" ]]
 }
 
 # The version an interpreter reports, without loading it. Reading the file

--- a/find-nutshell
+++ b/find-nutshell
@@ -77,13 +77,21 @@ nutshell_find() {
     # remote cannot be reached. This is the shape op settled on for every other
     # dependency, and the interpreter is not an exception to it.
     if [[ -n "$want" ]] && ! _nutshell_is_version "$want"; then
+        # What the caller named still wins, before the remote is asked. An
+        # override that is quietly ignored is worse than one that fails, and a
+        # test suite that exports this must not be sent to the network by every
+        # child process it starts.
+        if [[ -n "${NUTSHELL_HOME:-}" ]]; then
+            if cand="$(_nutshell_root_of "${NUTSHELL_HOME}/init")"; then
+                NUTSHELL_INIT="$cand"; NUTSHELL_FROM="NUTSHELL_HOME"
+                return 0
+            fi
+            printf 'nutshell: NUTSHELL_HOME is %s and there is no init in it\n' \
+                "$NUTSHELL_HOME" >&2
+            return 1
+        fi
         if cand="$(_nutshell_branch "$want")"; then
             NUTSHELL_INIT="$cand"; NUTSHELL_FROM="branch:${want}"
-            return 0
-        fi
-        if [[ -n "${NUTSHELL_HOME:-}" ]] \
-           && cand="$(_nutshell_root_of "${NUTSHELL_HOME}/init")"; then
-            NUTSHELL_INIT="$cand"; NUTSHELL_FROM="NUTSHELL_HOME"
             return 0
         fi
         if [[ -n "$root" ]] \

--- a/find-nutshell
+++ b/find-nutshell
@@ -8,17 +8,24 @@
 # Sourced by a tool before nutshell exists, so it is plain bash and depends on
 # nothing.
 #
-# The order matters and the reason is the whole point: an installed nutshell is
-# shared by everything on the machine, and a copy inside one project is a
-# second version that drifts from it in silence. Every other package manager
-# settled this the same way. cargo keeps one shared registry and resolves the
-# toolchain separately; pnpm keeps one content-addressed store and links into
-# it; yarn 2 has no per-project tree at all. A per-project physical copy is the
-# thing that goes stale, and it went stale here twice in one day.
+# Versions coexist. A tool asks for the one it needs and gets that one, and a
+# machine carrying four of them is the ordinary state rather than a mess to
+# clean up. This is rustup's arrangement and renki's: a store of toolchains
+# keyed by version, one resolution step in front of it, and a fetch when the
+# asked-for one is not there yet.
 #
-# So: what the caller named, then what is installed, then what is vendored. The
-# vendored copy is the fallback for a machine with nothing installed, which is
-# the machine this tool is usually rescuing.
+# The order: what the caller named, then what is installed if it satisfies,
+# then the store, then a fetch into the store, then whatever is vendored. Only
+# the last of those is a compromise, and it is there for the machine with no
+# network that this tool is usually rescuing.
+#
+# Preferring an installed interpreter over the store is deliberate. One shared
+# nutshell that everything uses is the good state; the store exists for the
+# tools that cannot use it, not to replace it. Every other package manager
+# settled the sharing question the same way: cargo keeps one registry and
+# resolves the toolchain separately, pnpm keeps one content-addressed store and
+# links into it, yarn 2 has no per-project tree at all. A per-project physical
+# copy is the thing that goes stale, and it went stale here twice in one day.
 #
 # Usage:
 #   . "${HERE}/find-nutshell"
@@ -96,14 +103,29 @@ nutshell_find() {
                 NUTSHELL_INIT="$cand"; NUTSHELL_FROM="installed"
                 return 0
             fi
-            # Said out loud. Silently falling through to the vendored copy
-            # would hide exactly the version skew this is here to surface.
-            printf 'nutshell: the installed one at %s is %s and this needs %s; using the vendored copy\n' \
+            # Said out loud. Falling through in silence would hide exactly
+            # the version skew this is here to surface.
+            printf 'nutshell: the installed one at %s is %s and this needs %s\n' \
                 "$cand" "$(_nutshell_version_of "$cand")" "$want" >&2
         fi
     fi
 
-    # 3. What is vendored, for a machine with nothing installed.
+    # 3. The store. Several versions live here at once and the newest one that
+    #    satisfies the caller is taken, which is what makes two tools wanting
+    #    two different nutshells a non-event.
+    if cand="$(_nutshell_in_store "$want")"; then
+        NUTSHELL_INIT="$cand"; NUTSHELL_FROM="toolchain"
+        return 0
+    fi
+
+    # 4. Not there yet, so fetch it. A version that exists and is simply not on
+    #    this machine is not a failure, it is a download.
+    if [[ -n "$want" ]] && cand="$(_nutshell_fetch "$want")"; then
+        NUTSHELL_INIT="$cand"; NUTSHELL_FROM="fetched"
+        return 0
+    fi
+
+    # 5. What is vendored, for a machine with no network and nothing installed.
     if [[ -n "$root" ]] && cand="$(_nutshell_root_of "${root}/lib/nutshell/init")"; then
         NUTSHELL_INIT="$cand"; NUTSHELL_FROM="vendored"
         return 0
@@ -112,6 +134,128 @@ nutshell_find() {
     printf 'nutshell: no interpreter found. Install one, set NUTSHELL_HOME, or run:\n' >&2
     printf '  git submodule update --init\n' >&2
     return 1
+}
+
+# Where toolchains live. One directory per version, each a checkout.
+#
+# Beside the externs, under one store root, because the interpreter is a
+# dependency like any other and giving it its own arrangement is what let it
+# drift out of step in the first place. `NUTSHELL_TOOLCHAINS` names this
+# directory; `NUTSHELL_STORE` names the root both it and the externs sit under.
+nutshell_store() {
+    if [[ -n "${NUTSHELL_TOOLCHAINS:-}" ]]; then
+        printf '%s' "${NUTSHELL_TOOLCHAINS%/}"
+        return 0
+    fi
+    if [[ -n "${NUTSHELL_STORE:-}" ]]; then
+        printf '%s/toolchains' "${NUTSHELL_STORE%/}"
+        return 0
+    fi
+    printf '%s/nutshell/toolchains' \
+        "${XDG_DATA_HOME:-${HOME:-.}/.local/share}"
+}
+
+#[pub]
+# Every version in the store, newest first, one per line.
+#
+# A directory is named by the version it holds, and one whose contents report
+# something else is skipped rather than trusted. The name is what the resolver
+# looks things up by, so a directory that lies about itself would be handed
+# out for a request it does not satisfy.
+# Usage: nutshell_toolchains -> prints versions
+nutshell_toolchains() {
+    local store d v name
+    store="$(nutshell_store)"
+    [[ -d "$store" ]] || return 0
+    for d in "$store"/*/; do
+        [[ -f "${d}init" ]] || continue
+        name="${d%/}"; name="${name##*/}"
+        v="$(_nutshell_version_of "${d}init")" || continue
+        [[ "$v" == "$name" ]] || continue
+        printf '%s\n' "$v"
+    done | _nutshell_sort_versions
+}
+
+# Newest first. Sorting fields rather than strings, because 0.10.0 is newer
+# than 0.9.0 and every string comparison says otherwise.
+_nutshell_sort_versions() {
+    local v a b c rest
+    while IFS= read -r v; do
+        [[ -n "$v" ]] || continue
+        IFS=. read -r a b c rest <<< "$v"
+        printf '%05d.%05d.%05d\t%s\n' \
+            "$(_nutshell_num "${a:-}")" \
+            "$(_nutshell_num "${b:-}")" \
+            "$(_nutshell_num "${c:-}")" \
+            "$v"
+    done | sort -r | cut -f2-
+}
+
+# One version field as a number. Anything from the first non-digit onward is
+# dropped, so a `0.4.0-rc1` sorts beside `0.4.0` instead of aborting the whole
+# listing on an arithmetic error.
+_nutshell_num() {
+    local n="${1:-}"
+    n="${n%%[!0-9]*}"
+    printf '%d' "$(( 10#${n:-0} ))"
+}
+
+# The newest toolchain satisfying the caller, or nothing.
+_nutshell_in_store() {
+    local want="${1:-}" store v cand
+    store="$(nutshell_store)"
+    [[ -d "$store" ]] || return 1
+    while IFS= read -r v; do
+        [[ -n "$v" ]] || continue
+        cand="$(_nutshell_root_of "${store}/${v}/init")" || continue
+        _nutshell_satisfies "$cand" "$want" && { printf '%s' "$cand"; return 0; }
+    done < <(nutshell_toolchains)
+    return 1
+}
+
+# Put a version in the store and print its root.
+#
+# Shallow, at the tag, from wherever the caller says nutshell lives. A failure
+# here is ordinary: no git, no network, or a version nobody has tagged yet. It
+# says which and falls through to whatever else the machine has.
+_nutshell_fetch() {
+    local want="$1" store dir remote
+    store="$(nutshell_store)"
+    dir="${store}/${want}"
+    remote="${NUTSHELL_REMOTE:-https://github.com/orgrinrt/nutshell.git}"
+
+    command -v git >/dev/null 2>&1 || {
+        printf 'nutshell: %s is not on this machine and there is no git to fetch it with\n' \
+            "$want" >&2
+        return 1
+    }
+
+    mkdir -p "$store" 2>/dev/null || return 1
+    # Into a scratch directory and moved into place, so an interrupted clone
+    # never leaves a half a toolchain behind for the next run to find and
+    # believe.
+    local tmp="${dir}.fetching.$$"
+    rm -rf "$tmp"
+    printf 'nutshell: fetching %s\n' "$want" >&2
+    if ! git clone --quiet --depth 1 --branch "$want" "$remote" "$tmp" 2>/dev/null; then
+        rm -rf "$tmp"
+        printf 'nutshell: could not fetch %s from %s\n' "$want" "$remote" >&2
+        return 1
+    fi
+
+    # What arrived has to be the version that was asked for. A tag that moved,
+    # or a branch name that happens to look like a version, would otherwise be
+    # stored under a name that lies about its contents.
+    local got; got="$(_nutshell_version_of "${tmp}/init")"
+    if [[ "$got" != "$want" ]]; then
+        rm -rf "$tmp"
+        printf 'nutshell: %s in %s reports itself as %s\n' "$want" "$remote" "${got:-nothing}" >&2
+        return 1
+    fi
+
+    rm -rf "$dir"
+    mv "$tmp" "$dir" || { rm -rf "$tmp"; return 1; }
+    printf '%s' "${dir}/init"
 }
 
 # The version an interpreter reports, without loading it. Reading the file

--- a/find-nutshell
+++ b/find-nutshell
@@ -71,6 +71,31 @@ _nutshell_root_of() {
 nutshell_find() {
     local root="${1:-}" want="${2:-}" cand bin
 
+    # A branch pin is not a floor, it is an identity: `dev` means the head of
+    # dev, today. Nothing already on the machine can be assumed to be that, so
+    # it is resolved against the remote first and only falls through when the
+    # remote cannot be reached. This is the shape op settled on for every other
+    # dependency, and the interpreter is not an exception to it.
+    if [[ -n "$want" ]] && ! _nutshell_is_version "$want"; then
+        if cand="$(_nutshell_branch "$want")"; then
+            NUTSHELL_INIT="$cand"; NUTSHELL_FROM="branch:${want}"
+            return 0
+        fi
+        if [[ -n "${NUTSHELL_HOME:-}" ]] \
+           && cand="$(_nutshell_root_of "${NUTSHELL_HOME}/init")"; then
+            NUTSHELL_INIT="$cand"; NUTSHELL_FROM="NUTSHELL_HOME"
+            return 0
+        fi
+        if [[ -n "$root" ]] \
+           && cand="$(_nutshell_root_of "${root}/lib/nutshell/init")"; then
+            NUTSHELL_INIT="$cand"; NUTSHELL_FROM="vendored"
+            return 0
+        fi
+        printf 'nutshell: could not reach %s and there is no copy here\n' \
+            "$want" >&2
+        return 1
+    fi
+
     # 1. What the caller named. An override exists so somebody working on
     #    nutshell itself can point a tool at their checkout.
     if [[ -n "${NUTSHELL_HOME:-}" ]]; then
@@ -131,9 +156,90 @@ nutshell_find() {
         return 0
     fi
 
-    printf 'nutshell: no interpreter found. Install one, set NUTSHELL_HOME, or run:\n' >&2
-    printf '  git submodule update --init\n' >&2
+    # Named in the order somebody would actually reach for them. The submodule
+    # advice that used to be here assumed every consumer vendored a checkout,
+    # which is the arrangement this file exists to make unnecessary.
+    printf 'nutshell: nothing here satisfies %s. Any of:\n' "${want:-any version}" >&2
+    printf '  NUTSHELL_HOME=/path/to/a/nutshell   point at a checkout\n' >&2
+    printf '  install one on PATH                 shared by everything\n' >&2
+    printf '  tag %s on the remote              so it can be fetched\n' "${want:-the version}" >&2
     return 1
+}
+
+# Does this name a version, or a branch? Versions are digits and dots, so
+# anything else is a ref. `0.4.0` and `dev` are the two shapes a pin takes.
+_nutshell_is_version() {
+    [[ "${1:-}" =~ ^[0-9]+(\.[0-9]+)*$ ]]
+}
+
+# The head of a branch, as a checkout in the store, refreshed when it moves.
+#
+# Kept under `branches/` so it cannot collide with the version directories,
+# whose names are checked against their own contents. A branch checkout has no
+# such invariant: the version inside it changes whenever the branch does, and
+# that is the point of pinning one.
+#
+# The remote is asked at most once an hour. A pin that means "the head" and
+# checks on every invocation turns a shell prompt into a network client; one
+# that never checks is not a branch pin at all.
+_nutshell_branch() {
+    local ref="$1" store dir stamp remote head now last
+    store="$(nutshell_toolchain_dir)/branches"
+    dir="${store}/${ref}"
+    stamp="${dir}.checked"
+    remote="${NUTSHELL_REMOTE:-https://github.com/orgrinrt/nutshell.git}"
+
+    now="$(date +%s 2>/dev/null)" || now=0
+    last=0
+    [[ -r "$stamp" ]] && read -r last < "$stamp" 2>/dev/null
+    [[ "$last" =~ ^[0-9]+$ ]] || last=0
+
+    # Inside the window, what is here is what the pin means.
+    if [[ -f "${dir}/init" ]] \
+       && (( now - last < ${NUTSHELL_BRANCH_TTL:-3600} )); then
+        printf '%s' "${dir}/init"
+        return 0
+    fi
+
+    command -v git >/dev/null 2>&1 || {
+        [[ -f "${dir}/init" ]] && { printf '%s' "${dir}/init"; return 0; }
+        return 1
+    }
+
+    head="$(git ls-remote "$remote" "refs/heads/${ref}" 2>/dev/null)"
+    head="${head%%[[:space:]]*}"
+    if [[ -z "$head" ]]; then
+        # Offline, or no such branch. What is already here is better than
+        # nothing, and stale is a thing this can say rather than pretend about.
+        if [[ -f "${dir}/init" ]]; then
+            printf 'nutshell: could not reach %s, using the %s already here\n' \
+                "$remote" "$ref" >&2
+            printf '%s' "${dir}/init"
+            return 0
+        fi
+        return 1
+    fi
+
+    if [[ -f "${dir}/init" ]] \
+       && [[ "$(git -C "$dir" rev-parse HEAD 2>/dev/null)" == "$head" ]]; then
+        mkdir -p "$store" 2>/dev/null && printf '%s\n' "$now" > "$stamp"
+        printf '%s' "${dir}/init"
+        return 0
+    fi
+
+    mkdir -p "$store" 2>/dev/null || return 1
+    local tmp="${dir}.fetching.$$"
+    rm -rf "$tmp"
+    printf 'nutshell: %s moved, fetching\n' "$ref" >&2
+    if ! git clone --quiet --depth 1 --branch "$ref" "$remote" "$tmp" 2>/dev/null; then
+        rm -rf "$tmp"
+        [[ -f "${dir}/init" ]] && { printf '%s' "${dir}/init"; return 0; }
+        return 1
+    fi
+    rm -rf "$dir"
+    mv "$tmp" "$dir" || { rm -rf "$tmp"; return 1; }
+    printf '%s\n' "$now" > "$stamp"
+    printf '%s' "${dir}/init"
 }
 
 #[pub]

--- a/lib.nut
+++ b/lib.nut
@@ -7,6 +7,7 @@
 array                    lib/array.sh
 attr                     lib/attr.sh
 check-runner             lib/check-runner.sh
+checkcache               lib/checkcache.sh
 cli                      lib/cli.sh
 color                    lib/color.sh
 deps                     lib/deps.sh

--- a/lib.nut
+++ b/lib.nut
@@ -27,6 +27,7 @@ nutshell                 nutshell.sh
 os                       lib/os.sh
 priv                     lib/priv.sh
 prompt                   lib/prompt.sh
+srcfile                  lib/srcfile.sh
 string                   lib/string.sh
 test                     lib/test.sh
 text                     lib/text.sh

--- a/lib/attr.sh
+++ b/lib/attr.sh
@@ -44,19 +44,38 @@ nut_once || return 0
 # parenthesised argument, `]`. Anything else is an ordinary comment.
 readonly ATTR_PATTERN='^[[:space:]]*#\[[a-z_][a-z0-9_]*(\(.*\))?\][[:space:]]*$'
 
+# The three below are matched with bash's own regex rather than by piping each
+# line through `sed`.
+#
+# `attr_on` walks every line of a file and asks `_attr_defines` about each one.
+# At a fork per line, times two subshells for the substitution and the pipe,
+# times every function a checker looks up, that was a quarter of a million
+# processes on one library and it made the QA gate take four minutes. Bash can
+# match a line against a pattern without leaving the process, and this needs no
+# `sed` and no `awk`, so it also works on a machine that has neither. The two
+# readers below were a `cut | grep` and an `awk` over this module's own output
+# and are bash for the same reason: a module this low should not need a
+# userland to answer a question about a comment.
+
 # _attr_name <line> -> the attribute's name
 _attr_name() {
-    printf '%s' "$1" | sed -E 's/^[[:space:]]*#\[//; s/(\(.*\))?\][[:space:]]*$//'
+    local l="$1"
+    [[ "$l" =~ ^[[:space:]]*#\[([a-zA-Z_][a-zA-Z0-9_]*) ]] || return 1
+    printf '%s' "${BASH_REMATCH[1]}"
 }
 
 # _attr_arg <line> -> what was inside the parentheses, or nothing
 _attr_arg() {
-    printf '%s' "$1" | sed -nE 's/^[[:space:]]*#\[[a-z_][a-z0-9_]*\((.*)\)\][[:space:]]*$/\1/p'
+    local l="$1"
+    [[ "$l" =~ ^[[:space:]]*#\[[a-z_][a-z0-9_]*\((.*)\)\][[:space:]]*$ ]] || return 1
+    printf '%s' "${BASH_REMATCH[1]}"
 }
 
 # _attr_defines <line> -> the function name this line defines, or nothing
 _attr_defines() {
-    printf '%s' "$1" | sed -nE 's/^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\).*/\1/p'
+    local l="$1"
+    [[ "$l" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\) ]] || return 1
+    printf '%s' "${BASH_REMATCH[1]}"
 }
 
 # attr_on <file> <function>
@@ -76,12 +95,21 @@ attr_on() {
             continue
         fi
 
-        defines="$(_attr_defines "$line")"
+        # Matched here rather than through `_attr_defines`, because a command
+        # substitution is a subshell and this runs on every line of the file.
+        # The helper stays for callers and for the tests; the loop cannot
+        # afford it.
+        defines=""
+        [[ "$line" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\) ]] \
+            && defines="${BASH_REMATCH[1]}"
         if [[ -n "$defines" ]]; then
             if [[ "$defines" == "$want" ]]; then
                 for line in "${pending[@]}"; do
-                    name="$(_attr_name "$line")"
-                    arg="$(_attr_arg "$line")"
+                    name=""; arg=""
+                    [[ "$line" =~ ^[[:space:]]*#\[([a-zA-Z_][a-zA-Z0-9_]*) ]] \
+                        && name="${BASH_REMATCH[1]}"
+                    [[ "$line" =~ ^[[:space:]]*#\[[a-z_][a-z0-9_]*\((.*)\)\][[:space:]]*$ ]] \
+                        && arg="${BASH_REMATCH[1]}"
                     if [[ -n "$arg" ]]; then
                         printf '%s\t%s\n' "$name" "$arg"
                     else
@@ -110,7 +138,11 @@ attr_on() {
 #[pub]
 # Usage: attr_has lib/string.sh str_trim pub -> returns 0 when marked
 attr_has() {
-    attr_on "$1" "$2" 2>/dev/null | cut -f1 | grep -qx "$3"
+    local want="$3" line
+    while IFS= read -r line; do
+        [[ "${line%%$'\t'*}" == "$want" ]] && return 0
+    done < <(attr_on "$1" "$2" 2>/dev/null)
+    return 1
 }
 
 # attr_arg <file> <function> <attribute>
@@ -118,7 +150,14 @@ attr_has() {
 #[pub]
 # Usage: attr_arg lib/foo.sh big_fn allow -> prints "loc = 400"
 attr_arg() {
-    attr_on "$1" "$2" 2>/dev/null | awk -F'\t' -v a="$3" '$1 == a { print $2; exit }'
+    local want="$3" line
+    while IFS= read -r line; do
+        if [[ "${line%%$'\t'*}" == "$want" ]]; then
+            [[ "$line" == *$'\t'* ]] && printf '%s' "${line#*$'\t'}"
+            return 0
+        fi
+    done < <(attr_on "$1" "$2" 2>/dev/null)
+    return 1
 }
 
 # attr_find <file> <attribute>
@@ -132,14 +171,21 @@ attr_find() {
     local file="$1" want="$2"
     local line pending=0 defines name
 
+    # Matched inline for the same reason `attr_on` does: a command substitution
+    # is a subshell, and this runs on every line of the file. The test suite
+    # calls it once per test file and a checker calls it once per source file.
     while IFS= read -r line; do
         if [[ "$line" =~ $ATTR_PATTERN ]]; then
-            name="$(_attr_name "$line")"
+            name=""
+            [[ "$line" =~ ^[[:space:]]*#\[([a-zA-Z_][a-zA-Z0-9_]*) ]] \
+                && name="${BASH_REMATCH[1]}"
             [[ "$name" == "$want" ]] && pending=1
             continue
         fi
 
-        defines="$(_attr_defines "$line")"
+        defines=""
+        [[ "$line" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\) ]] \
+            && defines="${BASH_REMATCH[1]}"
         if [[ -n "$defines" ]]; then
             [[ "$pending" -eq 1 ]] && printf '%s\n' "$defines"
             pending=0

--- a/lib/check-runner.sh
+++ b/lib/check-runner.sh
@@ -253,21 +253,53 @@ _find_config_file() {
     return 1
 }
 
-# Find repo root by looking for common markers
-_find_repo_root() {
-    local dir="$_CHECK_RUNNER_DIR"
-    
-    while [[ "$dir" != "/" ]]; do
-        # Check for repo markers
-        if [[ -d "$dir/.git" ]] || [[ -f "$dir/nut.toml" ]] || [[ -f "$dir/Cargo.toml" ]] || [[ -f "$dir/package.json" ]]; then
-            echo "$dir"
+# Walk up from a directory to the first repository marker above it.
+_walk_to_marker() {
+    local dir="${1:-}"
+    [[ -d "$dir" ]] || return 1
+    dir="$(cd "$dir" && pwd)" || return 1
+
+    while [[ -n "$dir" && "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/nut.toml" ]] \
+           || [[ -f "$dir/Cargo.toml" ]] || [[ -f "$dir/package.json" ]]; then
+            printf '%s' "$dir"
             return 0
         fi
         dir="$(dirname "$dir")"
     done
-    
-    # Fall back to nutshell root if nothing else found
-    echo "$NUTSHELL_ROOT"
+    return 1
+}
+
+# The repository being checked.
+#
+# From where the check was invoked, not from where this file happens to sit.
+# Walking up from this file finds whichever nutshell is running the check, so
+# every consumer was having nutshell's own source graded against the
+# consumer's thresholds. It looked like a passing gate and no consumer's code
+# had ever been read. `paths.exclude` could not help: the walk started inside
+# the directory the consumer was excluding.
+#
+# It is not only a vendoring problem. A consumer resolving nutshell out of the
+# store gets the same answer, because a store checkout carries a `.git` too.
+_find_repo_root() {
+    local root
+
+    # What the caller named. A config file states which repository it is the
+    # config for, and its directory is that repository.
+    if [[ -n "${NUTSHELL_CONFIG:-}" ]] && [[ -f "$NUTSHELL_CONFIG" ]]; then
+        root="$(cd "$(dirname "$NUTSHELL_CONFIG")" && pwd)" && {
+            printf '%s' "$root"; return 0
+        }
+    fi
+
+    # Where the check was run from. `./check` at a project root, or anywhere
+    # inside it, both mean that project.
+    root="$(_walk_to_marker "$PWD")" && { printf '%s' "$root"; return 0; }
+
+    # Nothing above the invocation directory says it is a repository, so there
+    # is nothing to check but the interpreter itself.
+    root="$(_walk_to_marker "$_CHECK_RUNNER_DIR")" && { printf '%s' "$root"; return 0; }
+    printf '%s' "$NUTSHELL_ROOT"
 }
 
 # =============================================================================

--- a/lib/check-runner.sh
+++ b/lib/check-runner.sh
@@ -254,18 +254,25 @@ _find_config_file() {
 }
 
 # Walk up from a directory to the first repository marker above it.
+#
+# `<levels>` bounds how far up may answer. Unbounded is right for the
+# interpreter finding itself and wrong for finding the project being checked,
+# because there is usually some repository somewhere above any directory.
 _walk_to_marker() {
-    local dir="${1:-}"
+    local dir="${1:-}" left="${2:-}"
     [[ -d "$dir" ]] || return 1
     dir="$(cd "$dir" && pwd)" || return 1
+    [[ "$left" =~ ^[0-9]+$ ]] || left=""
 
     while [[ -n "$dir" && "$dir" != "/" ]]; do
+        if [[ -n "$left" ]] && (( left < 0 )); then return 1; fi
         if [[ -d "$dir/.git" ]] || [[ -f "$dir/nut.toml" ]] \
            || [[ -f "$dir/Cargo.toml" ]] || [[ -f "$dir/package.json" ]]; then
             printf '%s' "$dir"
             return 0
         fi
         dir="$(dirname "$dir")"
+        [[ -n "$left" ]] && left=$(( left - 1 ))
     done
     return 1
 }
@@ -294,7 +301,15 @@ _find_repo_root() {
 
     # Where the check was run from. `./check` at a project root, or anywhere
     # inside it, both mean that project.
-    root="$(_walk_to_marker "$PWD")" && { printf '%s' "$root"; return 0; }
+    #
+    # Bounded, because the walk does not stop at the first thing that is not a
+    # project: run from a scratch directory under a `$HOME` that is itself a
+    # dotfiles repository, an unbounded walk grades the dotfiles repository.
+    # `NUTSHELL_CHECK_DEPTH` is the number of levels above the invocation that
+    # may answer, and four is deep enough for `crates/foo/src/bar` and shallow
+    # enough that a stray ancestor cannot.
+    root="$(_walk_to_marker "$PWD" "${NUTSHELL_CHECK_DEPTH:-4}")" \
+        && { printf '%s' "$root"; return 0; }
 
     # Nothing above the invocation directory says it is a repository, so there
     # is nothing to check but the interpreter itself.

--- a/lib/check-runner.sh
+++ b/lib/check-runner.sh
@@ -517,16 +517,31 @@ _is_excluded() {
 # Get all files matching include patterns, excluding configured paths
 #[pub]
 # Usage: get_lib_files -> prints file paths, one per line
+declare -g _NUT_LIB_FILES_CACHED=""
+declare -g _NUT_LIB_FILES=""
+
 get_lib_files() {
     _framework_init
-    
+
+    # The list, once. `find` per include pattern, per call, and the callers ask
+    # per function: 210 invocations in one run of the wrapper check alone. The
+    # tree does not change while a check runs.
+    if [[ -n "$_NUT_LIB_FILES_CACHED" ]]; then
+        printf '%s\n' "$_NUT_LIB_FILES"
+        return 0
+    fi
+
     local pattern file
-    for pattern in "${NUT_INCLUDE_PATTERNS[@]}"; do
-        while IFS= read -r -d '' file; do
-            _is_excluded "$file" && continue
-            echo "$file"
-        done < <(find "$LIB_DIR" -name "$pattern" -type f -print0 2>/dev/null)
-    done | sort -u
+    _NUT_LIB_FILES="$(
+        for pattern in "${NUT_INCLUDE_PATTERNS[@]}"; do
+            while IFS= read -r -d '' file; do
+                _is_excluded "$file" && continue
+                printf '%s\n' "$file"
+            done < <(find "$LIB_DIR" -name "$pattern" -type f -print0 2>/dev/null)
+        done | sort -u
+    )"
+    _NUT_LIB_FILES_CACHED=1
+    printf '%s\n' "$_NUT_LIB_FILES"
 }
 
 # Get all script files (same as lib files for nutshell)

--- a/lib/check-runner.sh
+++ b/lib/check-runner.sh
@@ -37,6 +37,7 @@ NUTSHELL_DEFAULTS_FILE="${NUTSHELL_ROOT}/examples/configs/empty.nut.toml"
 # that loads its dependencies invisibly is exactly the case that check exists
 # to catch, so the framework running it must not be the one exception.
 use log validate toml attr string
+use srcfile
 
 # =============================================================================
 # PATHS - Determined after config is loaded
@@ -44,6 +45,8 @@ use log validate toml attr string
 
 # These are set by _framework_init after config discovery
 REPO_ROOT=""
+# Whether a passing check prints a line. Resolved once by `_framework_init`.
+declare -g SHOW_PASSING="true"
 LIB_DIR=""
 CONFIG_FILE=""
 
@@ -353,6 +356,9 @@ _framework_init() {
         LIB_DIR="${REPO_ROOT}/${lib_dir_config}"
     fi
     
+    # Resolved here so the loggers do not go back to the file. See `log_pass`.
+    SHOW_PASSING="$(cfg_get_or "output.show_passing" "true")"
+
     # Cache exclude paths
     cfg_get_array "paths.exclude" NUT_EXCLUDE_PATHS || NUT_EXCLUDE_PATHS=()
     
@@ -456,11 +462,16 @@ log_test() {
 log_pass() {
     TESTS_PASSED=$((TESTS_PASSED + 1))
     TESTS_RUN=$((TESTS_RUN + 1))
-    
-    local show_passing
-    show_passing="$(cfg_get_or "output.show_passing" "true")"
-    
-    if is_truthy "$show_passing"; then
+
+    # Read once, at init, rather than per passing check.
+    #
+    # This ran a full TOML parse every time a check passed. `cfg_get_or` does
+    # cache, but a check runs its per-item work inside a command substitution
+    # and a subshell's cache dies when it returns, so the cache never held.
+    # Traced over one run of the docs check: 318 config lookups, 312 of them
+    # this one key, each re-parsing the whole file line by line and character
+    # by character. It was most of the run.
+    if is_truthy "$SHOW_PASSING"; then
         echo -e "${GREEN}  ✓${NC} $*"
     fi
 }
@@ -763,10 +774,21 @@ print_summary() {
 }
 
 # Exit with appropriate code based on test results
+#
+# The 2 is what this always said it did and never did. Its own usage line
+# promised "2 on warnings only" while the body had two branches and returned 0
+# for a run with warnings in it, so the only way the runner could tell a warning
+# from a clean pass was to grep the child's output for the glyph it prints.
+#
+# That is why a check with 23 warnings could be reported as a clean pass: the
+# grep is over tens of kilobytes of a child's stdout, it depends on quiet mode
+# leaving the line in, on which `grep` is installed, and on the glyph surviving
+# the pipe. A verdict belongs in an exit code.
 #[pub]
 # Usage: exit_with_status -> does not return; exits 0 clean, 1 on failures, 2 on warnings only
 exit_with_status() {
     [[ $TESTS_FAILED -gt 0 ]] && exit 1
+    [[ $TESTS_WARNED -gt 0 ]] && exit 2
     exit 0
 }
 

--- a/lib/checkcache.sh
+++ b/lib/checkcache.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/checkcache - A check's answer for a file, kept until it can change
+# =============================================================================
+# Part of nutshell. https://github.com/orgrinrt/nutshell
+#
+# A check's finding about a file is a pure function of two things: the file,
+# and the check that read it. Neither changes between two runs of the gate, and
+# the overwhelming case is that nothing changed at all, so the overwhelming
+# case should cost nothing.
+#
+# **The checker is part of the key, not just the file.** A check that gains a
+# step, or tightens a threshold, has to read every file again; a cache over the
+# file alone would keep answering with the old check's opinion and there would
+# be no way to tell. The config counts for the same reason: the thresholds come
+# out of `nut.toml` and they are what the answer was measured against.
+#
+# Freshness is decided with `-nt` rather than by hashing. A hash is a process
+# per file, which is the cost this is trying to avoid; the file test is a stat
+# the shell does itself. The trade is that touching a file without changing it
+# re-runs the check, which is the harmless direction to be wrong in.
+#
+# Usage:
+#   use checkcache
+#
+#   if nut_cache_hit "$check" "$file"; then
+#       nut_cache_read "$check" "$file"      # the findings, as they were
+#   else
+#       findings="$(work_it_out "$file")"
+#       nut_cache_write "$check" "$file" "$findings"
+#   fi
+# =============================================================================
+
+[[ -n "${_NUTSHELL_CHECKCACHE_SH:-}" ]] && return 0
+readonly _NUTSHELL_CHECKCACHE_SH=1
+
+if ! declare -F use >/dev/null 2>&1; then
+    printf 'nutshell: source nutshell first\n' >&2
+    return 1
+fi
+
+# Off by default until a caller turns it on, because a cache that is wrong is
+# worse than a check that is slow.
+declare -g NUT_CACHE_ENABLED="${NUT_CACHE:-0}"
+
+# Where an answer is kept. Under the store, beside the toolchains and externs,
+# because it is derived data about this machine and not part of any project.
+_nut_cache_root() {
+    if [[ -n "${NUT_CACHE_DIR:-}" ]]; then
+        printf '%s' "${NUT_CACHE_DIR%/}"
+        return 0
+    fi
+    if declare -F nutshell_store_root >/dev/null 2>&1; then
+        printf '%s/checks' "$(nutshell_store_root)"
+        return 0
+    fi
+    printf '%s/nutshell/checks' "${XDG_CACHE_HOME:-${HOME:-/tmp}/.cache}"
+}
+
+# One file's answer, for one check. The path a source file flattens to.
+_nut_cache_path() {
+    local check="${1:-}" file="${2:-}" flat
+    [[ -n "$check" && -n "$file" ]] || return 1
+    flat="${file//\//_}"
+    flat="${flat//[^A-Za-z0-9._-]/_}"
+    printf '%s/%s/%s' "$(_nut_cache_root)" "${check//[^A-Za-z0-9._-]/_}" "$flat"
+}
+
+#[pub]
+# Is there an answer for this file that nothing has invalidated?
+#
+# Fresh means newer than the file, newer than the check that produced it, and
+# newer than the config the thresholds came from. Any of the three moving means
+# the answer could be different and has to be worked out again.
+# Usage: nut_cache_hit <check> <file> -> returns 0 on a usable answer
+nut_cache_hit() {
+    [[ "${NUT_CACHE_ENABLED:-0}" == "1" ]] || return 1
+    local check="${1:-}" file="${2:-}" entry
+    entry="$(_nut_cache_path "$check" "$file")" || return 1
+    [[ -f "$entry" ]] || return 1
+    [[ -e "$file" ]] || return 1
+    [[ "$entry" -nt "$file" ]] || return 1
+
+    # The check itself. Named by the caller, because only it knows which file
+    # it is; a check that does not say cannot be cached.
+    local src="${NUT_CACHE_CHECKER:-}"
+    [[ -n "$src" && -e "$src" ]] || return 1
+    [[ "$entry" -nt "$src" ]] || return 1
+
+    # And the thresholds it measured against.
+    if [[ -n "${CONFIG_FILE:-}" && -e "${CONFIG_FILE}" ]]; then
+        [[ "$entry" -nt "$CONFIG_FILE" ]] || return 1
+    fi
+    return 0
+}
+
+#[pub]
+# The answer that was kept. Nothing, and non-zero, when there is none.
+# Usage: nut_cache_read <check> <file> -> prints what was cached
+nut_cache_read() {
+    local entry; entry="$(_nut_cache_path "$1" "$2")" || return 1
+    [[ -r "$entry" ]] || return 1
+    cat "$entry"
+}
+
+#[pub]
+# Keep an answer. A failure to write is not a failure of the check: the run
+# still has the answer, it just will not have it next time.
+# Usage: nut_cache_write <check> <file> <findings>
+nut_cache_write() {
+    [[ "${NUT_CACHE_ENABLED:-0}" == "1" ]] || return 0
+    local entry; entry="$(_nut_cache_path "$1" "$2")" || return 0
+    mkdir -p "${entry%/*}" 2>/dev/null || return 0
+    printf '%s' "${3:-}" > "$entry" 2>/dev/null || return 0
+    return 0
+}
+
+#[pub]
+# Throw the whole thing away.
+# Usage: nut_cache_clear [check]
+nut_cache_clear() {
+    local root; root="$(_nut_cache_root)"
+    if [[ -n "${1:-}" ]]; then
+        rm -rf "${root}/${1//[^A-Za-z0-9._-]/_}"
+    else
+        rm -rf "$root"
+    fi
+    return 0
+}

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -76,9 +76,22 @@ _extern_manifest() {
     return 1
 }
 
+# Where fetched dependencies live: one central, content-addressed store shared
+# by every project on the machine, the same arrangement pnpm and yarn 2 settled
+# on. Two projects on the same commit of the same dependency have one copy of
+# it between them, and a project tree carries no dependency of its own.
+#
+# Under data rather than cache, deliberately. A cache is something a cleaner is
+# entitled to delete at any moment; this is where the dependencies of every
+# project on the machine actually live, and losing it offline breaks all of
+# them at once. `NUTSHELL_STORE` overrides it.
 _extern_cache_root() {
+    if [[ -n "${NUTSHELL_STORE:-}" ]]; then
+        printf '%s/externs' "${NUTSHELL_STORE%/}"
+        return 0
+    fi
     xdg_set_app_name nutshell
-    printf '%s/externs' "$(xdg_app_cache)"
+    printf '%s/externs' "$(xdg_app_data)"
 }
 
 # -----------------------------------------------------------------------------

--- a/lib/srcfile.sh
+++ b/lib/srcfile.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/srcfile - A source file, read once, asked many times
+# =============================================================================
+# Part of nutshell. https://github.com/orgrinrt/nutshell
+#
+# Every checker reads the same files and asks the same four questions about
+# them: where is this function, where does it end, what is in its body, what is
+# on line N. Each of those used to be a pipeline: `grep | head | cut` for a
+# definition, `tail | grep | head | cut` for its end, a seven-stage `grep -v`
+# chain for a body. Thousands of processes per run, and every checker starting
+# again from nothing.
+#
+# Usage:
+#   use srcfile
+#
+#   nut_load_file lib/log.sh          # once, in the shell that loops
+#   nut_defined_at lib/log.sh log_info
+#   nut_body_of    lib/log.sh log_info BODY
+# =============================================================================
+
+[[ -n "${_NUTSHELL_SRCFILE_SH:-}" ]] && return 0
+readonly _NUTSHELL_SRCFILE_SH=1
+
+declare -gA _NUT_FILE_BODY=()
+declare -gA _NUT_FILE_AT=()
+declare -gA _NUT_FILE_N=()
+
+#[pub]
+# Read a file into the cache, once. Later calls for it do nothing.
+# Usage: nut_load_file <file>
+nut_load_file() {
+    local file="${1:-}"
+    [[ -n "${_NUT_FILE_N[$file]:-}" ]] && return 0
+    [[ -r "$file" ]] || return 1
+
+    local -a lines=()
+    if [[ "$(type -t mapfile)" == "builtin" ]]; then
+        mapfile -t lines < "$file" 2>/dev/null || return 1
+    else
+        local l
+        while IFS= read -r l || [[ -n "$l" ]]; do lines+=("$l"); done < "$file" || return 1
+    fi
+
+    local i line name
+    for (( i = 0; i < ${#lines[@]}; i++ )); do
+        line="${lines[$i]}"
+        _NUT_FILE_BODY["${file}:$((i + 1))"]="$line"
+        if [[ "$line" =~ ^[[:space:]]*(function[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_-]*)[[:space:]]*\( ]]; then
+            name="${BASH_REMATCH[2]}"
+            [[ -n "${_NUT_FILE_AT["${file}:${name}"]:-}" ]] \
+                || _NUT_FILE_AT["${file}:${name}"]=$((i + 1))
+        fi
+    done
+    _NUT_FILE_N[$file]="${#lines[@]}"
+    return 0
+}
+
+#[pub]
+# One line of a loaded file, by number. Nothing when it is not there.
+# Usage: nut_file_line <file> <n> -> prints the line
+nut_file_line() { printf '%s' "${_NUT_FILE_BODY["${1}:${2}"]:-}"; }
+
+#[pub]
+# How many lines a loaded file has.
+# Usage: nut_file_lines <file> -> prints a count
+nut_file_lines() { printf '%s' "${_NUT_FILE_N[${1}]:-0}"; }
+
+#[pub]
+# The line a function is defined on, or nothing.
+# Usage: nut_defined_at <file> <function> -> prints a line number
+nut_defined_at() {
+    local at="${_NUT_FILE_AT["${1}:${2}"]:-}"
+    [[ -n "$at" ]] || return 1
+    printf '%s' "$at"
+}
+
+#[pub]
+# Where a function's body ends: the first line that closes it at column one, or
+# closes it alone on its own line. The same heuristic the checks used, without
+# the `tail | grep | head | cut` it took four processes to express.
+# Usage: nut_ends_at <file> <function> -> prints a line number
+nut_ends_at() {
+    local file="$1" start end n line
+    start="$(nut_defined_at "$file" "$2")" || return 1
+    n="${_NUT_FILE_N[$file]:-0}"
+    for (( end = start + 1; end <= n; end++ )); do
+        line="${_NUT_FILE_BODY["${file}:${end}"]}"
+        [[ "$line" == "}" ]] && { printf '%s' "$end"; return 0; }
+        [[ "$line" =~ ^[[:space:]]*\}[[:space:]]*$ ]] && { printf '%s' "$end"; return 0; }
+    done
+    return 1
+}
+
+#[pub]
+# The lines of a function's body that carry something.
+#
+# Comments, blanks, bare declarations and a bare `return` are dropped, which is
+# what a seven-stage `grep -v` chain was doing per function.
+# Usage: nut_body_of <file> <function> <array-name>
+nut_body_of() {
+    local file="$1" fn="$2" out="$3" start end i line
+    [[ "$out" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 2
+    eval "$out=()"
+    start="$(nut_defined_at "$file" "$fn")" || return 1
+    end="$(nut_ends_at "$file" "$fn")" || return 1
+    for (( i = start + 1; i < end; i++ )); do
+        line="${_NUT_FILE_BODY["${file}:${i}"]}"
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line//[[:space:]]/}" ]] && continue
+        [[ "$line" =~ ^[[:space:]]*(local|readonly)[[:space:]] ]] && continue
+        [[ "$line" =~ ^[[:space:]]*return[[:space:]]*$ ]] && continue
+        [[ "$line" =~ ^[[:space:]]*return[[:space:]]+\$\?[[:space:]]*$ ]] && continue
+        [[ "$line" =~ ^[[:space:]]*\}[[:space:]]*$ ]] && continue
+        eval "$out+=(\"\$line\")"
+    done
+    return 0
+}
+

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -62,6 +62,20 @@ _toml_trim_into() {
 _toml_clean_into() {
     _toml_valid_target "$1" || return 2
     local __toml_out="$1" __toml_line="$2"
+
+    # The ordinary line has no quote and no `#` in it, and then there is
+    # nothing to scan for: the quote rules below only matter when a quote or a
+    # comment character is present. Deciding that costs one test; the loop
+    # costs six commands per character.
+    #
+    # This is the hottest path in the library. Config lookups go through it for
+    # every line of the file, and a trace of one QA run showed 1.4 million
+    # executions of the loop below, which was most of the run.
+    case "$__toml_line" in
+        *'"'*|*"'"*|*'#'*) ;;
+        *) _toml_trim_into "$__toml_out" "$__toml_line"; return ;;
+    esac
+
     local __toml_acc="" __toml_i __toml_c __toml_q=0 __toml_qc=""
     for (( __toml_i = 0; __toml_i < ${#__toml_line}; __toml_i++ )); do
         __toml_c="${__toml_line:__toml_i:1}"

--- a/nut.toml
+++ b/nut.toml
@@ -18,9 +18,13 @@
 # =============================================================================
 
 [meta]
+# The schema's version, not nutshell's. `examples/configs/empty.nut.toml` says
+# so where the field is documented, and a review read it as a third claim about
+# what nutshell is, next to `init`'s constant and the newest tag. Said here so
+# the next reader does not have to go and check.
 version = "1.0.0"
-name = "Tough Configuration"
-description = "Strict conventions. No compromises. No technical debt."
+name = "nutshell"
+description = "Everything you need, in a nutshell. Strict conventions, no compromises."
 
 # -----------------------------------------------------------------------------
 # Paths

--- a/tests/attr_test.sh
+++ b/tests/attr_test.sh
@@ -54,3 +54,54 @@ it_tells_two_arguments_of_one_attribute_apart() {
     assert_eq "$(attr_arg "$FIXTURE" wrapper_allowed allow)" "trivial_wrapper"
     assert_eq "$(attr_arg "$FIXTURE" big_but_allowed allow)" "loc = 400"
 }
+
+# --- what this module needs on the machine ------------------------------------
+#
+# Nothing. It reads comments, and it used to do that by piping every line of
+# the file through `sed`, once per line, per lookup. On a library of 36 files
+# and 440 functions that was a quarter of a million processes and it made the
+# QA gate take four minutes.
+#
+# Bash can match a line itself. That is both the fast answer and the portable
+# one: a module this low should not need a userland to answer a question about
+# a comment, and a rescue console may not have one.
+
+#[test]
+it_calls_no_external_tool_at_all() {
+    local src="${BASH_SOURCE[0]%/*}/../lib/attr.sh"
+    local stray
+    # Code lines only. The comments above talk about the tools this no longer
+    # uses, and saying so is the point of them.
+    stray="$(grep -nE '(^|[^[:alnum:]_#])(awk|sed|grep|cut|head|tail|tr|wc|sort|expr)[[:space:]]' "$src" \
+        | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+    assert_empty "$stray"
+}
+
+#[test]
+it_spawns_nothing_while_walking_a_file() {
+    # The property behind the one above, measured rather than read. A command
+    # substitution is a fork too, so this catches the shape that was actually
+    # slow: `$(_attr_defines "$line")` per line.
+    local src="${BASH_SOURCE[0]%/*}/../lib/attr.sh"
+    local body
+    body="$(sed -n '/^attr_on() {/,/^}/p' "$src"; sed -n '/^attr_find() {/,/^}/p' "$src")"
+    # No `$(...)` inside either walker. `$(( ))` is arithmetic and is not one.
+    local subs; subs="$(grep -n '\$(' <<<"$body" | grep -v '\$((' || true)"
+    assert_empty "$subs"
+}
+
+#[test]
+it_still_reads_an_attribute_with_an_argument_out_of_a_real_file() {
+    # The control for both above: taking the tools out has to leave the
+    # answers alone, including the tab-separated argument form.
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-attr.XXXXXX")"
+    printf '#[pub]\n#[allow(loc = 400)]\n# prose does not break the run\n\nbig_fn() {\n  :\n}\n' \
+        > "$d/x.sh"
+    assert_ok  attr_has "$d/x.sh" big_fn pub
+    assert_ok  attr_has "$d/x.sh" big_fn allow
+    assert_fails attr_has "$d/x.sh" big_fn nope
+    assert_eq "$(attr_arg "$d/x.sh" big_fn allow)" "loc = 400"
+    assert_empty "$(attr_arg "$d/x.sh" big_fn pub)"
+    assert_eq "$(attr_find "$d/x.sh" pub)" "big_fn"
+    rm -rf "$d"
+}

--- a/tests/branch_test.sh
+++ b/tests/branch_test.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Tests for a pin that names a branch rather than a version.
+#
+# A branch pin is not a floor, it is an identity: `dev` means the head of dev,
+# today. That makes it the one pin whose answer changes without anybody
+# editing anything, so what it costs to keep current, and what it does when the
+# remote cannot be reached, are the whole of it.
+#
+# It is also the one that shares a directory with every other project on the
+# machine while nothing locks it. So the checkouts are keyed by the revision
+# they hold and are written once, and none of this may ever delete a tree a
+# running interpreter is sourcing out of.
+
+use test
+
+. "${BASH_SOURCE[0]%/*}/../find-nutshell"
+
+_br_setup() {
+    BRROOT="$(mktemp -d)"
+    export NUTSHELL_TOOLCHAINS="$BRROOT/store"
+    export NUTSHELL_REMOTE="$BRROOT/remote.git"
+    NUTSHELL_INIT=""; NUTSHELL_FROM=""
+    unset NUTSHELL_HOME
+    # Whatever is installed on the machine running these must not decide
+    # their answers.
+    _BR_PATH_KEEP="$PATH"
+    local d out=""
+    while IFS= read -r d; do
+        [[ -n "$d" ]] || continue
+        [[ -x "$d/nutshell" ]] && continue
+        out="${out:+$out:}$d"
+    done <<< "${PATH//:/$'\n'}"
+    export PATH="$out"
+}
+_br_end() {
+    rm -rf "$BRROOT"
+    unset BRROOT NUTSHELL_TOOLCHAINS NUTSHELL_REMOTE
+    NUTSHELL_INIT=""; NUTSHELL_FROM=""
+    export PATH="${_BR_PATH_KEEP:-$PATH}"
+}
+
+# A remote carrying one branch, and a way to move it.
+_br_remote() {
+    local branch="${1:-dev}" version="${2:-0.4.0}"
+    BRWORK="$BRROOT/work"
+    mkdir -p "$BRWORK"
+    printf 'export NUTSHELL_VERSION="%s"\n' "$version" > "$BRWORK/init"
+    git -C "$BRWORK" init -q -b "$branch"
+    git -C "$BRWORK" config user.email t@example.invalid
+    git -C "$BRWORK" config user.name t
+    git -C "$BRWORK" config commit.gpgsign false
+    git -C "$BRWORK" add -A
+    git -C "$BRWORK" commit -qm "$version"
+    git init -q --bare "$NUTSHELL_REMOTE"
+    git -C "$BRWORK" remote add origin "$NUTSHELL_REMOTE"
+    git -C "$BRWORK" push -q origin "$branch"
+}
+_br_move() {
+    printf '# %s\n' "${1:-moved}" >> "$BRWORK/init"
+    git -C "$BRWORK" commit -qam "${1:-moved}"
+    git -C "$BRWORK" push -q origin HEAD
+}
+_br_head() { git -C "$BRWORK" rev-parse HEAD; }
+_br_base() { printf '%s/branches/%s' "$NUTSHELL_TOOLCHAINS" "${1:-dev}"; }
+
+# --- what a branch pin resolves to -------------------------------------------
+
+#[test]
+it_resolves_a_branch_pin_to_the_head_of_that_branch() {
+    _br_setup; _br_remote dev 0.4.0
+    assert_ok nutshell_find "" dev
+    assert_eq "$NUTSHELL_FROM" "branch:dev"
+    assert_contains "$NUTSHELL_INIT" "$(_br_head)"
+    _br_end
+}
+
+#[test]
+it_keys_the_checkout_by_the_revision_rather_than_by_the_branch_name() {
+    _br_setup; _br_remote dev 0.4.0
+    nutshell_find "" dev
+    # The directory name is what makes the store safe to share: a checkout
+    # named for a branch has to be replaced when the branch moves, and
+    # replacing it is deleting a tree somebody may be sourcing out of.
+    assert_ok test -f "$(_br_base)/$(_br_head)/init"
+    assert_fails test -f "$(_br_base)/init"
+    _br_end
+}
+
+#[test]
+it_records_the_revision_the_branch_last_resolved_to() {
+    _br_setup; _br_remote dev 0.4.0
+    nutshell_find "" dev
+    assert_eq "$(_nutshell_branch_head "$(_br_base)")" "$(_br_head)"
+    _br_end
+}
+
+# --- what it costs to keep current -------------------------------------------
+
+#[test]
+it_does_not_ask_the_remote_again_inside_the_window() {
+    _br_setup; _br_remote dev 0.4.0
+    nutshell_find "" dev
+    local first="$NUTSHELL_INIT"
+    # The remote is taken away entirely, and the answer has to come back with
+    # nothing said. Checking only that the path is unchanged would pass either
+    # way: the offline fallback returns that same path, having gone to the
+    # network to find out it could not. Silence is what distinguishes them.
+    export NUTSHELL_REMOTE="$BRROOT/gone.git"
+    local said; said="$(nutshell_find "" dev 2>&1 >/dev/null)"
+    assert_eq "$NUTSHELL_INIT" "$first"
+    assert_empty "$said"
+    _br_end
+}
+
+#[test]
+it_asks_again_once_the_window_is_out_and_follows_the_branch() {
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    local before="$NUTSHELL_INIT"
+    _br_move second
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+    assert_ne "$NUTSHELL_INIT" "$before"
+    assert_contains "$NUTSHELL_INIT" "$(_br_head)"
+    _br_end
+}
+
+#[test]
+it_leaves_the_old_revision_in_place_when_the_branch_moves() {
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    local old; old="$NUTSHELL_INIT"
+    _br_move second
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+    # Somebody else's push must not pull the floor out from under a run that
+    # already started. The old checkout is still there and still sourceable;
+    # it goes when it is a day old, not when it stops being the head.
+    assert_ok test -f "$old"
+    _br_end
+}
+
+#[test]
+it_does_not_refetch_a_revision_the_store_already_holds() {
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    printf 'in use\n' > "$(_br_base)/$(_br_head)/marker"
+    # The window is out and the head has not moved. That is a stamp refresh,
+    # not a clone, and certainly not a replacement of the directory.
+    local said; said="$(NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>&1 >/dev/null)"
+    assert_fails grep -q 'moved, fetching' <<<"$said"
+    assert_ok test -f "$(_br_base)/$(_br_head)/marker"
+    _br_end
+}
+
+# --- when the remote cannot be reached ---------------------------------------
+
+#[test]
+it_runs_from_the_last_known_revision_when_the_remote_is_unreachable() {
+    _br_setup; _br_remote dev 0.4.0
+    nutshell_find "" dev
+    local known="$NUTSHELL_INIT"
+    export NUTSHELL_REMOTE="$BRROOT/gone.git"
+    local said
+    said="$(NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>&1 >/dev/null)"
+    assert_eq "$NUTSHELL_INIT" "$known"
+    # Named rather than pretended about. A stale head that runs beats a
+    # refusal, and a reader has to be able to tell which one they got.
+    assert_contains "$said" "could not reach"
+    _br_end
+}
+
+#[test]
+it_names_the_revision_it_fell_back_to() {
+    _br_setup; _br_remote dev 0.4.0
+    nutshell_find "" dev
+    local head; head="$(_br_head)"
+    export NUTSHELL_REMOTE="$BRROOT/gone.git"
+    local said; said="$(NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>&1 >/dev/null)"
+    assert_contains "$said" "${head:0:12}"
+    _br_end
+}
+
+#[test]
+it_falls_through_to_a_vendored_copy_when_the_branch_was_never_fetched() {
+    _br_setup
+    export NUTSHELL_REMOTE="$BRROOT/gone.git"
+    local root="$BRROOT/project"
+    mkdir -p "$root/lib/nutshell"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$root/lib/nutshell/init"
+    assert_ok nutshell_find "$root" dev 2>/dev/null
+    assert_eq "$NUTSHELL_FROM" "vendored"
+    _br_end
+}
+
+#[test]
+it_takes_what_the_caller_named_before_asking_the_remote_anything() {
+    _br_setup
+    export NUTSHELL_REMOTE="$BRROOT/gone.git"
+    local d="$BRROOT/named"
+    mkdir -p "$d"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$d/init"
+    # A suite that exports this must not send every child process it starts to
+    # the network.
+    NUTSHELL_HOME="$d" assert_ok nutshell_find "" dev
+    assert_eq "$NUTSHELL_FROM" "NUTSHELL_HOME"
+    _br_end
+}
+
+# --- names that are not branch names -----------------------------------------
+
+#[test]
+it_refuses_a_ref_that_would_escape_the_store() {
+    _br_setup; _br_remote dev 0.4.0
+    local outside="$BRROOT/outside"
+    mkdir -p "$outside"; printf 'here\n' > "$outside/keep"
+    assert_fails _nutshell_branch "../outside" 2>/dev/null
+    assert_ok test -f "$outside/keep"
+    _br_end
+}
+
+#[test]
+it_refuses_a_ref_carrying_a_slash() {
+    _br_setup
+    # `feat/thing` is a legal branch name and is not a legal directory name
+    # here. Refusing it is a limit, and it is a stated one rather than a path
+    # built out of it.
+    assert_fails _nutshell_branch "feat/thing" 2>/dev/null
+    _br_end
+}
+
+# --- pruning ------------------------------------------------------------------
+
+#[test]
+it_keeps_a_revision_that_is_not_a_day_old_yet() {
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    local old; old="$(_br_head)"
+    _br_move second
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+    assert_ok test -d "$(_br_base)/$old"
+    _br_end
+}
+
+#[test]
+it_drops_a_revision_nothing_has_touched_for_a_day() {
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    local old; old="$(_br_head)"
+    # Aged deliberately. Two days back, so a machine on either side of a
+    # daylight-saving boundary still reads it as older than a day.
+    touch -t "$(date -v-2d +%Y%m%d%H%M 2>/dev/null || date -d '2 days ago' +%Y%m%d%H%M)" \
+        "$(_br_base)/$old"
+    _br_move second
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+    assert_fails test -d "$(_br_base)/$old"
+    # And the one it just resolved to is still there, which is the half that
+    # makes the pruning safe rather than merely tidy.
+    assert_ok test -f "$(_br_base)/$(_br_head)/init"
+    _br_end
+}

--- a/tests/branch_test.sh
+++ b/tests/branch_test.sh
@@ -257,3 +257,15 @@ it_drops_a_revision_nothing_has_touched_for_a_day() {
     assert_ok test -f "$(_br_base)/$(_br_head)/init"
     _br_end
 }
+
+#[test]
+it_says_a_slashed_ref_is_a_name_problem_and_not_a_network_one() {
+    _br_setup; _br_remote dev 0.4.0
+    # `feat/toolchains` is a legal branch name and is not a directory name in
+    # the store. The limit is real; reporting it as "could not reach" sends the
+    # reader to check their connection.
+    local said; said="$(nutshell_find "" "feat/toolchains" 2>&1 >/dev/null)"
+    assert_contains "$said" "cannot name a toolchain directory"
+    assert_fails grep -q "could not reach" <<<"$said"
+    _br_end
+}

--- a/tests/check_file_cache_test.sh
+++ b/tests/check_file_cache_test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Tests for reading a file once and answering from it.
+#
+# Every check reads the same twenty-odd files, and used to do it with a
+# pipeline per question per function: `grep | head | cut` for a definition,
+# `tail | grep | head | cut` for its end, a seven-stage `grep -v` chain for its
+# body, and five more processes to count what was in it. Thousands of processes
+# per check, and each check starting again from nothing.
+#
+# The answers have to be the same ones. A faster checker that reports different
+# functions is not a faster checker.
+
+use test
+
+. "${BASH_SOURCE[0]%/*}/../lib/check-runner.sh"
+
+_cfc_tmp() { printf '%s' "$(mktemp -d "${TMPDIR:-/tmp}/nutshell-filecache.XXXXXX")"; }
+
+# A file with one of each shape the body reader has to judge.
+_cfc_file() {
+    local d="$1"
+    mkdir -p "$d"
+    cat > "$d/a.sh" <<'EOS'
+#!/usr/bin/env bash
+
+thin() { other "$1"; }
+
+#[pub]
+documented() {
+    local a="$1"
+    printf '%s' "$a"
+}
+
+does_work() {
+    local a="$1" b="$2"
+    # a comment, which is not a line of body
+
+    readonly c=3
+    if [[ -n "$a" ]]; then
+        printf '%s-%s' "$a" "$b"
+    fi
+    return
+}
+EOS
+    printf '%s' "$d/a.sh"
+}
+
+#[test]
+it_finds_where_a_function_is_defined() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    assert_ok nut_load_file "$f"
+    assert_eq "$(nut_defined_at "$f" documented)" "6"
+    assert_eq "$(nut_defined_at "$f" does_work)" "11"
+    assert_fails nut_defined_at "$f" no_such_function
+    rm -rf "$d"
+}
+
+#[test]
+it_finds_where_a_function_ends() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    assert_eq "$(nut_ends_at "$f" documented)" "9"
+    assert_eq "$(nut_ends_at "$f" does_work)" "20"
+    rm -rf "$d"
+}
+
+#[test]
+it_drops_the_lines_that_are_not_body() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    local -a body=()
+    assert_ok nut_body_of "$f" does_work body
+    # `local`, `readonly`, the comment, the blank and the bare `return` all go.
+    # What is left is the `if`, the `printf` and the `fi`.
+    assert_eq "${#body[@]}" "3"
+    assert_contains "${body[*]}" "printf"
+    assert_fails grep -q 'readonly' <<<"${body[*]}"
+    assert_fails grep -q 'local' <<<"${body[*]}"
+    rm -rf "$d"
+}
+
+#[test]
+it_refuses_an_array_name_that_is_not_one() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    # The name reaches `eval`. Anything but a plain identifier is refused
+    # before it gets there.
+    local -a body=()
+    assert_fails nut_body_of "$f" does_work 'x[$(touch /tmp/nut-should-not-exist)]'
+    assert_fails test -e /tmp/nut-should-not-exist
+    rm -rf "$d"
+}
+
+#[test]
+it_reads_a_file_once_however_often_it_is_asked() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    # The file is edited underneath, and the cache is what answers. A loader
+    # that re-read on every call would see the new content, which is the shape
+    # that was costing thousands of processes.
+    printf 'changed() { :; }\n' > "$f"
+    nut_load_file "$f"
+    assert_ok nut_defined_at "$f" does_work
+    assert_fails nut_defined_at "$f" changed
+    rm -rf "$d"
+}
+
+#[test]
+it_says_how_many_lines_a_file_has() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    assert_eq "$(nut_file_lines "$f")" "$(wc -l < "$f" | tr -d ' ')"
+    assert_eq "$(nut_file_line "$f" 3)" 'thin() { other "$1"; }'
+    rm -rf "$d"
+}
+
+#[test]
+it_refuses_a_file_that_is_not_there() {
+    assert_fails nut_load_file "/no/such/file/at/all.sh"
+    assert_fails nut_load_file ""
+}
+
+# --- the answers have to be the ones the pipelines gave ------------------------
+
+#[test]
+it_counts_the_same_variables_the_five_stage_pipeline_did() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    local -a body=()
+    nut_body_of "$f" does_work body
+
+    # The old shape, kept here as the oracle rather than as the implementation:
+    # grep the names out, drop the punctuation, unique them, count. Five
+    # processes, and the only reason it is acceptable in a test is that a test
+    # runs once and a checker runs per function.
+    local want
+    want="$(printf '%s\n' "${body[@]}" \
+        | grep -oE '\$\{?[a-zA-Z_][a-zA-Z0-9_]*' | sed 's/[${}]//g' \
+        | sort -u | wc -l | tr -d ' ')"
+
+    local -A seen=(); local line rest name
+    for line in "${body[@]}"; do
+        rest="$line"
+        while [[ "$rest" =~ \$\{?([a-zA-Z_][a-zA-Z0-9_]*) ]]; do
+            name="${BASH_REMATCH[1]}"; seen["$name"]=1
+            rest="${rest#*"${BASH_REMATCH[0]}"}"
+        done
+    done
+    assert_eq "${#seen[@]}" "$want"
+    # And not vacuously zero, which is what a broken reader would give.
+    assert_ne "${#seen[@]}" "0"
+    rm -rf "$d"
+}
+
+#[test]
+it_counts_the_same_tokens_the_pipeline_did() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    local -a body=()
+    nut_body_of "$f" does_work body
+
+    local want
+    want="$(printf '%s\n' "${body[@]}" | tr -s '[:space:]' '\n' | grep -v '^$' \
+        | wc -l | tr -d ' ')"
+
+    local line n=0; local -a words=()
+    for line in "${body[@]}"; do
+        # shellcheck disable=SC2206
+        words=($line); n=$(( n + ${#words[@]} ))
+    done
+    assert_eq "$n" "$want"
+    assert_ne "$n" "0"
+    rm -rf "$d"
+}

--- a/tests/check_reporting_test.sh
+++ b/tests/check_reporting_test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Tests for a failing check saying what it found.
+#
+# The runner sets `NUTSHELL_CHECK_QUIET=1` so eight checks do not each print a
+# summary block. A check that fails then prints nothing at all, and the runner
+# showed a bare red cross with no thread to pull. Observed on a consumer whose
+# gate went from green to failing the moment it started reading the right
+# repository, with nothing on screen to say why.
+
+use test
+
+_CRP_TMP="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-checkrep.XXXXXX")"
+trap '[[ -n "${_CRP_TMP:-}" ]] && rm -rf "$_CRP_TMP"' EXIT
+_CRP_NUT="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+
+# A project whose only check is one we wrote, so what the runner does with a
+# child's output is the only thing under test.
+_crp_project() {
+    local name="$1" body="$2"
+    local d="$_CRP_TMP/$name"
+    mkdir -p "$d/checks"
+    printf '[qa]\ncustom_checks = ["checks/probe.sh"]\nrun_builtins = false\n' > "$d/nut.toml"
+    printf '#!/usr/bin/env bash\n%s\n' "$body" > "$d/checks/probe.sh"
+    chmod +x "$d/checks/probe.sh"
+    printf '%s' "$d"
+}
+
+_crp_run() { (cd "$1" && "$_CRP_NUT/check" 2>&1); }
+
+#[test]
+it_shows_what_a_check_found_when_the_check_prints_it() {
+    local d; d="$(_crp_project talks '
+printf "✗ the thing is wrong\n"
+exit 1')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "the thing is wrong"
+}
+
+#[test]
+it_asks_a_silent_failing_check_again_with_its_report_turned_on() {
+    # The case. Quiet on the first run, and the reader is left with a cross.
+    local d; d="$(_crp_project quiet '
+if [[ "${NUTSHELL_CHECK_QUIET:-0}" == "1" ]]; then exit 1; fi
+printf "✗ four wrappers are trivial\n"
+exit 1')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "four wrappers are trivial"
+}
+
+#[test]
+it_says_so_when_a_check_fails_and_will_not_explain_itself_either_way() {
+    # A check that says nothing however it is asked. The runner cannot invent
+    # a reason, and printing nothing at all is what it used to do.
+    local d; d="$(_crp_project mute 'exit 1')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "failed and printed nothing"
+}
+
+#[test]
+it_does_not_ask_again_when_the_check_passed() {
+    # The second run costs a whole check. It happens on failure only, and a
+    # check that ran twice would say so here.
+    local d; d="$(_crp_project counted '
+printf "%s\n" "ran" >> "$PWD/ran.log"
+exit 0')"
+    _crp_run "$d" >/dev/null
+    assert_eq "$(grep -c . "$d/ran.log" 2>/dev/null || printf 0)" "1"
+}

--- a/tests/check_reporting_test.sh
+++ b/tests/check_reporting_test.sh
@@ -66,3 +66,60 @@ exit 0')"
     _crp_run "$d" >/dev/null
     assert_eq "$(grep -c . "$d/ran.log" 2>/dev/null || printf 0)" "1"
 }
+
+# --- the verdict is an exit code, not a glyph in the output --------------------
+#
+# `exit_with_status` promised "2 on warnings only" in its own usage line and
+# had two branches that never returned 2. So the only way the runner could tell
+# a warning from a clean pass was to grep tens of kilobytes of the child's
+# stdout for the character it prints, which needs quiet mode to have left the
+# line in and needs whichever `grep` is installed to read the pattern the same
+# way. A check reporting 23 warnings came out as a clean pass.
+
+#[test]
+it_reports_warnings_through_the_exit_code() {
+    local d; d="$(_crp_project warned '
+. "'"$_CRP_NUT"'/init"
+use check-runner
+log_warn_test() { :; }
+TESTS_WARNED=1
+exit_with_status')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "⚠"
+    assert_fails grep -q '✓ probe' <<<"$out"
+}
+
+#[test]
+it_reports_a_clean_run_as_clean() {
+    local d; d="$(_crp_project clean '
+. "'"$_CRP_NUT"'/init"
+use check-runner
+exit_with_status')"
+    local out; out="$(_crp_run "$d")"
+    assert_fails grep -q '⚠' <<<"$out"
+}
+
+#[test]
+it_still_reads_the_glyph_from_a_check_that_cannot_say_two() {
+    # A custom check that does not use the framework has no `exit_with_status`
+    # to call, so the fallback stays.
+    local d; d="$(_crp_project glyphonly '
+printf "  ⚠ something wants a look\n"
+exit 0')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "⚠"
+}
+
+#[test]
+it_does_not_ask_a_warning_to_explain_itself() {
+    # Re-running is for a failure that said nothing. A warning is not a
+    # failure, and asking cost a whole second run of the check.
+    local d; d="$(_crp_project quietwarn '
+. "'"$_CRP_NUT"'/init"
+use check-runner
+printf "%s\n" "ran" >> "$PWD/ran.log"
+TESTS_WARNED=1
+exit_with_status')"
+    _crp_run "$d" >/dev/null
+    assert_eq "$(grep -c . "$d/ran.log" 2>/dev/null || printf 0)" "1"
+}

--- a/tests/check_root_test.sh
+++ b/tests/check_root_test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Tests for which repository the QA gate reads.
+#
+# The gate reported PASSED WITH WARNINGS in two consumers and none of it was
+# about them. `_find_repo_root` walked up from this file, which lands on
+# whichever nutshell is running the check, so the thresholds were the
+# consumer's and the files they were applied to were nutshell's. Nothing in
+# either consumer's source had ever been read, and `paths.exclude` naming the
+# vendored directory could not help, because the walk began inside it.
+#
+# It is not only a vendoring problem: a consumer resolving nutshell out of the
+# store gets the same answer, because a store checkout carries a `.git` too.
+
+use test
+
+. "${BASH_SOURCE[0]%/*}/../lib/check-runner.sh"
+
+_CR_TMP="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-checkroot.XXXXXX")"
+trap '[[ -n "${_CR_TMP:-}" ]] && rm -rf "$_CR_TMP"' EXIT
+
+# A consumer, and a nutshell sitting inside it the way a vendored or
+# store-resolved one does.
+_cr_consumer() {
+    local d="$_CR_TMP/$1"
+    mkdir -p "$d/lib/nutshell/lib" "$d/libs"
+    printf '[meta]\nname = "%s"\n' "$1" > "$d/nut.toml"
+    mkdir -p "$d/.git"
+    printf '[meta]\nname = "nutshell"\n' > "$d/lib/nutshell/nut.toml"
+    mkdir -p "$d/lib/nutshell/.git"
+    printf '%s' "$d"
+}
+
+#[test]
+it_reads_the_repository_the_check_was_run_from() {
+    local d; d="$(_cr_consumer one)"
+    local got; got="$(cd "$d" && _CHECK_RUNNER_DIR="$d/lib/nutshell/lib" NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_eq "$got" "$(cd "$d" && pwd)"
+}
+
+#[test]
+it_does_not_read_the_nutshell_that_is_running_the_check() {
+    # The defect, stated as its own case. The runner sits inside the consumer,
+    # in a directory that is itself a repository, which is exactly what the
+    # old walk stopped at.
+    local d; d="$(_cr_consumer two)"
+    local got; got="$(cd "$d" && _CHECK_RUNNER_DIR="$d/lib/nutshell/lib" NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_ne "$got" "$(cd "$d/lib/nutshell" && pwd)"
+}
+
+#[test]
+it_reads_the_repository_from_a_directory_inside_it() {
+    # `./check` is run from the root, but a person in a subdirectory reaching
+    # for an installed one means the same project.
+    local d; d="$(_cr_consumer three)"
+    mkdir -p "$d/libs/tui"
+    local got; got="$(cd "$d/libs/tui" && _CHECK_RUNNER_DIR="$d/lib/nutshell/lib" NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_eq "$got" "$(cd "$d" && pwd)"
+}
+
+#[test]
+it_takes_the_directory_of_a_config_that_was_named() {
+    # A config file states which repository it is the config for, and that
+    # outranks where the command happened to be typed.
+    local d e
+    d="$(_cr_consumer four)"; e="$(_cr_consumer five)"
+    local got; got="$(cd "$e" && NUTSHELL_CONFIG="$d/nut.toml" _find_repo_root)"
+    assert_eq "$got" "$(cd "$d" && pwd)"
+}
+
+#[test]
+it_reads_nutshell_itself_when_it_is_checking_itself() {
+    # The case that always worked and has to keep working: nutshell's own
+    # `./check`, run at nutshell's own root.
+    local root; root="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+    local got; got="$(cd "$root" && NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_eq "$got" "$root"
+}
+
+#[test]
+it_falls_back_to_the_interpreter_when_nothing_above_says_repository() {
+    # Run from somewhere that is not a project at all. There is nothing to
+    # check but the interpreter, and saying so beats reporting on a directory
+    # nobody asked about.
+    local bare="$_CR_TMP/bare"; mkdir -p "$bare"
+    local fake="$_CR_TMP/fakenut/lib"; mkdir -p "$fake"
+    mkdir -p "$_CR_TMP/fakenut/.git"
+    local got; got="$(cd "$bare" && _CHECK_RUNNER_DIR="$fake" NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_eq "$got" "$(cd "$_CR_TMP/fakenut" && pwd)"
+}
+
+#[test]
+it_refuses_to_walk_from_a_directory_that_is_not_there() {
+    assert_fails _walk_to_marker "$_CR_TMP/no-such-directory"
+    assert_fails _walk_to_marker ""
+}

--- a/tests/check_root_test.sh
+++ b/tests/check_root_test.sh
@@ -93,3 +93,38 @@ it_refuses_to_walk_from_a_directory_that_is_not_there() {
     assert_fails _walk_to_marker "$_CR_TMP/no-such-directory"
     assert_fails _walk_to_marker ""
 }
+
+#[test]
+it_does_not_walk_past_a_few_levels_to_find_some_ancestor() {
+    # There is usually a repository somewhere above any directory. A `$HOME`
+    # that is a dotfiles checkout, or a workspace clone holding member clones,
+    # both make an unbounded walk grade something nobody asked about.
+    local top="$_CR_TMP/deep"
+    mkdir -p "$top/.git" "$top/a/b/c/d/e/f"
+    local fake="$_CR_TMP/deepnut/lib"; mkdir -p "$fake" "$_CR_TMP/deepnut/.git"
+    local got; got="$(cd "$top/a/b/c/d/e/f" && _CHECK_RUNNER_DIR="$fake" NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_ne "$got" "$(cd "$top" && pwd)"
+    assert_eq "$got" "$(cd "$_CR_TMP/deepnut" && pwd)"
+}
+
+#[test]
+it_still_reaches_a_project_root_from_a_source_directory_inside_it() {
+    # The depth has to clear the ordinary case it exists beside:
+    # `crates/foo/src/bar` is four levels down and must still answer.
+    local top="$_CR_TMP/proj"
+    mkdir -p "$top/crates/foo/src/bar"
+    printf '[meta]\nname = "proj"\n' > "$top/nut.toml"
+    local fake="$_CR_TMP/projnut/lib"; mkdir -p "$fake" "$_CR_TMP/projnut/.git"
+    local got; got="$(cd "$top/crates/foo/src/bar" && _CHECK_RUNNER_DIR="$fake" NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_eq "$got" "$(cd "$top" && pwd)"
+}
+
+#[test]
+it_lets_the_depth_be_named_when_a_tree_is_deeper_than_that() {
+    local top="$_CR_TMP/verydeep"
+    mkdir -p "$top/a/b/c/d/e/f"
+    printf '[meta]\nname = "verydeep"\n' > "$top/nut.toml"
+    local fake="$_CR_TMP/vdnut/lib"; mkdir -p "$fake" "$_CR_TMP/vdnut/.git"
+    local got; got="$(cd "$top/a/b/c/d/e/f" && _CHECK_RUNNER_DIR="$fake" NUTSHELL_CONFIG="" NUTSHELL_CHECK_DEPTH=9 _find_repo_root)"
+    assert_eq "$got" "$(cd "$top" && pwd)"
+}

--- a/tests/checkcache_test.sh
+++ b/tests/checkcache_test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Tests for keeping a check's answer until it can change.
+#
+# A cache that is wrong is worse than a check that is slow, so most of this is
+# about what has to invalidate it. Three things can: the file, the check that
+# read it, and the config the thresholds came from. op's point, and the one an
+# obvious implementation misses: the checker counts. A cache over the file
+# alone keeps answering with the old check's opinion after the check changes,
+# and nothing says so.
+
+use test
+use checkcache
+
+_cc_setup() {
+    CCROOT="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-cc.XXXXXX")"
+    export NUT_CACHE_DIR="$CCROOT/cache"
+    export NUT_CACHE_ENABLED=1
+    export NUT_CACHE_CHECKER="$CCROOT/checker.sh"
+    printf 'a checker\n' > "$NUT_CACHE_CHECKER"
+    printf 'some source\n' > "$CCROOT/src.sh"
+    CONFIG_FILE="$CCROOT/nut.toml"; printf 'threshold = 1\n' > "$CONFIG_FILE"
+    # Everything below wants the entry to be newer than its inputs, and a
+    # filesystem with one-second stamps cannot tell two writes apart.
+    sleep 1
+}
+_cc_end() {
+    rm -rf "$CCROOT"
+    unset CCROOT NUT_CACHE_DIR NUT_CACHE_ENABLED NUT_CACHE_CHECKER CONFIG_FILE
+}
+
+#[test]
+it_has_nothing_before_anything_is_written() {
+    _cc_setup
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_gives_back_what_was_kept() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'two findings here'
+    assert_ok nut_cache_hit probe "$CCROOT/src.sh"
+    assert_eq "$(nut_cache_read probe "$CCROOT/src.sh")" "two findings here"
+    _cc_end
+}
+
+#[test]
+it_forgets_when_the_file_changes() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'old answer'
+    sleep 1
+    printf 'edited\n' > "$CCROOT/src.sh"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_forgets_when_the_check_itself_changes() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'old answer'
+    sleep 1
+    # The one an obvious cache misses. The file is untouched and the answer is
+    # still wrong, because a different check is asking.
+    printf 'a checker, with another step\n' > "$NUT_CACHE_CHECKER"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_forgets_when_the_thresholds_change() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'old answer'
+    sleep 1
+    printf 'threshold = 2\n' > "$CONFIG_FILE"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_keeps_one_answer_per_check_for_the_same_file() {
+    _cc_setup
+    nut_cache_write one "$CCROOT/src.sh" 'what one thinks'
+    nut_cache_write two "$CCROOT/src.sh" 'what two thinks'
+    assert_eq "$(nut_cache_read one "$CCROOT/src.sh")" "what one thinks"
+    assert_eq "$(nut_cache_read two "$CCROOT/src.sh")" "what two thinks"
+    _cc_end
+}
+
+#[test]
+it_answers_nothing_when_the_checker_is_not_named() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    unset NUT_CACHE_CHECKER
+    # A check that will not say which file it is cannot be cached, because
+    # there is no way to notice it changing.
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_stays_out_of_the_way_until_it_is_turned_on() {
+    _cc_setup
+    NUT_CACHE_ENABLED=0
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    # And nothing was written, so turning it on later does not find a stale one.
+    NUT_CACHE_ENABLED=1
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_forgets_a_file_that_is_no_longer_there() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    rm -f "$CCROOT/src.sh"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_can_be_thrown_away() {
+    _cc_setup
+    nut_cache_write one "$CCROOT/src.sh" 'a'
+    nut_cache_write two "$CCROOT/src.sh" 'b'
+    nut_cache_clear one
+    assert_fails nut_cache_hit one "$CCROOT/src.sh"
+    assert_ok    nut_cache_hit two "$CCROOT/src.sh"
+    nut_cache_clear
+    assert_fails nut_cache_hit two "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_does_not_let_a_path_escape_the_cache_directory() {
+    _cc_setup
+    local outside="$CCROOT/outside"; mkdir -p "$outside"; printf 'keep\n' > "$outside/f"
+    nut_cache_write '../../outside' '../../outside/f' 'nope'
+    assert_ok test -f "$outside/f"
+    assert_eq "$(cat "$outside/f")" "keep"
+    _cc_end
+}

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -788,20 +788,35 @@ it_puts_the_store_where_it_is_told_to() {
 }
 
 #[test]
-it_does_not_put_the_store_under_the_cache_directory() {
-    _isolate
-    local root; root="$(_extern_cache_root)"
-    # Not merely somewhere else: specifically not in the directory a cleaner is
-    # entitled to empty.
-    assert_fails grep -q '/\.cache/' <<<"$root"
-}
-
-#[test]
 it_puts_the_store_under_the_data_directory_when_nothing_overrides_it() {
     local root
     root="$(unset NUTSHELL_STORE; XDG_DATA_HOME=/tmp/xdg-probe _extern_cache_root)"
     assert_contains "$root" "/tmp/xdg-probe"
     assert_contains "$root" "externs"
+    _isolate
+}
+
+#[test]
+it_does_not_put_the_store_under_the_cache_directory() {
+    # With nothing overriding it, so the branch that derives the path is the
+    # one under test. Asserting this with `NUTSHELL_STORE` pointing at a
+    # scratch directory, as this used to, is a claim about `mktemp` that no
+    # change to the derivation could ever falsify.
+    #
+    # Not merely somewhere else: specifically not in the directory a cleaner is
+    # entitled to empty, which is where every project's dependencies used to
+    # live.
+    local root cache
+    root="$(unset NUTSHELL_STORE XDG_DATA_HOME; _extern_cache_root)"
+    cache="$(unset XDG_CACHE_HOME; xdg_set_app_name nutshell; xdg_app_cache)"
+    assert_ne "$root" ""
+    assert_ne "$cache" ""
+    # Against what this platform actually calls its cache, not against the
+    # spelling one platform happens to use. Matching `/.cache/` passes on macOS
+    # whatever the derivation does, because the cache there is
+    # `~/Library/Caches`, so that assertion could not fail on half the machines
+    # it runs on.
+    assert_ne "${root%/externs}" "$cache"
     _isolate
 }
 

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -804,3 +804,48 @@ it_puts_the_store_under_the_data_directory_when_nothing_overrides_it() {
     assert_contains "$root" "externs"
     _isolate
 }
+
+# --- one root, spelled twice -------------------------------------------------
+#
+# `find-nutshell` runs before nutshell exists and cannot use `lib/xdg.sh`, so
+# the platform branch is written out in both places. Nothing but this test
+# holds them together, and without it they were already apart: the toolchains
+# went to `~/.local/share` on macOS while the externs went to
+# `~/Library/Application Support`, and the README said they shared a root.
+
+#[test]
+it_puts_the_externs_and_the_toolchains_under_one_root() {
+    unset NUTSHELL_STORE NUTSHELL_TOOLCHAINS
+    # shellcheck source=/dev/null
+    . "${BASH_SOURCE[0]%/*}/../find-nutshell"
+    local externs toolchains
+    externs="$(_extern_cache_root)"
+    toolchains="$(nutshell_toolchain_dir)"
+    assert_eq "${externs%/externs}" "${toolchains%/toolchains}"
+    assert_eq "${externs%/externs}" "$(nutshell_store_root)"
+    _isolate
+}
+
+#[test]
+it_keeps_them_together_when_the_root_is_named() {
+    export NUTSHELL_STORE="/tmp/one-root-probe"
+    # shellcheck source=/dev/null
+    . "${BASH_SOURCE[0]%/*}/../find-nutshell"
+    assert_eq "$(_extern_cache_root)" "/tmp/one-root-probe/externs"
+    assert_eq "$(nutshell_toolchain_dir)" "/tmp/one-root-probe/toolchains"
+    _isolate
+}
+
+#[test]
+it_keeps_them_together_when_xdg_names_the_data_directory() {
+    unset NUTSHELL_STORE NUTSHELL_TOOLCHAINS
+    export XDG_DATA_HOME="/tmp/xdg-one-root"
+    # shellcheck source=/dev/null
+    . "${BASH_SOURCE[0]%/*}/../find-nutshell"
+    # The branch both sides take when the variable is set, which is the one
+    # place they already agreed. The two above are where they did not.
+    assert_eq "$(_extern_cache_root)" "/tmp/xdg-one-root/nutshell/externs"
+    assert_eq "$(nutshell_toolchain_dir)" "/tmp/xdg-one-root/nutshell/toolchains"
+    unset XDG_DATA_HOME
+    _isolate
+}

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -40,9 +40,17 @@ TOML
 }
 
 # Each test gets its own cache root, so one test's checkout is not another's.
+# A store of its own for each test.
+#
+# `NUTSHELL_STORE` rather than an XDG variable, because the store root is the
+# thing being isolated and pointing at whichever XDG directory it currently
+# derives from is isolation that stops working the moment it moves. It did:
+# the store went from the cache directory to the data directory and the tests
+# kept setting the cache one, so they were writing into the real store and
+# nothing said so.
 _isolate() {
-    XDG_CACHE_HOME="$(fs_temp_dir nutshell-extern-cache)"
-    export XDG_CACHE_HOME
+    NUTSHELL_STORE="$(fs_temp_dir nutshell-extern-store)"
+    export NUTSHELL_STORE
 }
 
 #[test]
@@ -767,4 +775,32 @@ it_resolves_the_tag_again_when_the_lock_entry_is_gone() {
 
     dir="$(extern_path fixture)"
     assert_eq "$(git -C "$dir" rev-parse HEAD)" "$first"
+}
+
+# --- the isolation itself ----------------------------------------------------
+
+#[test]
+it_puts_the_store_where_it_is_told_to() {
+    # The negative control for every test above. Each of them believes it is
+    # working in a store of its own, and none of them would notice being wrong.
+    _isolate
+    assert_contains "$(_extern_cache_root)" "$NUTSHELL_STORE"
+}
+
+#[test]
+it_does_not_put_the_store_under_the_cache_directory() {
+    _isolate
+    local root; root="$(_extern_cache_root)"
+    # Not merely somewhere else: specifically not in the directory a cleaner is
+    # entitled to empty.
+    assert_fails grep -q '/\.cache/' <<<"$root"
+}
+
+#[test]
+it_puts_the_store_under_the_data_directory_when_nothing_overrides_it() {
+    local root
+    root="$(unset NUTSHELL_STORE; XDG_DATA_HOME=/tmp/xdg-probe _extern_cache_root)"
+    assert_contains "$root" "/tmp/xdg-probe"
+    assert_contains "$root" "externs"
+    _isolate
 }

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -13,7 +13,7 @@ use extern test fs
 # commits, so a test can pin to the older one and see whether it is obeyed.
 _extern_fixture() {
     local work dep first second
-    work="$(fs_temp_dir nutshell-extern)"
+    work="$(_ex_tmp work)"
     dep="${work}/dep"
 
     mkdir -p "${dep}/lib"
@@ -48,8 +48,26 @@ TOML
 # the store went from the cache directory to the data directory and the tests
 # kept setting the cache one, so they were writing into the real store and
 # nothing said so.
+# One root for the whole file, taken down at the end of it.
+#
+# Every scratch directory here is a child of this one. `fs_temp_dir` and a bare
+# `mktemp -d` both make one under the system temporary directory and neither
+# removes it, and this file was leaving twenty-seven per run.
+#
+# The three that still call `mktemp -d` run in a fresh `bash -c` which has none
+# of this file's helpers, and each removes its own directory on the way out.
+# They say `self-cleaned` on the line, which is what the guard below allows.
+_EX_TMP="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-extern.XXXXXX")"
+trap '[[ -n "${_EX_TMP:-}" ]] && rm -rf "$_EX_TMP"' EXIT
+
+# A scratch directory under this file's own root.
+_ex_tmp() {
+    local d; d="$(mktemp -d "${_EX_TMP}/${1:-d}.XXXXXX")"
+    printf '%s' "$d"
+}
+
 _isolate() {
-    NUTSHELL_STORE="$(fs_temp_dir nutshell-extern-store)"
+    NUTSHELL_STORE="$(_ex_tmp store)"
     export NUTSHELL_STORE
 }
 
@@ -405,7 +423,7 @@ _manifest_fixture() {
     # fs_temp_dir passes it through, while a path that has been cd'd into comes
     # back single-slashed. Comparing one against the other fails on the slash
     # rather than on the behaviour.
-    root="$(cd "$(fs_temp_dir nutshell-manifest)" && pwd)"
+    root="$(cd "$(_ex_tmp manifest)" && pwd)"
     mkdir -p "${root}/unit" "${root}/elsewhere" "${root}/project/sub" "${root}/loose"
     printf '[deps.a]\ngit = "x"\n' > "${root}/unit/nut.toml"
     printf '[deps.b]\ngit = "y"\n' > "${root}/project/nut.toml"
@@ -518,7 +536,7 @@ it_does_not_hand_back_a_checkout_that_has_gone() {
 
 #[test]
 it_takes_a_nested_module_separated_all_the_way_down() {
-    local d; d="$(mktemp -d)"
+    local d; d="$(_ex_tmp)"
     mkdir -p "$d/dep/libs/tui"
     printf 'MARKER=reached\n' > "$d/dep/libs/tui/key.sh"
     printf '[meta]\nname="dep"\n' > "$d/dep/nut.toml"
@@ -531,7 +549,7 @@ it_takes_a_nested_module_separated_all_the_way_down() {
 
 #[test]
 it_refuses_a_module_path_that_uses_a_slash() {
-    local d; d="$(mktemp -d)"
+    local d; d="$(_ex_tmp)"
     mkdir -p "$d/dep/libs/tui"
     printf 'MARKER=reached\n' > "$d/dep/libs/tui/key.sh"
     extern_path() { printf '%s/dep' "$d"; }
@@ -544,7 +562,7 @@ it_refuses_a_module_path_that_uses_a_slash() {
 
 #[test]
 it_says_the_spelling_that_would_have_worked() {
-    local d out; d="$(mktemp -d)"
+    local d out; d="$(_ex_tmp)"
     mkdir -p "$d/dep/libs/tui"
     : > "$d/dep/libs/tui/key.sh"
     extern_path() { printf '%s/dep' "$d"; }
@@ -556,7 +574,7 @@ it_says_the_spelling_that_would_have_worked() {
 
 #[test]
 it_still_takes_a_flat_module() {
-    local d; d="$(mktemp -d)"
+    local d; d="$(_ex_tmp)"
     mkdir -p "$d/dep/lib"
     : > "$d/dep/lib/plain.sh"
     extern_path() { printf '%s/dep' "$d"; }
@@ -578,7 +596,7 @@ it_loads_a_module_once_however_it_was_named() {
     out="$(bash -c '
         cd '"$PWD"'
         . ./init
-        d=$(mktemp -d); mkdir -p "$d/libs/tui"
+        d=$(mktemp -d); mkdir -p "$d/libs/tui"  # self-cleaned, fresh shell
         printf "COUNT=\$(( \${COUNT:-0} + 1 ))\n" > "$d/libs/tui/key.sh"
         use extern
         extern_path() { printf "%s" "$d"; }
@@ -595,7 +613,7 @@ it_answers_that_a_module_is_loaded_by_either_name() {
     out="$(bash -c '
         cd '"$PWD"'
         . ./init
-        d=$(mktemp -d); mkdir -p "$d/libs/tui"
+        d=$(mktemp -d); mkdir -p "$d/libs/tui"  # self-cleaned, fresh shell
         : > "$d/libs/tui/key.sh"
         use extern
         extern_path() { printf "%s" "$d"; }
@@ -613,7 +631,7 @@ it_does_not_record_a_module_that_failed_to_load() {
     out="$(bash -c '
         cd '"$PWD"'
         . ./init
-        d=$(mktemp -d); mkdir -p "$d/libs"
+        d=$(mktemp -d); mkdir -p "$d/libs"  # self-cleaned, fresh shell
         printf "return 1\n" > "$d/libs/bad.sh"
         use extern
         extern_path() { printf "%s" "$d"; }
@@ -631,7 +649,7 @@ it_finds_a_units_manifest_when_run_from_somewhere_else() {
     # resolve a single dependency: the manifest search had only PWD, which is a
     # fact about where the shell was started rather than about which unit is
     # asking.
-    local d out; d="$(mktemp -d)"
+    local d out; d="$(_ex_tmp)"
     mkdir -p "$d/unit/lib" "$d/dep/libs"
     printf '[meta]\nname="unit"\n\n[deps.dep]\ngit = "x"\n' > "$d/unit/nut.toml"
     printf 'MARKER=reached\n' > "$d/dep/libs/thing.sh"
@@ -660,7 +678,7 @@ it_finds_a_units_manifest_when_run_from_somewhere_else() {
 # and months of work in it had never reached the consumer.
 
 _ex_origin() {
-    local d; d="$(mktemp -d)"
+    local d; d="$(_ex_tmp)"
     git -C "$d" init --quiet -b dev
     git -C "$d" config user.email t@t; git -C "$d" config user.name t
     mkdir -p "$d/libs"
@@ -679,7 +697,7 @@ _ex_advance() {
 #[test]
 it_takes_the_newest_commit_when_the_lock_says_nothing() {
     local origin; origin="$(_ex_origin)"
-    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    local mirror; mirror="$(_ex_tmp)"; rm -rf "$mirror"
     git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
     local before; before="$(_extern_ref_commit "$mirror" dev)"
 
@@ -701,7 +719,7 @@ it_answers_with_the_commit_it_already_has_when_the_ref_cannot_be_fetched() {
     # A machine with no network still has whatever it cloned. A stale answer
     # beats no answer for a tool whose job is a machine that is broken.
     local origin; origin="$(_ex_origin)"
-    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    local mirror; mirror="$(_ex_tmp)"; rm -rf "$mirror"
     git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
     local before; before="$(_extern_ref_commit "$mirror" dev)"
     rm -rf "$origin"
@@ -715,7 +733,7 @@ it_answers_with_the_commit_it_already_has_when_the_ref_cannot_be_fetched() {
 #[test]
 it_refuses_a_ref_the_mirror_has_never_heard_of() {
     local origin; origin="$(_ex_origin)"
-    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    local mirror; mirror="$(_ex_tmp)"; rm -rf "$mirror"
     git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
     local rc=0
     _extern_ref_commit "$mirror" "no-such-ref" >/dev/null 2>&1 || rc=$?
@@ -731,7 +749,7 @@ it_takes_a_commit_that_carries_a_file_the_old_one_did_not() {
     # commit of a library resolved every module that existed then and none of
     # the ones added since, and the error named the module rather than the pin.
     local origin; origin="$(_ex_origin)"
-    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    local mirror; mirror="$(_ex_tmp)"; rm -rf "$mirror"
     git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
     _ex_advance "$origin"
     _extern_refresh "$mirror" dev
@@ -863,4 +881,16 @@ it_keeps_them_together_when_xdg_names_the_data_directory() {
     assert_eq "$(nutshell_toolchain_dir)" "/tmp/xdg-one-root/nutshell/toolchains"
     unset XDG_DATA_HOME
     _isolate
+}
+
+#[test]
+it_makes_no_scratch_directory_outside_its_own_root() {
+    # The leak was twenty-seven per run and nothing failed while it happened.
+    # The three that stay are in a fresh `bash -c` which cannot see `_ex_tmp`,
+    # and each removes its own directory; they are named so, and the check
+    # allows exactly those.
+    local stray
+    stray="$(grep -nE 'mktemp -d[)" ]|fs_temp_dir[ )"]' "${BASH_SOURCE[0]}" \
+        | grep -v '_EX_TMP' | grep -v 'self-cleaned' | grep -vE '^[0-9]+: *#' || true)"
+    assert_empty "$stray"
 }

--- a/tests/find_test.sh
+++ b/tests/find_test.sh
@@ -25,18 +25,33 @@ _fake_nutshell() {
 # Every test gets an empty store and a remote that cannot answer, so nothing
 # here reaches the network and nothing depends on what this machine happens to
 # have downloaded already. The tests that are about the store fill it in.
+# One root for the whole file, taken down at the end of it.
+#
+# Every scratch directory here is a child of this one. Making them with a bare
+# `mktemp -d` leaves them: removing the `store` child of one says nothing about
+# its parent, and this file was leaving twenty-six directories in the temporary
+# directory on every run.
+_FIND_TMP="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-find.XXXXXX")"
+trap '[[ -n "${_FIND_TMP:-}" ]] && rm -rf "$_FIND_TMP"' EXIT
+
+# A scratch directory under this file's own root.
+_tmp() {
+    local d; d="$(mktemp -d "${_FIND_TMP}/${1:-d}.XXXXXX")"
+    printf '%s' "$d"
+}
+
 _reset() {
     NUTSHELL_INIT=""; NUTSHELL_FROM=""; unset NUTSHELL_HOME
     [[ -n "${NUTSHELL_TOOLCHAINS:-}" ]] && rm -rf "$NUTSHELL_TOOLCHAINS"
-    export NUTSHELL_TOOLCHAINS="$(mktemp -d)/store"
+    export NUTSHELL_TOOLCHAINS="$(_tmp store)/store"
     export NUTSHELL_REMOTE="/nonexistent/nutshell.git"
 }
 
 #[test]
 it_prefers_what_the_caller_named() {
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/named"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/named"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell"
     NUTSHELL_HOME="$d/named" nutshell_find "$root"
     local from="$NUTSHELL_FROM" init="$NUTSHELL_INIT"
     rm -rf "$d" "$root"; _reset
@@ -49,8 +64,8 @@ it_refuses_a_named_home_with_no_interpreter_in_it() {
     # Silently falling through to another one would make the override a
     # suggestion, and an override that is a suggestion is worse than none.
     _reset
-    local d; d="$(mktemp -d)"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    local d; d="$(_tmp)"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell"
     local rc=0
     NUTSHELL_HOME="$d/nothing" nutshell_find "$root" 2>/dev/null || rc=$?
     rm -rf "$d" "$root"; _reset
@@ -61,8 +76,8 @@ it_refuses_a_named_home_with_no_interpreter_in_it() {
 it_prefers_an_installed_one_over_a_vendored_one() {
     # The whole point. A per-project copy is the thing that goes stale.
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/installed"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell"
     PATH="$d/installed/bin:$PATH" nutshell_find "$root"
     local from="$NUTSHELL_FROM" init="$NUTSHELL_INIT"
     rm -rf "$d" "$root"; _reset
@@ -75,7 +90,7 @@ it_falls_back_to_the_vendored_one_when_nothing_is_installed() {
     # The machine this tool is usually rescuing has nothing installed, so the
     # vendored copy is a fallback rather than a mistake.
     _reset
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell"
     # A PATH with the ordinary tools on it and no nutshell, which is the
     # machine this is the fallback for.
     PATH="/usr/bin:/bin" nutshell_find "$root"
@@ -89,7 +104,7 @@ it_follows_a_launcher_that_is_a_link() {
     # The one on PATH is usually a link into a checkout, and the init sits
     # beside the binary rather than beside the link.
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/real"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/real"
     mkdir -p "$d/bin"; ln -s "$d/real/bin/nutshell" "$d/bin/nutshell"
     PATH="$d/bin:$PATH" nutshell_find ""
     local from="$NUTSHELL_FROM" init="$NUTSHELL_INIT"
@@ -103,7 +118,7 @@ it_does_not_take_a_file_called_init_that_is_not_one() {
     # A tool with its own `init` would be sourced and would fail somewhere
     # less obvious than here.
     _reset
-    local root; root="$(mktemp -d)"
+    local root; root="$(_tmp)"
     mkdir -p "$root/lib/nutshell"
     printf 'echo not nutshell\n' > "$root/lib/nutshell/init"
     local rc=0
@@ -172,7 +187,7 @@ it_finds_the_interpreter_with_nothing_on_the_path_at_all() {
     # ways that include its PATH. A resolver needing a tool to find the
     # interpreter fails exactly when it is needed.
     _reset
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell"
     PATH="" nutshell_find "$root"
     local from="$NUTSHELL_FROM"
     rm -rf "$root"; _reset
@@ -191,7 +206,7 @@ it_finds_the_interpreter_with_nothing_on_the_path_at_all() {
 it_reads_a_version_without_running_the_interpreter() {
     # Read rather than sourced: a candidate about to be rejected must not be
     # given the chance to run first.
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/n" "1.2.3"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/n" "1.2.3"
     local v; v="$(_nutshell_version_of "$d/n/init")"
     rm -rf "$d"
     assert_eq "$v" "1.2.3"
@@ -201,7 +216,7 @@ it_reads_a_version_without_running_the_interpreter() {
 it_takes_the_quotes_off_the_version() {
     # Trimming at the first character that is not a digit or a dot trims at the
     # opening quote and answers with nothing.
-    local d; d="$(mktemp -d)"
+    local d; d="$(_tmp)"
     mkdir -p "$d/n"
     printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$d/n/init"
     local v; v="$(_nutshell_version_of "$d/n/init")"
@@ -212,8 +227,8 @@ it_takes_the_quotes_off_the_version() {
 #[test]
 it_skips_an_installed_one_that_is_too_old() {
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.3.0"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/installed" "0.3.0"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
     PATH="$d/installed/bin:$PATH" nutshell_find "$root" "0.4.0" 2>/dev/null
     local from="$NUTSHELL_FROM"
     rm -rf "$d" "$root"; _reset
@@ -225,8 +240,8 @@ it_says_out_loud_when_it_skips_the_installed_one() {
     # Silently falling through would hide exactly the version skew this exists
     # to surface.
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.3.0"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/installed" "0.3.0"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
     local out
     out="$(PATH="$d/installed/bin:$PATH" nutshell_find "$root" "0.4.0" 2>&1)"
     rm -rf "$d" "$root"; _reset
@@ -238,8 +253,8 @@ it_says_out_loud_when_it_skips_the_installed_one() {
 it_still_prefers_an_installed_one_that_is_new_enough() {
     # The control. Skipping the too-old must not stop it preferring the rest.
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.5.0"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/installed" "0.5.0"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
     PATH="$d/installed/bin:$PATH" nutshell_find "$root" "0.4.0"
     local from="$NUTSHELL_FROM"
     rm -rf "$d" "$root"; _reset
@@ -249,8 +264,8 @@ it_still_prefers_an_installed_one_that_is_new_enough() {
 #[test]
 it_prefers_an_installed_one_when_no_minimum_is_named() {
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.1.0"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "9.9.9"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/installed" "0.1.0"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell" "9.9.9"
     PATH="$d/installed/bin:$PATH" nutshell_find "$root"
     local from="$NUTSHELL_FROM"
     rm -rf "$d" "$root"; _reset
@@ -262,8 +277,8 @@ it_honours_a_named_home_even_when_it_is_too_old() {
     # An override quietly ignored is worse than one that fails, and somebody
     # working on nutshell itself needs theirs honoured.
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/named" "0.0.1"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "9.9.9"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/named" "0.0.1"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell" "9.9.9"
     NUTSHELL_HOME="$d/named" nutshell_find "$root" "0.4.0"
     local from="$NUTSHELL_FROM"
     rm -rf "$d" "$root"; _reset
@@ -272,8 +287,42 @@ it_honours_a_named_home_even_when_it_is_too_old() {
 
 #[test]
 it_compares_the_pieces_as_numbers_when_choosing_too() {
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/n" "0.10.0"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/n" "0.10.0"
     assert_ok    _nutshell_satisfies "$d/n/init" "0.9.0"
     assert_fails _nutshell_satisfies "$d/n/init" "0.11.0"
     rm -rf "$d"
+}
+
+# --- the scratch directories this file makes ----------------------------------
+#
+# Twenty-six of them per run were being left in the temporary directory, and
+# the leak was invisible: `_reset` removed the `store` child of a `mktemp -d`
+# and never the parent, and every test made one or two more that nothing
+# removed at all. Nothing failed, and the directory filled up.
+
+#[test]
+it_takes_its_scratch_directories_down_when_the_file_is_done_with_them() {
+    # A whole life of the file in one subshell: source it, take a directory,
+    # leave. The trap is what has to fire, so the assertion is made from
+    # outside the shell that armed it.
+    local d
+    d="$(bash -c '. "$0" >/dev/null 2>&1; _tmp probe' "${BASH_SOURCE[0]}")"
+    assert_ne "$d" ""
+    assert_fails test -d "$d"
+}
+
+#[test]
+it_puts_a_scratch_directory_under_its_own_root() {
+    local d; d="$(_tmp probe)"
+    assert_contains "$d" "$_FIND_TMP"
+}
+
+#[test]
+it_makes_no_scratch_directory_outside_that_root() {
+    # The one bare `mktemp -d` allowed is the root itself, and the helper that
+    # takes children of it names the root in the same line. Anything else is
+    # the leak coming back, and it comes back silently.
+    local stray
+    stray="$(grep -nE 'mktemp -d[)" ]' "${BASH_SOURCE[0]}" | grep -v '_FIND_TMP' || true)"
+    assert_empty "$stray"
 }

--- a/tests/find_test.sh
+++ b/tests/find_test.sh
@@ -22,7 +22,15 @@ _fake_nutshell() {
     chmod +x "$d/bin/nutshell"
 }
 
-_reset() { NUTSHELL_INIT=""; NUTSHELL_FROM=""; unset NUTSHELL_HOME; }
+# Every test gets an empty store and a remote that cannot answer, so nothing
+# here reaches the network and nothing depends on what this machine happens to
+# have downloaded already. The tests that are about the store fill it in.
+_reset() {
+    NUTSHELL_INIT=""; NUTSHELL_FROM=""; unset NUTSHELL_HOME
+    [[ -n "${NUTSHELL_TOOLCHAINS:-}" ]] && rm -rf "$NUTSHELL_TOOLCHAINS"
+    export NUTSHELL_TOOLCHAINS="$(mktemp -d)/store"
+    export NUTSHELL_REMOTE="/nonexistent/nutshell.git"
+}
 
 #[test]
 it_prefers_what_the_caller_named() {

--- a/tests/toolchain_test.sh
+++ b/tests/toolchain_test.sh
@@ -73,27 +73,52 @@ _tc_remote() {
 # --- where the store is ------------------------------------------------------
 
 #[test]
-it_takes_the_store_location_from_the_environment() {
+it_takes_the_toolchain_directory_from_the_environment() {
     _tc_setup
-    assert_eq "$(nutshell_store)" "$TCROOT/store"
+    assert_eq "$(nutshell_toolchain_dir)" "$TCROOT/store"
+    _tc_end
+}
+
+#[test]
+it_puts_the_toolchains_under_the_store_root() {
+    _tc_setup
+    unset NUTSHELL_TOOLCHAINS
+    assert_eq "$(NUTSHELL_STORE="$TCROOT/s" nutshell_toolchain_dir)" \
+        "$TCROOT/s/toolchains"
+    assert_eq "$(NUTSHELL_STORE="$TCROOT/s" nutshell_store_root)" "$TCROOT/s"
     _tc_end
 }
 
 #[test]
 it_falls_back_to_the_data_directory() {
     _tc_setup
-    unset NUTSHELL_TOOLCHAINS
-    XDG_DATA_HOME="$TCROOT/data"
-    assert_eq "$(XDG_DATA_HOME="$TCROOT/data" nutshell_store)" \
+    unset NUTSHELL_TOOLCHAINS NUTSHELL_STORE
+    assert_eq "$(XDG_DATA_HOME="$TCROOT/data" nutshell_toolchain_dir)" \
         "$TCROOT/data/nutshell/toolchains"
+    _tc_end
+}
+
+#[test]
+it_puts_the_store_where_the_platform_puts_application_data() {
+    _tc_setup
+    unset NUTSHELL_TOOLCHAINS NUTSHELL_STORE XDG_DATA_HOME
+    local root; root="$(HOME="$TCROOT/h" nutshell_store_root)"
+    case "$(uname -s)" in
+        Darwin) assert_eq "$root" "$TCROOT/h/Library/Application Support/nutshell" ;;
+        *)      assert_eq "$root" "$TCROOT/h/.local/share/nutshell" ;;
+    esac
     _tc_end
 }
 
 #[test]
 it_drops_a_trailing_slash_so_the_paths_under_it_are_not_doubled() {
     _tc_setup
-    assert_eq "$(NUTSHELL_TOOLCHAINS="$TCROOT/store/" nutshell_store)" \
+    assert_eq "$(NUTSHELL_TOOLCHAINS="$TCROOT/store/" nutshell_toolchain_dir)" \
         "$TCROOT/store"
+    unset NUTSHELL_TOOLCHAINS
+    assert_eq "$(NUTSHELL_STORE="$TCROOT/s/" nutshell_store_root)" "$TCROOT/s"
+    assert_eq "$(NUTSHELL_STORE="$TCROOT/s/" nutshell_toolchain_dir)" \
+        "$TCROOT/s/toolchains"
     _tc_end
 }
 

--- a/tests/toolchain_test.sh
+++ b/tests/toolchain_test.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# Tests for several versions on one machine at once.
+#
+# The state this exists for is ordinary, not exceptional: two tools wanting two
+# different nutshells, on a machine that has one of them. Failing there is the
+# defect. The store keeps every version that has been asked for, the resolver
+# takes the newest that satisfies the caller, and a version nobody has fetched
+# yet is a download rather than an error.
+
+use test
+
+. "${BASH_SOURCE[0]%/*}/../find-nutshell"
+
+_tc_setup() {
+    TCROOT="$(mktemp -d)"
+    export NUTSHELL_TOOLCHAINS="$TCROOT/store"
+    export NUTSHELL_REMOTE="$TCROOT/remote.git"
+    NUTSHELL_INIT=""; NUTSHELL_FROM=""
+    unset NUTSHELL_HOME
+    # Any directory holding a nutshell comes off PATH, so whatever is installed
+    # on the machine running these tests cannot decide their answers. The rest
+    # of PATH stays: these tests need git and the ordinary tools.
+    _TC_PATH_KEEP="$PATH"
+    local d out=""
+    while IFS= read -r d; do
+        [[ -n "$d" ]] || continue
+        [[ -x "$d/nutshell" ]] && continue
+        out="${out:+$out:}$d"
+    done <<< "${PATH//:/$'\n'}"
+    export PATH="$out"
+}
+_tc_end() {
+    rm -rf "$TCROOT"
+    unset TCROOT NUTSHELL_TOOLCHAINS NUTSHELL_REMOTE
+    NUTSHELL_INIT=""; NUTSHELL_FROM=""
+    export PATH="${_TC_PATH_KEEP:-$PATH}"
+}
+
+# A version sitting in the store.
+_tc_store() {
+    local v="$1" name="${2:-$1}"
+    mkdir -p "$NUTSHELL_TOOLCHAINS/$name"
+    printf 'export NUTSHELL_VERSION="%s"\n' "$v" \
+        > "$NUTSHELL_TOOLCHAINS/$name/init"
+}
+
+# A remote holding one tagged version, so a fetch has somewhere real to go.
+_tc_remote() {
+    # Two statements: bash declares every name in one `local` before running
+    # any of its assignments, so naming v in work's value reads it while it is
+    # still unset and `set -u` stops the test dead.
+    local v="$1"
+    local work="$TCROOT/work-$v"
+    mkdir -p "$work"
+    printf 'export NUTSHELL_VERSION="%s"\n' "$v" > "$work/init"
+    git -C "$work" init -q -b main
+    git -C "$work" config user.email t@example.invalid
+    git -C "$work" config user.name t
+    git -C "$work" config commit.gpgsign false
+    git -C "$work" config tag.gpgsign false
+    git -C "$work" add -A
+    git -C "$work" commit -qm "$v"
+    # Annotated, with a message, because a machine whose git is set to force
+    # annotated tags refuses a lightweight one and the error is "no tag
+    # message?", which says nothing about tags being the subject.
+    git -C "$work" tag -a "$v" -m "$v"
+    [[ -d "$NUTSHELL_REMOTE" ]] || git init -q --bare "$NUTSHELL_REMOTE"
+    git -C "$work" remote add origin "$NUTSHELL_REMOTE" 2>/dev/null || true
+    git -C "$work" push -q origin main --tags 2>/dev/null || \
+        git -C "$work" push -q origin "$v"
+}
+
+# --- where the store is ------------------------------------------------------
+
+#[test]
+it_takes_the_store_location_from_the_environment() {
+    _tc_setup
+    assert_eq "$(nutshell_store)" "$TCROOT/store"
+    _tc_end
+}
+
+#[test]
+it_falls_back_to_the_data_directory() {
+    _tc_setup
+    unset NUTSHELL_TOOLCHAINS
+    XDG_DATA_HOME="$TCROOT/data"
+    assert_eq "$(XDG_DATA_HOME="$TCROOT/data" nutshell_store)" \
+        "$TCROOT/data/nutshell/toolchains"
+    _tc_end
+}
+
+#[test]
+it_drops_a_trailing_slash_so_the_paths_under_it_are_not_doubled() {
+    _tc_setup
+    assert_eq "$(NUTSHELL_TOOLCHAINS="$TCROOT/store/" nutshell_store)" \
+        "$TCROOT/store"
+    _tc_end
+}
+
+# --- what is in it -----------------------------------------------------------
+
+#[test]
+it_lists_nothing_when_the_store_is_not_there() {
+    _tc_setup
+    assert_empty "$(nutshell_toolchains)"
+    _tc_end
+}
+
+#[test]
+it_lists_nothing_when_the_store_is_empty() {
+    _tc_setup
+    mkdir -p "$NUTSHELL_TOOLCHAINS"
+    assert_empty "$(nutshell_toolchains)"
+    _tc_end
+}
+
+#[test]
+it_lists_what_is_in_the_store_newest_first() {
+    _tc_setup
+    _tc_store 0.3.0; _tc_store 0.4.0; _tc_store 0.2.0
+    assert_eq "$(nutshell_toolchains)" "$(printf '0.4.0\n0.3.0\n0.2.0')"
+    _tc_end
+}
+
+#[test]
+it_orders_by_number_and_not_by_spelling() {
+    _tc_setup
+    _tc_store 0.9.0; _tc_store 0.10.0; _tc_store 0.10.2
+    # Every string comparison puts 0.9.0 above 0.10.0, and every one of them is
+    # wrong.
+    assert_eq "$(nutshell_toolchains)" "$(printf '0.10.2\n0.10.0\n0.9.0')"
+    _tc_end
+}
+
+#[test]
+it_skips_a_directory_with_no_interpreter_in_it() {
+    _tc_setup
+    _tc_store 0.4.0
+    mkdir -p "$NUTSHELL_TOOLCHAINS/0.5.0"
+    assert_eq "$(nutshell_toolchains)" "0.4.0"
+    _tc_end
+}
+
+#[test]
+it_skips_a_directory_whose_contents_disagree_with_its_name() {
+    _tc_setup
+    _tc_store 0.4.0
+    _tc_store 0.1.0 0.9.9      # named 0.9.9, reports 0.1.0
+    # The name is what the resolver looks things up by, so a directory that
+    # lies about itself would be handed out for a request it cannot satisfy.
+    assert_eq "$(nutshell_toolchains)" "0.4.0"
+    _tc_end
+}
+
+# --- resolving out of it -----------------------------------------------------
+
+#[test]
+it_resolves_to_a_toolchain_when_nothing_is_installed() {
+    _tc_setup
+    _tc_store 0.4.0
+    assert_ok nutshell_find "" 0.4.0
+    assert_eq "$NUTSHELL_FROM" "toolchain"
+    assert_eq "$NUTSHELL_INIT" "$NUTSHELL_TOOLCHAINS/0.4.0/init"
+    _tc_end
+}
+
+#[test]
+it_takes_the_newest_one_that_satisfies_the_caller() {
+    _tc_setup
+    _tc_store 0.3.0; _tc_store 0.4.0; _tc_store 0.5.0
+    assert_ok nutshell_find "" 0.4.0
+    assert_eq "$NUTSHELL_INIT" "$NUTSHELL_TOOLCHAINS/0.5.0/init"
+    _tc_end
+}
+
+#[test]
+it_will_not_take_one_older_than_the_caller_needs() {
+    _tc_setup
+    _tc_store 0.2.0; _tc_store 0.3.0
+    # Nothing satisfies, nothing to fetch from: a refusal, not a wrong answer
+    # that fails later with a missing function.
+    assert_fails nutshell_find "" 0.4.0 2>/dev/null
+    _tc_end
+}
+
+#[test]
+it_takes_any_of_them_when_the_caller_names_no_minimum() {
+    _tc_setup
+    _tc_store 0.2.0; _tc_store 0.3.0
+    assert_ok nutshell_find "" ""
+    assert_eq "$NUTSHELL_INIT" "$NUTSHELL_TOOLCHAINS/0.3.0/init"
+    _tc_end
+}
+
+#[test]
+it_prefers_a_satisfying_installed_one_over_the_store() {
+    _tc_setup
+    _tc_store 0.9.0
+    mkdir -p "$TCROOT/installed/bin"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$TCROOT/installed/init"
+    printf '#!/usr/bin/env bash\n' > "$TCROOT/installed/bin/nutshell"
+    chmod +x "$TCROOT/installed/bin/nutshell"
+    export PATH="$TCROOT/installed/bin:$PATH"
+    # One shared nutshell that everything uses is the good state. The store is
+    # for the tools that cannot use it, not a replacement for it.
+    assert_ok nutshell_find "" 0.4.0
+    assert_eq "$NUTSHELL_FROM" "installed"
+    _tc_end
+}
+
+#[test]
+it_falls_to_the_store_when_the_installed_one_is_too_old() {
+    _tc_setup
+    _tc_store 0.4.0
+    mkdir -p "$TCROOT/installed/bin"
+    printf 'export NUTSHELL_VERSION="0.3.0"\n' > "$TCROOT/installed/init"
+    printf '#!/usr/bin/env bash\n' > "$TCROOT/installed/bin/nutshell"
+    chmod +x "$TCROOT/installed/bin/nutshell"
+    export PATH="$TCROOT/installed/bin:$PATH"
+    assert_ok nutshell_find "" 0.4.0 2>/dev/null
+    assert_eq "$NUTSHELL_FROM" "toolchain"
+    _tc_end
+}
+
+#[test]
+it_prefers_the_store_over_a_vendored_copy() {
+    _tc_setup
+    _tc_store 0.4.0
+    local root="$TCROOT/project"
+    mkdir -p "$root/lib/nutshell"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$root/lib/nutshell/init"
+    # The vendored copy is the compromise, kept for a machine with no network.
+    assert_ok nutshell_find "$root" 0.4.0
+    assert_eq "$NUTSHELL_FROM" "toolchain"
+    _tc_end
+}
+
+# --- fetching ----------------------------------------------------------------
+
+#[test]
+it_fetches_a_version_that_is_not_here_yet() {
+    _tc_setup
+    _tc_remote 0.4.0
+    assert_ok nutshell_find "" 0.4.0 2>/dev/null
+    assert_eq "$NUTSHELL_FROM" "fetched"
+    assert_eq "$NUTSHELL_INIT" "$NUTSHELL_TOOLCHAINS/0.4.0/init"
+    # And it is in the store afterwards, so the next caller does not fetch it
+    # again.
+    assert_eq "$(nutshell_toolchains)" "0.4.0"
+    _tc_end
+}
+
+#[test]
+it_does_not_fetch_when_the_store_already_answers() {
+    _tc_setup
+    _tc_store 0.4.0
+    # No remote at all. A fetch here would fail loudly, so silence is the
+    # assertion.
+    assert_ok nutshell_find "" 0.4.0
+    assert_eq "$NUTSHELL_FROM" "toolchain"
+    _tc_end
+}
+
+#[test]
+it_refuses_a_fetch_whose_contents_report_another_version() {
+    _tc_setup
+    # Tagged 0.4.0, but the file inside says 0.1.0: a tag that moved, or a
+    # branch name that happens to look like a version. Storing it under the
+    # asked-for name would put a lie in the store for every later run.
+    local work="$TCROOT/work"
+    mkdir -p "$work"
+    printf 'export NUTSHELL_VERSION="0.1.0"\n' > "$work/init"
+    git -C "$work" init -q -b main
+    git -C "$work" config user.email t@example.invalid
+    git -C "$work" config user.name t
+    git -C "$work" config commit.gpgsign false
+    git -C "$work" config tag.gpgsign false
+    git -C "$work" add -A; git -C "$work" commit -qm x
+    git -C "$work" tag -a 0.4.0 -m 0.4.0
+    git init -q --bare "$NUTSHELL_REMOTE"
+    git -C "$work" remote add origin "$NUTSHELL_REMOTE"
+    git -C "$work" push -q origin main --tags
+    assert_fails nutshell_find "" 0.4.0 2>/dev/null
+    assert_empty "$(nutshell_toolchains)"
+    _tc_end
+}
+
+#[test]
+it_leaves_no_half_a_toolchain_behind_when_the_fetch_fails() {
+    _tc_setup
+    export NUTSHELL_REMOTE="$TCROOT/no-such-remote.git"
+    assert_fails nutshell_find "" 0.4.0 2>/dev/null
+    assert_empty "$(nutshell_toolchains)"
+    assert_fails test -e "$NUTSHELL_TOOLCHAINS/0.4.0"
+    _tc_end
+}
+
+#[test]
+it_falls_back_to_the_vendored_copy_when_the_fetch_cannot_happen() {
+    _tc_setup
+    export NUTSHELL_REMOTE="$TCROOT/no-such-remote.git"
+    local root="$TCROOT/project"
+    mkdir -p "$root/lib/nutshell"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$root/lib/nutshell/init"
+    # The rescue machine: no network, nothing installed, and what is in the
+    # tree is all there is.
+    assert_ok nutshell_find "$root" 0.4.0 2>/dev/null
+    assert_eq "$NUTSHELL_FROM" "vendored"
+    _tc_end
+}
+
+#[test]
+it_does_not_fetch_when_the_caller_names_no_version() {
+    _tc_setup
+    _tc_remote 0.4.0
+    # Nothing to ask the remote for. Guessing at the newest would make an
+    # unpinned tool track whatever was tagged last, silently.
+    assert_fails nutshell_find "" "" 2>/dev/null
+    assert_empty "$(nutshell_toolchains)"
+    _tc_end
+}

--- a/tests/toolchain_test.sh
+++ b/tests/toolchain_test.sh
@@ -344,3 +344,157 @@ it_does_not_fetch_when_the_caller_names_no_version() {
     assert_empty "$(nutshell_toolchains)"
     _tc_end
 }
+
+# --- the store is shared, and nothing in it is deleted while it is in use -----
+#
+# Every project on this machine resolves out of one store and nothing locks it.
+# So the two dangerous moves are removing a directory another process is
+# sourcing out of, and building a store path out of a name a caller supplied.
+
+#[test]
+it_adopts_the_copy_that_got_there_first_instead_of_deleting_it() {
+    _tc_setup
+    _tc_remote 0.4.0
+    # A directory already in place, carrying a mark this test can recognise.
+    # A fetch that deletes and replaces loses the mark; one that adopts what is
+    # there keeps it, and both answers are the same version, which is the whole
+    # reason adopting is allowed.
+    mkdir -p "$NUTSHELL_TOOLCHAINS/0.4.0"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$NUTSHELL_TOOLCHAINS/0.4.0/init"
+    printf 'in use\n' > "$NUTSHELL_TOOLCHAINS/0.4.0/marker"
+    assert_ok _nutshell_fetch 0.4.0 >/dev/null 2>&1
+    assert_ok test -f "$NUTSHELL_TOOLCHAINS/0.4.0/marker"
+    _tc_end
+}
+
+#[test]
+it_clears_the_scratch_copy_a_lost_race_left_inside_the_target() {
+    _tc_setup
+    local dir="$NUTSHELL_TOOLCHAINS/0.4.0" tmp="$NUTSHELL_TOOLCHAINS/0.4.0.fetching.99"
+    mkdir -p "$dir"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$dir/init"
+    printf 'in use\n' > "$dir/marker"
+    mkdir -p "$tmp"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$tmp/init"
+
+    # The state a loser actually reaches. The existence check and the rename
+    # are two steps, so a directory that appeared between them turns the
+    # rename into a move *inside* it, and `<dir>/<scratch>` is what that
+    # leaves. Both the target and the store have to come out of this clean.
+    assert_ok _nutshell_adopt "$tmp" "$dir"
+    assert_ok test -f "$dir/marker"
+    assert_fails test -e "$tmp"
+    assert_fails test -e "$dir/0.4.0.fetching.99"
+    _tc_end
+}
+
+#[test]
+it_renames_the_scratch_copy_into_place_when_nothing_is_there() {
+    _tc_setup
+    local dir="$NUTSHELL_TOOLCHAINS/0.4.0" tmp="$NUTSHELL_TOOLCHAINS/0.4.0.fetching.99"
+    mkdir -p "$tmp"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$tmp/init"
+    printf 'fetched\n' > "$tmp/marker"
+
+    # The winner's path, and the negative control for the one above: the copy
+    # that arrives first is the one kept, not thrown away.
+    assert_ok _nutshell_adopt "$tmp" "$dir"
+    assert_ok test -f "$dir/marker"
+    assert_fails test -e "$tmp"
+    _tc_end
+}
+
+#[test]
+it_refuses_a_version_name_that_would_escape_the_store() {
+    _tc_setup
+    local outside="$TCROOT/outside"
+    mkdir -p "$outside"
+    printf 'here\n' > "$outside/keep"
+    # The name reaches `rm -rf "${store}/${want}"` in the old shape. It has to
+    # be refused before a path is built out of it, not after.
+    assert_fails _nutshell_fetch "../outside" 2>/dev/null
+    assert_ok test -f "$outside/keep"
+    _tc_end
+}
+
+#[test]
+it_refuses_a_version_name_carrying_a_slash() {
+    _tc_setup
+    assert_fails _nutshell_fetch "0.4.0/../../etc" 2>/dev/null
+    assert_fails _nutshell_fetch "" 2>/dev/null
+    _tc_end
+}
+
+# --- a fetch that cannot succeed is not repeated on every invocation ----------
+#
+# The standing case, not a corner: a tool pinned at a version nobody has tagged
+# resolves to vendored in the end and pays a network round trip on the way
+# there, on every run of every tool on the machine.
+
+#[test]
+it_does_not_retry_a_fetch_that_just_failed() {
+    _tc_setup
+    export NUTSHELL_REMOTE="$TCROOT/no-such-remote.git"
+    local root="$TCROOT/project"
+    mkdir -p "$root/lib/nutshell"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$root/lib/nutshell/init"
+
+    assert_ok nutshell_find "$root" 0.9.9 2>/dev/null
+    assert_eq "$NUTSHELL_FROM" "vendored"
+    # The second run says nothing, because it does not go looking again.
+    local second; second="$(nutshell_find "$root" 0.9.9 2>&1 >/dev/null)"
+    assert_fails grep -q 'could not fetch' <<<"$second"
+    _tc_end
+}
+
+#[test]
+it_tries_again_once_the_window_is_out() {
+    _tc_setup
+    export NUTSHELL_REMOTE="$TCROOT/no-such-remote.git"
+    NUTSHELL_FETCH_RETRY=0 assert_fails _nutshell_fetch 0.9.9 2>/dev/null
+    # A zero window is no window: the negative cache must not be a way to
+    # never fetch again.
+    assert_fails NUTSHELL_FETCH_RETRY=0 _nutshell_fetch_failed_recently 0.9.9
+    assert_ok _nutshell_fetch_failed_recently 0.9.9
+    _tc_end
+}
+
+#[test]
+it_remembers_nothing_about_a_fetch_that_worked() {
+    _tc_setup
+    _tc_remote 0.4.0
+    assert_ok _nutshell_fetch 0.4.0 >/dev/null 2>&1
+    assert_fails _nutshell_fetch_failed_recently 0.4.0
+    _tc_end
+}
+
+# --- the store is release-only, and says so -----------------------------------
+#
+# `_nutshell_num` trims a version field at the first non-digit, and the comment
+# on it used to say that made `0.4.0-rc1` sort beside `0.4.0`. It cannot arrive
+# to be sorted. These are the two gates that stop it.
+
+#[test]
+it_skips_a_directory_whose_name_is_not_the_version_inside_it() {
+    _tc_setup
+    # The interpreter reports `0.4.0`; the directory claims a prerelease. The
+    # name is what the resolver looks up by, so a directory that disagrees with
+    # itself would be handed out for a request it does not satisfy.
+    _tc_store 0.4.0 "0.4.0-rc1"
+    assert_empty "$(nutshell_toolchains)"
+    _tc_end
+}
+
+#[test]
+it_refuses_to_store_a_fetch_whose_version_is_not_the_name_asked_for() {
+    _tc_setup
+    _tc_remote 0.4.0
+    # A tag spelled as a prerelease, holding an interpreter that reports the
+    # plain version. There is nowhere in the store for it to go.
+    local work="$TCROOT/work-0.4.0"
+    git -C "$work" tag -a "0.4.0-rc1" -m rc
+    git -C "$work" push -q origin "0.4.0-rc1"
+    assert_fails _nutshell_fetch "0.4.0-rc1" 2>/dev/null
+    assert_fails test -e "$NUTSHELL_TOOLCHAINS/0.4.0-rc1"
+    _tc_end
+}

--- a/tools/assoc-array-report
+++ b/tools/assoc-array-report
@@ -235,6 +235,110 @@ arm_memfs_table() {
     printf '%s' "$last"
 }
 
+# G: slots addressed by arithmetic, with the caller holding the index.
+#
+#    The table is `_g0.._gN`, and a lookup is one `eval` on a name built from a
+#    number. No per-character encoding anywhere, because nothing has to turn a
+#    key into a name: whatever resolved the key once handed back the index and
+#    the caller kept it.
+#
+#    This is the ceiling for the technique, and it is not a map. It is what a
+#    map becomes once the key lookup has already happened, so it says what the
+#    key lookup is actually costing in every other arm.
+arm_slots_by_index() {
+    local i last=""
+    for (( i = 0; i < ENTRIES; i++ )); do eval "_g${i}=\${VALS[\$i]}"; done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        eval "last=\${_g$(( i * ENTRIES / LOOKUPS )):-}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        eval "last=\${_g$(( ENTRIES + i )):-MISS}"
+    done
+    printf '%s' "$last"
+}
+
+# G2: the same slots, several fields per entry, addressed by stride.
+#
+#     `_h$(( i * 3 + f ))` is a record of three fields. Whether striding costs
+#     anything over one field is the question; the arithmetic is native and the
+#     name is still just a number.
+arm_slots_by_stride() {
+    local i last="" base
+    for (( i = 0; i < ENTRIES; i++ )); do
+        base=$(( i * 3 ))
+        eval "_h${base}=\${KEYS[\$i]}"
+        eval "_h$(( base + 1 ))=\${VALS[\$i]}"
+        eval "_h$(( base + 2 ))=\$i"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        base=$(( (i * ENTRIES / LOOKUPS) * 3 ))
+        eval "last=\${_h$(( base + 1 )):-}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        base=$(( (ENTRIES + i) * 3 ))
+        eval "last=\${_h$(( base + 1 )):-MISS}"
+    done
+    printf '%s' "$last"
+}
+
+# H: a hash table built by hand over those slots.
+#
+#    The honest version of "index it yourself": hash the key with shell
+#    arithmetic, probe linearly on collision, store key and value side by side
+#    so a probe can tell a hit from a neighbour. This is what it costs to keep
+#    string keys without the shell's own symbol table doing the work.
+#
+#    The hash is over every character, which is where the cost goes, and that
+#    is the point of measuring it: the shell's symbol table hashes in C.
+_hash_into() {
+    local __s="${2:-}" __n __i __h=5381 __c
+    __n=${#__s}
+    for (( __i = 0; __i < __n; __i++ )); do
+        printf -v __c '%d' "'${__s:__i:1}"
+        __h=$(( (__h * 33 + __c) & 0x7fffffff ))
+    done
+    printf -v "$1" '%d' "$(( __h % BUCKETS ))"
+}
+
+arm_hand_rolled_hash() {
+    local BUCKETS=$(( ENTRIES * 2 ))
+    local i last="" h probe k
+    for (( i = 0; i < ENTRIES; i++ )); do
+        _hash_into h "${KEYS[$i]}"
+        probe=$h
+        while :; do
+            eval "k=\${_kk${probe}+set}"
+            [[ -z "$k" ]] && break
+            probe=$(( (probe + 1) % BUCKETS ))
+        done
+        eval "_kk${probe}=\${KEYS[\$i]}"
+        eval "_vv${probe}=\${VALS[\$i]}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        local want="${KEYS[$(( i * ENTRIES / LOOKUPS ))]}"
+        _hash_into h "$want"
+        probe=$h; last="MISS"
+        while :; do
+            eval "k=\${_kk${probe}-}"
+            [[ -z "$k" ]] && break
+            if [[ "$k" == "$want" ]]; then eval "last=\${_vv${probe}}"; break; fi
+            probe=$(( (probe + 1) % BUCKETS ))
+        done
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        local want="no/such-key.sh:$i"
+        _hash_into h "$want"
+        probe=$h; last="MISS"
+        while :; do
+            eval "k=\${_kk${probe}-}"
+            [[ -z "$k" ]] && break
+            if [[ "$k" == "$want" ]]; then eval "last=\${_vv${probe}}"; break; fi
+            probe=$(( (probe + 1) % BUCKETS ))
+        done
+    done
+    printf '%s' "$last"
+}
+
 # -----------------------------------------------------------------------------
 # Running them
 # -----------------------------------------------------------------------------
@@ -259,16 +363,20 @@ main() {
     printf '  host      %s %s\n\n' "$(uname -s)" "$(uname -m)"
 
     local -a names=(arm_bash_assoc arm_eval_names arm_eval_names_nofork
-                    arm_one_string arm_one_file arm_dir_table arm_memfs_table)
+                    arm_one_string arm_one_file arm_dir_table arm_memfs_table
+                    arm_slots_by_index arm_slots_by_stride arm_hand_rolled_hash)
     local -a labels=("bash declare -A" "eval names, encoded via subshell"
                      "eval names, encoded in place" "one string, scanned"
                      "one file, read in shell" "one file per key"
-                     "one file per key, in memory")
+                     "one file per key, in memory"
+                     "slots by index, caller holds it"
+                     "slots by stride, three fields"
+                     "hash table rolled by hand")
     # Above these sizes an arm takes long enough that running it stops being
     # worth the wait. Stated per arm rather than hidden, because which arms
     # have a ceiling at all is itself the result: the two that address a key
     # directly have none.
-    local -a ceiling=(0 4000 0 800 4000 0 0)
+    local -a ceiling=(0 4000 0 800 4000 0 0 0 0 4000)
     local -a took=()
     local i t base=""
 

--- a/tools/assoc-array-report
+++ b/tools/assoc-array-report
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/tools/assoc-array-report - What a map costs without bash arrays
+# =============================================================================
+#
+# POSIX sh has no associative arrays. nutshell uses them in the places that
+# decide how fast it is: the config cache, the toolchain store tables, the
+# attribute tables, and the file-line table the QA checks read. So "make
+# nutshell POSIX" has a price, and the price is a number rather than an
+# opinion. This is the number.
+#
+# **A report, not a gate.** There is no threshold anybody can justify here; the
+# decision it feeds is a design one.
+#
+# **This is not a bench.** nutshell has no bench harness, so this is an ad-hoc
+# measurement and is called that. It does what it can without one: every arm is
+# a real alternative somebody would actually reach for, the arms run on the
+# same generated input, the input is shaped like nutshell's own keys, and the
+# controls below refuse to print numbers the instrument cannot support.
+#
+# The size defaults to the largest real table: `_PAD_LINES` in the docs check
+# holds one entry per line of source, which on this library is 9606 across 24
+# files. The keys are the real shape too, `<path>:<n>`, because two of the arms
+# cannot take a key with a slash or a colon in it and the encoding that fixes
+# that is part of what they cost.
+#
+# Usage:
+#   tools/assoc-array-report [entries] [lookups]
+# =============================================================================
+
+set -uo pipefail
+
+ENTRIES="${1:-2000}"
+LOOKUPS="${2:-500}"
+REAL_TABLE=9606
+
+# -----------------------------------------------------------------------------
+# The input, shaped like nutshell's own keys
+# -----------------------------------------------------------------------------
+
+declare -a KEYS=() VALS=()
+_generate() {
+    local i
+    for (( i = 0; i < ENTRIES; i++ )); do
+        # `<path>:<n>`, which is what `_PAD_LINES` and `_PAD_AT` are keyed by.
+        # Slash, dot, dash and colon all appear, and none of them may go into a
+        # variable name unencoded.
+        KEYS+=("lib/some-module.sh:$i")
+        VALS+=("value number $i")
+    done
+}
+
+# A key as a variable name. Every arm that builds a name out of a key pays this.
+_encode() {
+    local k="$1" out="" i c
+    for (( i = 0; i < ${#k}; i++ )); do
+        c="${k:i:1}"
+        case "$c" in
+            [A-Za-z0-9_]) out+="$c" ;;
+            *) printf -v c '_%02x' "'$c"; out+="$c" ;;
+        esac
+    done
+    printf '%s' "$out"
+}
+
+# -----------------------------------------------------------------------------
+# The arms. Each builds a table of ENTRIES pairs, then does LOOKUPS hits and
+# LOOKUPS misses, and prints the value it last found so nothing can be
+# optimised away by not being used.
+# -----------------------------------------------------------------------------
+
+# A: bash associative array. The thing being given up.
+arm_bash_assoc() {
+    declare -A m=()
+    local i last=""
+    for (( i = 0; i < ENTRIES; i++ )); do m["${KEYS[$i]}"]="${VALS[$i]}"; done
+    for (( i = 0; i < LOOKUPS; i++ )); do last="${m["${KEYS[$(( i * ENTRIES / LOOKUPS ))]}"]:-}"; done
+    for (( i = 0; i < LOOKUPS; i++ )); do last="${m["no/such-key.sh:$i"]:-MISS}"; done
+    printf '%s' "$last"
+}
+
+# B: variable names built out of the key, read and written through `eval`.
+#    The classic POSIX substitute, and the one that needs the encoding.
+arm_eval_names() {
+    local i last="" n
+    for (( i = 0; i < ENTRIES; i++ )); do
+        n="$(_encode "${KEYS[$i]}")"
+        eval "_aa_${n}=\${VALS[\$i]}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        n="$(_encode "${KEYS[$(( i * ENTRIES / LOOKUPS ))]}")"
+        eval "last=\${_aa_${n}:-}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        n="$(_encode "no/such-key.sh:$i")"
+        eval "last=\${_aa_${n}:-MISS}"
+    done
+    printf '%s' "$last"
+}
+
+# B2: the same, without a fork for the encoding. `_encode` above is called
+#     through a command substitution, which is what a caller writes first and
+#     is a fork per operation. This is the same arm with the encoding done in
+#     place, and the gap between the two is the cost of that habit rather than
+#     of the technique.
+arm_eval_names_nofork() {
+    local i last="" n
+    for (( i = 0; i < ENTRIES; i++ )); do
+        printf -v n '%s' "${KEYS[$i]//[^A-Za-z0-9_]/_}"
+        eval "_bb_${n}=\${VALS[\$i]}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        printf -v n '%s' "${KEYS[$(( i * ENTRIES / LOOKUPS ))]//[^A-Za-z0-9_]/_}"
+        eval "last=\${_bb_${n}:-}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        printf -v n '%s' "no/such-key.sh:${i}"
+        n="${n//[^A-Za-z0-9_]/_}"
+        eval "last=\${_bb_${n}:-MISS}"
+    done
+    printf '%s' "$last"
+}
+
+# C: one string holding every pair, scanned with parameter expansion.
+#    No forks and no files, and quadratic the moment the table is large.
+arm_one_string() {
+    local map=$'\n' i last="" rest
+    for (( i = 0; i < ENTRIES; i++ )); do map+="${KEYS[$i]}=${VALS[$i]}"$'\n'; done
+    # A miss has to be a miss. `${map#*pat}` returns the whole string unchanged
+    # when the pattern is absent, so without the membership test below this arm
+    # answered a real value for a key that was not there. The correctness
+    # control caught it on the first run, which is the reason that control is
+    # there and ahead of the timing.
+    local pat
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        pat=$'\n'"${KEYS[$(( i * ENTRIES / LOOKUPS ))]}"=
+        if [[ "$map" == *"$pat"* ]]; then
+            rest="${map#*"$pat"}"; last="${rest%%$'\n'*}"
+        else
+            last="MISS"
+        fi
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        pat=$'\n'"no/such-key.sh:${i}="
+        if [[ "$map" == *"$pat"* ]]; then
+            rest="${map#*"$pat"}"; last="${rest%%$'\n'*}"
+        else
+            last="MISS"
+        fi
+    done
+    printf '%s' "$last"
+}
+
+# D: one file, a line per pair, read back in the shell.
+arm_one_file() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/aa.XXXXXX")"
+    local f="$d/map" i last="" k v want
+    for (( i = 0; i < ENTRIES; i++ )); do printf '%s\t%s\n' "${KEYS[$i]}" "${VALS[$i]}"; done > "$f"
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        want="${KEYS[$(( i * ENTRIES / LOOKUPS ))]}"
+        last=""
+        while IFS=$'\t' read -r k v; do [[ "$k" == "$want" ]] && { last="$v"; break; }; done < "$f"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        want="no/such-key.sh:$i"; last="MISS"
+        while IFS=$'\t' read -r k v; do [[ "$k" == "$want" ]] && { last="$v"; break; }; done < "$f"
+    done
+    rm -rf "$d"
+    printf '%s' "$last"
+}
+
+# E: the filesystem as the table, one file per key. The lookup is a read of a
+#    known path rather than a search, which is the only arm here whose lookup
+#    does not get slower as the table grows.
+arm_dir_table() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/aa.XXXXXX")"
+    local i last="" n
+    for (( i = 0; i < ENTRIES; i++ )); do
+        n="${KEYS[$i]//[^A-Za-z0-9_]/_}"
+        printf '%s' "${VALS[$i]}" > "$d/$n"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        n="${KEYS[$(( i * ENTRIES / LOOKUPS ))]//[^A-Za-z0-9_]/_}"
+        last=""; [[ -r "$d/$n" ]] && read -r last < "$d/$n"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        n="no/such-key.sh:${i}"; n="${n//[^A-Za-z0-9_]/_}"
+        last="MISS"; [[ -r "$d/$n" ]] && read -r last < "$d/$n"
+    done
+    rm -rf "$d"
+    printf '%s' "$last"
+}
+
+# A memory filesystem, if this machine has one.
+#
+# Not POSIX. The standard says nothing about where a path's bytes live, and
+# that is the only syscall lever a shell really has: `dd bs=` shapes a transfer
+# and nothing shapes an allocation. Linux has `/dev/shm` and usually a tmpfs
+# `/tmp`; macOS has neither, so this arm reports itself skipped there rather
+# than quietly measuring a disk and calling it memory.
+_memfs() {
+    local d
+    for d in /dev/shm /run/shm; do
+        [[ -d "$d" && -w "$d" ]] && { printf '%s' "$d"; return 0; }
+    done
+    # A tmpfs `/tmp`, where the platform can be asked.
+    if command -v findmnt >/dev/null 2>&1; then
+        case "$(findmnt -no FSTYPE --target /tmp 2>/dev/null)" in
+            tmpfs|ramfs) printf '/tmp'; return 0 ;;
+        esac
+    fi
+    return 1
+}
+
+# F: the same table as E, on a memory filesystem. The gap between the two is
+#    what the disk was costing, which is the part of a syscall a shell can
+#    actually do something about.
+arm_memfs_table() {
+    local root; root="$(_memfs)" || { printf 'SKIP'; return 0; }
+    local d; d="$(mktemp -d "${root}/aa.XXXXXX")"
+    local i last="" n
+    for (( i = 0; i < ENTRIES; i++ )); do
+        n="${KEYS[$i]//[^A-Za-z0-9_]/_}"
+        printf '%s' "${VALS[$i]}" > "$d/$n"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        n="${KEYS[$(( i * ENTRIES / LOOKUPS ))]//[^A-Za-z0-9_]/_}"
+        last=""; [[ -r "$d/$n" ]] && read -r last < "$d/$n"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        n="no/such-key.sh:${i}"; n="${n//[^A-Za-z0-9_]/_}"
+        last="MISS"; [[ -r "$d/$n" ]] && read -r last < "$d/$n"
+    done
+    rm -rf "$d"
+    printf '%s' "$last"
+}
+
+# -----------------------------------------------------------------------------
+# Running them
+# -----------------------------------------------------------------------------
+
+_ms() {
+    local fn="$1" start end out
+    start="$(date +%s%N 2>/dev/null)" || return 1
+    out="$("$fn")"
+    end="$(date +%s%N 2>/dev/null)" || return 1
+    _LAST_OUT="$out"
+    printf '%s' "$(( (end - start) / 1000000 ))"
+}
+
+main() {
+    _generate
+
+    printf 'What a map costs without bash associative arrays\n\n'
+    printf '  entries   %s\n' "$ENTRIES"
+    printf '  lookups   %s hits and %s misses\n' "$LOOKUPS" "$LOOKUPS"
+    printf '  keys      the real shape, <path>:<n>\n'
+    printf '  bash      %s\n' "${BASH_VERSION:-unknown}"
+    printf '  host      %s %s\n\n' "$(uname -s)" "$(uname -m)"
+
+    local -a names=(arm_bash_assoc arm_eval_names arm_eval_names_nofork
+                    arm_one_string arm_one_file arm_dir_table arm_memfs_table)
+    local -a labels=("bash declare -A" "eval names, encoded via subshell"
+                     "eval names, encoded in place" "one string, scanned"
+                     "one file, read in shell" "one file per key"
+                     "one file per key, in memory")
+    # Above these sizes an arm takes long enough that running it stops being
+    # worth the wait. Stated per arm rather than hidden, because which arms
+    # have a ceiling at all is itself the result: the two that address a key
+    # directly have none.
+    local -a ceiling=(0 4000 0 800 4000 0 0)
+    local -a took=()
+    local i t base=""
+
+    for (( i = 0; i < ${#names[@]}; i++ )); do
+        if (( ceiling[i] > 0 && ENTRIES > ceiling[i] )); then
+            took+=("-")
+            continue
+        fi
+        t="$(_ms "${names[$i]}")" || { printf 'no nanosecond clock here; cannot measure\n' >&2; return 1; }
+        took+=("$t")
+        [[ -z "$base" ]] && base="$t"
+    done
+
+    # The control that matters most: every arm has to give the same answers.
+    # Comparing a fast wrong one against a slow right one is not a comparison,
+    # and an arm whose encoding collides two keys would look excellent.
+    local want="" got=""
+    for (( i = 0; i < ${#names[@]}; i++ )); do
+        [[ "${took[$i]}" == "-" ]] && continue
+        got="$("${names[$i]}")"
+        [[ "$got" == "SKIP" ]] && continue
+        if [[ -z "$want" ]]; then want="$got"; continue; fi
+        if [[ "$got" != "$want" ]]; then
+            printf 'arms disagree: %s answered %q where the first answered %q\n' \
+                "${labels[$i]}" "$got" "$want" >&2
+            return 1
+        fi
+    done
+
+    # And that the input is distinct enough to be worth answering. An encoding
+    # that maps two real keys onto one name would pass the check above while
+    # holding half the table.
+    local -A seen=(); local n
+    for (( i = 0; i < ENTRIES; i++ )); do
+        n="${KEYS[$i]//[^A-Za-z0-9_]/_}"
+        seen["$n"]=1
+    done
+    if (( ${#seen[@]} != ENTRIES )); then
+        printf 'the name encoding collides: %s keys became %s names\n' \
+            "$ENTRIES" "${#seen[@]}" >&2
+        return 1
+    fi
+
+    # The second control. Every arm answers the same question on the same
+    # input, so if they all take the same time the instrument is measuring
+    # something other than the arms and the numbers below mean nothing.
+    local spread=0
+    for (( i = 1; i < ${#took[@]}; i++ )); do
+        [[ "${took[$i]}" == "-" ]] && continue
+        (( took[i] != took[0] )) && spread=1
+    done
+    if (( spread == 0 )); then
+        printf 'every arm took the same time, so this is not measuring the arms\n' >&2
+        return 1
+    fi
+
+    printf '  %-34s %9s  %s\n' "arm" "ms" "against bash"
+    for (( i = 0; i < ${#names[@]}; i++ )); do
+        local rel="-"
+        if [[ "${took[$i]}" == "-" ]]; then
+            printf '  %-34s %9s  %s\n' "${labels[$i]}" "-" "not run at this size"
+            continue
+        fi
+        if [[ "$("${names[$i]}")" == "SKIP" ]]; then
+            printf '  %-34s %9s  %s\n' "${labels[$i]}" "-" "no memory filesystem here"
+            continue
+        fi
+        (( base > 0 )) && rel="$(( took[i] * 100 / base ))%"
+        printf '  %-34s %9s  %s\n' "${labels[$i]}" "${took[$i]}" "$rel"
+    done
+
+    printf '\n'
+    printf 'The real table this stands in for is %s entries, and the arms that\n' "$REAL_TABLE"
+    printf 'search rather than address grow with it. Run with a larger first\n'
+    printf 'argument to see that; the default is small enough to finish.\n'
+}
+
+main "$@"


### PR DESCRIPTION
The interpreter was the one dep that never got fetched. It resolved by picking
whatever the machine happened to have, so a tool wanting a version nobody had
installed fell through to the vendored copy and complained about it on every
single run. Externs were already central and content addressed. Now the
interpreter is one of them instead of its own special case.

- a toolchain store keyed by version. `nutshell_toolchains` lists newest first
  and the newest one that satisfies the caller wins
- a version that isn't there gets cloned at its tag into the store, through a
  scratch dir so an interrupted clone leaves nothing behind, and gets refused
  if what shows up reports a different version than the tag promised
- externs and toolchains under one root, and that root moved out of the cache
  dir into the data dir. A cache is something a cleaner can nuke whenever it
  feels like it, and this is where every project's deps live. Clearing it
  offline breaks all of them at once
- `NUTSHELL_STORE` names the root, `NUTSHELL_TOOLCHAINS` the toolchain dir,
  `NUTSHELL_REMOTE` where a fetch goes

An installed one still wins when it satisfies. One shared nutshell everything
uses is the good state, the store is for tools that can't use it, and vendored
is the last resort now instead of the second, for a machine with no network.

A pin can name a branch too, which means that branch's head, asked at most once
an hour.

## The store is shared so stop deleting out of it

Every project on the machine resolves out of one store and nothing locks it. So
a fetch doesn't wipe a directory before dropping its own copy in anymore. That
was deleting trees other people are actively sourcing from.

A version dir is named for the version inside it, so two copies hold the same
thing. First one there wins, loser throws its own away. A branch checkout has
no such luck, so it went under `branches/<ref>/<revision>`, written once and
never replaced, with `.head` saying which one the branch resolved to last. Which
is also what the pin design in `docs/TODO.md` wants, where a branch has already
become the rev it pointed at before anything gets looked up. Old revs go when
they're a day old, not the moment they stop being the head.

A ref or version that would escape the store gets refused before a path is
built out of it. Not after.

## Stop retrying a fetch that can't work

Pinning a version nobody tagged is the normal standing state around here, and
it was costing a network round trip and two lines of stderr on every run of
every tool before falling through to vendored anyway. Now the failure is
remembered for the same hour a branch head is.

## The store is release-only and now admits it

Version fields compare as numbers so `0.10.0` sorts above `0.9.0`, and a field
with a suffix doesn't blow up the listing with an arithmetic error.

It also doesn't order prereleases, and the comment claiming `0.4.0-rc1` sorts
next to `0.4.0` was describing something that can't happen. A dir whose name
isn't what the interpreter inside reports gets skipped, and a fetch whose
contents disagree with the name asked for gets refused. So a prerelease can
never become a dir in the store to begin with. Both gates have tests now.

Store still isn't shareable between users on one machine, it's per user. Nothing
needs it yet and the permissions question is real enough that guessing would be
worse than leaving it.

## Sanity

`./test` is 438.

`tests/toolchain_test.sh` is 35: store location and its three overrides,
ordering by number not spelling, a dir whose contents disagree with its name,
preferring installed and falling to the store when that's too old, store over
vendored, a real fetch against a local bare repo, a fetch refused because the
tag reports another version, a failed fetch leaving nothing, falling to vendored
when no fetch can happen, adopting a copy that got there first, clearing the
scratch copy a lost race leaves inside the target, both escaping names, and the
negative fetch cache with a zero window as its control.

`tests/branch_test.sh` is 15 and it's new. Branch pinning had zero tests before
this, which is a bit embarrassing given it's the thing hulilupteri actually
uses. What it resolves to, keyed by revision, the window, following the branch
when it moves, leaving the old rev alone while it does, the offline fallback
naming the rev it ran from, and the pruning with a keep-it control.

`tests/find_test.sh` was leaving 26 dirs in `$TMPDIR` per run. Measured it, then
fixed it, now it's zero and three tests hold that. There are a few hundred of
those still sitting on my machine from before, whatever.

One test in `tests/extern_test.sh` asserted a derived path wasn't under `.cache`
while `NUTSHELL_STORE` pointed at a scratch dir, so the derivation it named
never even ran. Now it runs with nothing overriding it, and compares against
what the platform actually calls its cache instead of matching `/.cache/`, which
macOS never says.