### PR TITLE
feat: add the half of the elevation api that steps back down

### DIFF
--- a/lib/priv.sh
+++ b/lib/priv.sh
@@ -111,6 +111,22 @@ priv_uid()  { _priv_learn_user; printf '%s' "$PRIV_UID"; }
 # Usage: priv_user_home -> a path
 priv_user_home() { _priv_learn_user; printf '%s' "$PRIV_HOME"; }
 
+# One argument, quoted so any POSIX shell reads it back as itself.
+#
+# Not `printf %q`. That emits bash's ANSI-C form for anything holding a tab, a
+# newline or a control character, and `$'...'` is a bashism: dash, which is
+# `/bin/sh` on Debian and Ubuntu, reads `$'\t'` as the four characters and the
+# path arrives silently wrong. This function's whole job is writing a person's
+# files as that person, so a mangled path is root writing somewhere nobody
+# asked it to.
+#
+# Single quotes take everything literally, so the only character needing work
+# is the single quote itself: close, escape it outside the quotes, reopen.
+_priv_sq() {
+    local s="${1:-}"
+    printf "'%s'" "${s//\'/\'\\\'\'}"
+}
+
 #[pub]
 # Run one step as the person, from inside something that elevated.
 #
@@ -149,8 +165,11 @@ priv_as_user() {
             # back into one string. Every other route avoids that.
             su)
                 local q="" a
-                for a in "$@"; do q+="${q:+ }$(printf '%q' "$a")"; done
-                su -s /bin/sh "$u" -c "$q"
+                for a in "$@"; do q+="${q:+ }$(_priv_sq "$a")"; done
+                # No `-s`. That flag is util-linux; BSD and macOS `su` is
+                # `su [-] [-flm] [login [args]]` and refuses it, and this is
+                # the branch a busybox rescue console actually takes.
+                su "$u" -c "$q"
                 return $?
                 ;;
         esac

--- a/lib/priv.sh
+++ b/lib/priv.sh
@@ -112,6 +112,55 @@ priv_uid()  { _priv_learn_user; printf '%s' "$PRIV_UID"; }
 priv_user_home() { _priv_learn_user; printf '%s' "$PRIV_HOME"; }
 
 #[pub]
+# Run one step as the person, from inside something that elevated.
+#
+# The other direction from `priv_run`, and the half that stops root's
+# fingerprints ending up on a person's files. `priv_return` repairs ownership
+# after the fact; this never creates the problem. Prefer it: a chown pass has
+# to be told every path, and the one it was not told about is the one nobody
+# notices.
+#
+# The cases that need it are the ones where the tool is root because some other
+# step needed root, and this step does not: git in somebody's checkout, a file
+# written into their home, anything reading their configuration.
+#
+# A no-op when not root, and a no-op when the person is root, so a caller does
+# not have to ask which it is.
+# Usage: priv_as_user "reading your checkout" git -C "$d" status
+priv_as_user() {
+    local what="${1:-a step}"; shift || true
+    (( $# > 0 )) || { log_error "priv_as_user: nothing to run"; return 2; }
+
+    local u; u="$(priv_user)"
+    if ! priv_is_root || [[ -z "$u" || "$u" == "root" ]]; then
+        "$@"
+        return $?
+    fi
+
+    local c
+    for c in runuser sudo su; do
+        command -v "$c" >/dev/null 2>&1 || continue
+        case "$c" in
+            # runuser is the one built for this: root to another user, no
+            # password, no login shell in the way.
+            runuser) runuser -u "$u" -- "$@"; return $? ;;
+            sudo)    sudo -n -u "$u" -- "$@"; return $? ;;
+            # Last, and through a shell, so the arguments have to be quoted
+            # back into one string. Every other route avoids that.
+            su)
+                local q="" a
+                for a in "$@"; do q+="${q:+ }$(printf '%q' "$a")"; done
+                su -s /bin/sh "$u" -c "$q"
+                return $?
+                ;;
+        esac
+    done
+
+    log_error "${what}: cannot step down to ${u}; there is no runuser, sudo or su"
+    return 2
+}
+
+#[pub]
 # Is this already root?
 # Usage: priv_is_root
 priv_is_root() { [[ "$(id -u 2>/dev/null)" == "0" ]]; }

--- a/tests/priv_test.sh
+++ b/tests/priv_test.sh
@@ -405,6 +405,39 @@ it_keeps_the_arguments_apart_through_runuser() {
 }
 
 #[test]
+it_quotes_every_metacharacter_so_any_posix_shell_reads_it_back() {
+    # `printf %q` was doing this, and it emits bash's `$'...'` for a tab, a
+    # newline or a control character. `dash` is `/bin/sh` on Debian and Ubuntu
+    # and reads that as the four characters it is written with, so the path
+    # arrived silently wrong. This function writes a person's files as that
+    # person; a mangled path is root writing somewhere nobody asked it to.
+    #
+    # The round trip is through `sh`, and asserts the argument comes back as
+    # itself rather than pinning a spelling.
+    #
+    # It cannot catch the bash-only form on a machine whose `sh` is bash, which
+    # macOS is, so it passes there either way. The case below it is the one
+    # that holds everywhere; this one is what says the replacement is correct.
+    local sh; sh="$(command -v sh)"
+    local t q back
+    for t in "plain" "/home/some body" "$(printf 'a\tb')" "it's" 'a$b' 'a*b' \
+             'a"b' 'a\b' 'a;b' 'a|b' 'a`b`' 'a&b' 'a
+b' "" "-x"; do
+        q="$(_priv_sq "$t")"
+        back="$("$sh" -c "printf %s $q")"
+        assert_eq "$back" "$t"
+    done
+}
+
+#[test]
+it_does_not_reach_for_the_bash_only_quoting_form() {
+    # The specific thing that was wrong, stated as its own case so a later
+    # change back to `printf %q` fails here rather than on somebody's Debian.
+    local q; q="$(_priv_sq "$(printf 'a\tb')")"
+    assert_fails grep -q "\$'" <<<"$q"
+}
+
+#[test]
 it_keeps_the_arguments_apart_through_su_which_goes_via_a_shell() {
     _priv_as_root
     _priv_stubs su
@@ -445,4 +478,16 @@ it_says_so_when_there_is_no_way_to_step_down_at_all() {
     priv_as_user "reading" true 2>/dev/null || rc=$?
     _priv_stubs_end; _priv_as_root_end
     assert_ne "$rc" "0"
+}
+
+#[test]
+it_does_not_pass_su_a_flag_only_one_su_has() {
+    _priv_as_root
+    _priv_stubs su
+    local out; out="$(priv_as_user "reading" true)"
+    _priv_stubs_end; _priv_as_root_end
+    # `-s` is util-linux. BSD and macOS `su` is `su [-] [-flm] [login [args]]`
+    # and refuses it, and this is the branch a busybox rescue console takes.
+    assert_fails grep -qx -- "-s" <<<"$out"
+    assert_contains "$out" "somebody"
 }

--- a/tests/priv_test.sh
+++ b/tests/priv_test.sh
@@ -271,3 +271,178 @@ it_ignores_a_path_that_is_not_there() {
     unset -f priv_is_root priv_user chown
     assert_eq "$called" "0"
 }
+
+# --- stepping back down --------------------------------------------------------
+#
+# The other direction, and the one with no way to test it for real without a
+# second account. What it does have is a choice between three commands and
+# three different ways of handing arguments to them, which is where it can be
+# wrong, so the three are stubbed and asked what they were given.
+
+# A directory holding stubs for the step-down commands, first on PATH. Each one
+# records that it ran and repeats its arguments one per line, so a test can see
+# both which command was picked and what survived the trip.
+_priv_stubs() {
+    _PRIV_STUB_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-priv.XXXXXX")"
+    # Absolute paths, found while PATH is still whole. Once PATH is only the
+    # stub directory, `env bash` cannot resolve bash and a test cannot reach
+    # `chmod` to write a stub of its own.
+    _PRIV_STUB_BASH="$(command -v bash)"
+    _PRIV_STUB_SH="$(command -v sh)"
+    _PRIV_STUB_CHMOD="$(command -v chmod)"
+    local c
+    for c in "$@"; do
+        _priv_stub_put "$c" "printf '%s\n' \"$c\"" 'printf '"'"'%s\n'"'"' "$@"'
+    done
+    _PRIV_PATH_KEEP="$PATH"
+    # The stub directory and nothing else. Prepending is not enough: a machine
+    # with a real `sudo` on it picks that one whenever the stub set leaves it
+    # out, so the two tests about falling past `sudo` would have been answered
+    # by the host's own sudo failing rather than by the fallback working.
+    export PATH="$_PRIV_STUB_DIR"
+}
+# Write one stub, from lines of bash handed in as arguments. `printf` is a
+# builtin and the interpreter and `chmod` are absolute, so this works with the
+# stub directory as the whole of PATH.
+_priv_stub_put() {
+    local name="$1"; shift
+    local f="$_PRIV_STUB_DIR/$name" line
+    printf '#!%s\n' "$_PRIV_STUB_BASH" > "$f"
+    for line in "$@"; do printf '%s\n' "$line" >> "$f"; done
+    "$_PRIV_STUB_CHMOD" +x "$f"
+}
+
+_priv_stubs_end() {
+    export PATH="${_PRIV_PATH_KEEP:-$PATH}"
+    [[ -n "${_PRIV_STUB_DIR:-}" ]] && rm -rf "$_PRIV_STUB_DIR"
+    unset _PRIV_STUB_DIR _PRIV_PATH_KEEP
+}
+
+# Pretend to be root, with somebody else having started this.
+_priv_as_root() {
+    PRIV_USER="somebody"; PRIV_UID="1234"; PRIV_HOME="/home/somebody"
+    priv_is_root() { return 0; }
+}
+_priv_as_root_end() { unset -f priv_is_root; _priv_reset; }
+
+#[test]
+it_runs_the_step_itself_when_it_is_not_root() {
+    _priv_reset
+    # Nothing to step down from. The step still has to happen, and it has to
+    # happen without any of the three commands being involved.
+    priv_is_root() { return 1; }
+    local out; out="$(priv_as_user "reading" printf 'ran\n')"
+    unset -f priv_is_root
+    assert_eq "$out" "ran"
+}
+
+#[test]
+it_runs_the_step_itself_when_the_person_is_root() {
+    _priv_reset
+    PRIV_USER="root"; PRIV_UID="0"; PRIV_HOME="/root"
+    priv_is_root() { return 0; }
+    # Stepping down to root from root is the same shell with two more
+    # processes in it.
+    _priv_stubs runuser sudo su
+    local out; out="$(priv_as_user "reading" printf 'ran\n')"
+    _priv_stubs_end
+    unset -f priv_is_root; _priv_reset
+    assert_eq "$out" "ran"
+}
+
+#[test]
+it_carries_the_status_of_the_step_back_out() {
+    _priv_reset
+    priv_is_root() { return 1; }
+    assert_fails priv_as_user "failing" false
+    assert_ok priv_as_user "working" true
+    unset -f priv_is_root
+}
+
+#[test]
+it_prefers_runuser_which_is_the_one_built_for_this() {
+    _priv_as_root
+    _priv_stubs runuser sudo su
+    local out; out="$(priv_as_user "reading" git status)"
+    _priv_stubs_end; _priv_as_root_end
+    assert_eq "$(head -1 <<<"$out")" "runuser"
+    assert_contains "$out" "-u"
+    assert_contains "$out" "somebody"
+}
+
+#[test]
+it_falls_to_sudo_when_there_is_no_runuser() {
+    _priv_as_root
+    _priv_stubs sudo su
+    local out; out="$(priv_as_user "reading" git status)"
+    _priv_stubs_end; _priv_as_root_end
+    assert_eq "$(head -1 <<<"$out")" "sudo"
+    # Non-interactive, because there is nobody at the keyboard inside a step
+    # that already elevated, and a prompt there hangs the run.
+    assert_contains "$out" "-n"
+}
+
+#[test]
+it_falls_to_su_last_of_the_three() {
+    _priv_as_root
+    _priv_stubs su
+    local out; out="$(priv_as_user "reading" git status)"
+    _priv_stubs_end; _priv_as_root_end
+    assert_eq "$(head -1 <<<"$out")" "su"
+}
+
+#[test]
+it_keeps_the_arguments_apart_through_runuser() {
+    _priv_as_root
+    _priv_stubs runuser
+    # A path with a space in it is the ordinary case, not a corner: people's
+    # home directories have spaces in them.
+    local out; out="$(priv_as_user "reading" git -C "/home/some body" status)"
+    _priv_stubs_end; _priv_as_root_end
+    assert_contains "$out" "/home/some body"
+    # One line per argument, so a path that was split shows up as two.
+    assert_eq "$(grep -c '^/home/some body$' <<<"$out")" "1"
+}
+
+#[test]
+it_keeps_the_arguments_apart_through_su_which_goes_via_a_shell() {
+    _priv_as_root
+    _priv_stubs su
+    # The one route that has to put the arguments back into a single string,
+    # and therefore the one that can lose them. Asserting the spelling of the
+    # quoting would pin an implementation; what matters is that a shell reading
+    # that string back gets the arguments it started with. So `su` runs its
+    # own payload and a stubbed `git` reports what actually arrived.
+    _priv_stub_put su \
+        'while [[ $# -gt 0 && "$1" != "-c" ]]; do shift; done' \
+        'shift' \
+        "exec ${_PRIV_STUB_SH} -c \"\$1\""
+    _priv_stub_put git 'printf '"'"'%s\n'"'"' "$@"'
+
+    # A path with a space in it is the ordinary case, not a corner: people's
+    # home directories have spaces in them.
+    local out; out="$(priv_as_user "reading" git -C "/home/some body" status)"
+    _priv_stubs_end; _priv_as_root_end
+    # One line per argument, so a path the shell split shows up as two.
+    assert_eq "$(grep -c '^/home/some body$' <<<"$out")" "1"
+    assert_eq "$(wc -l <<<"$out" | tr -d ' ')" "3"
+}
+
+#[test]
+it_refuses_a_step_with_nothing_in_it() {
+    _priv_reset
+    assert_fails priv_as_user "nothing" 2>/dev/null
+    _priv_reset
+}
+
+#[test]
+it_says_so_when_there_is_no_way_to_step_down_at_all() {
+    _priv_as_root
+    # A machine with none of the three. Failing quietly here would run the
+    # step as root, which is the whole thing this exists to prevent.
+    _priv_stubs
+    local rc=0
+    priv_as_user "reading" true 2>/dev/null || rc=$?
+    _priv_stubs_end; _priv_as_root_end
+    assert_ne "$rc" "0"
+}


### PR DESCRIPTION
`priv_run` gets you root. Nothing got you back out, so a tool that elevated for
one step and then wrote a file into somebody's home left it owned by root.
`priv_return` repairs that afterwards, and a repair pass has to be told every
path, and the one it wasn't told about is the one nobody notices until it bites.

`priv_as_user` is the other direction. One step, as the person, from inside
something that already elevated. Git in their checkout, a file into their home,
anything reading their config.

- `runuser` first, it's the one actually built for this, then `sudo -n`, then
  `su -s /bin/sh` last because that one goes through a shell and the args have
  to be quoted back into one string
- no-op when not root, no-op when the person is root, so a caller doesn't have
  to ask which it is
- says so and refuses when the machine has none of the three, instead of quietly
  running the step as root, which is the exact thing this exists to stop

## Sanity

`./test tests/priv_test.sh` is 32, twelve of them new here. No way to test this
for real without a second account, so the three commands get stubbed and asked
what they were handed, which is where this can actually be wrong anyway.

The `su` case doesn't assert a spelling of the quoting, that would just pin an
implementation. Its stub runs its own payload and a stubbed `git` reports what
arrived, so what's checked is a path with a space in it coming out the far end
as one argument. Confirmed against the unquoted version, which fails on it.

The stub dir is the whole of PATH while a test runs, not just first on it. Had
it prepended at first and this machine's own `sudo` was answering the two tests
about falling past `sudo`. Would have shipped green and proved nothing.