### PR TITLE
release: 0.4.0, the interpreter becomes a dependency like any other

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ git clone https://github.com/orgrinrt/nutshell.git
 
 ### When a project needs a version the machine does not have
 
-Copy `find-nutshell` into the project and let it resolve. It is one file, it
-depends on nothing, and it is what has to be on disk before anything else can
-be found:
+Copy `find-nutshell` into the project and let it resolve. It is one file, it needs no nutshell module, and it is what has to be on disk
+before anything else can be found. It does use `git`, `date`, `uname` and the
+ordinary file tools, since fetching is what it is for:
 
 ```bash
 # in the project
@@ -74,9 +74,10 @@ machine carrying four of them is the ordinary state.
   toolchains/branches/<ref>/<revision>/
 ```
 
-The store is `${XDG_DATA_HOME:-~/.local/share}/nutshell` on Linux and
-`~/Library/Application Support/nutshell` on macOS. Both are where that platform
-puts application data, which is the point: it is not the cache directory.
+`XDG_DATA_HOME` names the store wherever it is set, on any platform. With it
+unset the store is `~/.local/share/nutshell` on Linux and
+`~/Library/Application Support/nutshell` on macOS, which is where each puts
+application data. The point of both is that neither is the cache directory.
 
 `NUTSHELL_STORE` moves the root, `NUTSHELL_TOOLCHAINS` just the toolchains, and
 `NUTSHELL_REMOTE` says where a fetch goes. Under the data directory and not the
@@ -114,21 +115,36 @@ revision runs and says which one it is.
 
 ## Quick Start
 
-Every script that uses nutshell needs **one line** at the top:
+With nutshell installed, a script needs no boilerplate at all. The shebang is
+the whole of it:
 
 ```bash
-#!/usr/bin/env bash
-. "${0%/*}/lib/nutshell/init"
+#!/usr/bin/env nutshell
 
 use os log
 
-log_info "Hello from nutshell!"
+log_info "hello"
 ```
 
-The `. "${0%/*}/lib/nutshell/init"` line is the **only boilerplate**. Copy it exactly.
+For a script that has to run where nutshell may not be installed, source the
+resolver instead and let it find one:
 
-> **What does `${0%/*}` mean?**  
-> It's bash for "directory containing this script". It ensures the script works regardless of where it's called from.
+```bash
+#!/usr/bin/env bash
+HERE="${BASH_SOURCE[0]%/*}"
+. "$HERE/find-nutshell"
+nutshell_find "$HERE" dev || exit 1
+. "$NUTSHELL_INIT"
+
+use os log
+
+log_info "hello"
+```
+
+That second form is what a project carries when it pins a version, and
+`find-nutshell` is the only file it needs beside its own source. There is no
+third form: a copy of nutshell in the tree is the arrangement the section above
+tells you not to adopt.
 
 ---
 
@@ -136,7 +152,7 @@ The `. "${0%/*}/lib/nutshell/init"` line is the **only boilerplate**. Copy it ex
 
 ```
 nutshell/
-├── init                    # Source this: . "${0%/*}/lib/nutshell/init"
+├── init                    # what `nutshell` and `find-nutshell` source
 ├── check                   # Main QA entry point (executable)
 ├── bin/
 │   └── nutshell           # Interpreter for #!/usr/bin/env nutshell
@@ -195,7 +211,7 @@ Each script is independent. Each one has the init line:
 ```bash
 #!/usr/bin/env bash
 # scripts/build.sh
-. "${0%/*}/lib/nutshell/init"
+. "$NUTSHELL_INIT"
 
 use os log fs
 
@@ -213,7 +229,7 @@ One script bootstraps, others use the clean shebang:
 ```bash
 #!/usr/bin/env bash
 # scripts/main.sh - The entry point
-. "${0%/*}/lib/nutshell/init"
+. "$NUTSHELL_INIT"
 
 # PATH is already set by init, so internal scripts can use nutshell shebang
 "${0%/*}/internal/build.sh" "$@"
@@ -306,9 +322,6 @@ use os log json http
 | `srcfile` | A source file read once (`nut_load_file`, `nut_defined_at`, `nut_body_of`) |
 | `checkcache` | A check's answer kept until it can change (`nut_cache_hit`, `nut_cache_read`) |
 | `priv` | Elevating for one step and stepping back (`priv_run`, `priv_as_user`) |
-| `extern` | Declared dependencies out of the store (`extern_path`, `extern_declared`) |
-| `modgraph` | What a module declares against what it calls |
-| `git` | Repository questions (`git_root`, `git_branch`, `git_is_clean`) |
 | `git` | Reading a repository (`git_trunk`, `git_changed_files`, `git_trailers`) |
 | `modgraph` | The module graph and its violations (`modgraph_build`, `modgraph_audit`) |
 | `extern` | Libraries from elsewhere (`extern_path`, `extern_resolve`) |
@@ -503,7 +516,7 @@ happens.
 ```bash
 #!/usr/bin/env bash
 # scripts/build.sh
-. "${0%/*}/lib/nutshell/init"
+. "$NUTSHELL_INIT"
 
 use os log deps fs
 
@@ -530,7 +543,7 @@ log_success "Build complete!"
 ```bash
 #!/usr/bin/env bash
 # scripts/fetch-data.sh
-. "${0%/*}/lib/nutshell/init"
+. "$NUTSHELL_INIT"
 
 use log http json
 
@@ -553,7 +566,7 @@ fi
 ```bash
 #!/usr/bin/env bash
 # scripts/install.sh
-. "${0%/*}/lib/nutshell/init"
+. "$NUTSHELL_INIT"
 
 use log prompt fs color
 
@@ -581,13 +594,13 @@ log_success "Installation complete!"
 Every script needs this line:
 
 ```bash
-. "${0%/*}/lib/nutshell/init"
+. "$NUTSHELL_INIT"
 ```
 
 Breaking it down:
 - `.` sources a file (same as `source`)
 - `"${0%/*}"` is the directory containing this script
-- `/lib/nutshell/init` is the path to nutshell's init file
+- `find-nutshell` is the resolver a project carries when it pins a version
 
 This works regardless of:
 - Where the script is called from (`./scripts/build.sh` or `scripts/build.sh`)
@@ -651,17 +664,27 @@ See `examples/configs/` for configuration templates:
 
 ## Why This Design?
 
-**Q: Why not a global install?**  
-A: Nutshell is designed to be bundled with your project. When someone clones your repo and runs `npm run build`, it should just work, with no "please install nutshell first".
+**Q: Why a global install rather than a copy in the project?**  
+A: Because a copy in the project is a second version, and it drifts from the
+machine's without saying so. It resolves the modules that existed when it was
+added and none added since, so what you get is an error naming a missing
+function rather than one naming a stale copy. That happened twice in one day in
+the projects this was written for.
 
-**Q: Why not `#!/usr/bin/env nutshell` everywhere?**  
-A: That requires `nutshell` to be on PATH. `./install` links it there in one step, but the source line works on a fresh clone with no setup at all, so it stays the default.
+**Q: Then what about a fresh clone with nothing installed?**  
+A: `find-nutshell` is for that. One file in the project, depending on nothing,
+which finds an installed one or fetches the version the project pins. It is
+what the second Quick Start form uses.
 
-**Q: Can I use the pretty shebang?**  
-A: Yes. The `init` file adds nutshell's `bin/` to PATH, so any scripts called after sourcing init can use `#!/usr/bin/env nutshell`, and `./install` makes it resolve everywhere else. This suits internal scripts in larger script suites.
+**Q: Can I use `#!/usr/bin/env nutshell` everywhere?**  
+A: Yes, once `./install` has linked it onto PATH, and that is the shape to
+prefer. `init` also puts nutshell's `bin/` on PATH, so anything a script starts
+after sourcing it can use the shebang without the install.
 
 **Q: What if I have many scripts?**  
-A: Each standalone script needs the init line. It's one line of boilerplate per file. For large script suites, consider Pattern 2 (entry point + internal scripts).
+A: Then the shebang is worth the one-time install: no boilerplate per file at
+all. Where that is not available, an entry point resolves once and everything
+it calls inherits PATH, which is Pattern 2 below.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ use os log json http
 | `text` | Text processing (`text_grep`, `text_replace`, `text_count_matches`) |
 | `json` | JSON parsing (`json_get`, `json_set`, `json_valid`, `json_pretty`) |
 | `http` | HTTP requests (`http_get`, `http_post`, `http_download`) |
-| `toml` | TOML parsing (`toml_get`, `toml_get_or`, `toml_is_true`) |
+| `toml` | TOML reading (`toml_get`, `toml_get_or`, `toml_is_true`, `toml_array`) |
+| `toml::write` | Changing a TOML file in place (`toml_set`, `toml_unset`) |
+| `toml::json` | TOML as JSON (`toml_to_json`) |
 | `prompt` | User prompts (`prompt_confirm`, `prompt_input`, `prompt_select`) |
 | `color` | Terminal colors (`color_red`, `color_green`, `color_bold`) |
 | `validate` | Validation (`is_set`, `is_integer`, `require_command`) |
@@ -323,7 +325,7 @@ Three namespaces, and they answer three different questions:
 | Written | Resolves to |
 |---|---|
 | `use log` | nutshell's own module |
-| `use shebang::diagnostics/findings` | a module in a library declared in `nut.toml` |
+| `use shebang::tui::term` | a module in a library declared in `nut.toml` |
 | `use super::mine` | `lib/mine.sh` in **this** unit, found from its `nut.toml` |
 
 `super::` is anchored on the manifest rather than on the running script, so a
@@ -387,7 +389,7 @@ ref = "main"
 and a module inside it is reached by namespacing the `use`:
 
 ```bash
-use shebang::diagnostics/findings
+use shebang::tui::term
 ```
 
 Declared in the manifest because a script that fetches its own dependencies

--- a/README.md
+++ b/README.md
@@ -31,6 +31,61 @@ Optionally, link the interpreter onto PATH so standalone scripts can use the
 ./scripts/lib/nutshell/install
 ```
 
+### The store
+
+Fetched dependencies live in one place shared by every project on the machine,
+keyed by url and commit, so two projects on the same commit of the same library
+have one copy of it between them and neither carries a dependency tree of its
+own.
+
+The interpreter is one of those dependencies rather than a special case.
+Versions sit side by side, a tool asks for the one it needs, and a version that
+is not on the machine yet is fetched at its tag rather than being a failure. A
+machine carrying four of them is the ordinary state.
+
+```
+<store>/
+  externs/       one directory per url and commit
+  toolchains/    one directory per version
+  toolchains/branches/<ref>/<revision>/
+```
+
+The store is `${XDG_DATA_HOME:-~/.local/share}/nutshell` on Linux and
+`~/Library/Application Support/nutshell` on macOS. Both are where that platform
+puts application data, which is the point: it is not the cache directory.
+
+`NUTSHELL_STORE` moves the root, `NUTSHELL_TOOLCHAINS` just the toolchains, and
+`NUTSHELL_REMOTE` says where a fetch goes. Under the data directory and not the
+cache directory, because a cache is something a cleaner is entitled to delete
+and this is where every project's dependencies actually live.
+
+A pin that names a version gets a directory named for that version, and one
+that names a branch gets a directory named for the revision that branch
+resolved to. The second is what makes the store safe to share: a revision
+directory is written once and never replaced, so somebody else's push cannot
+delete the tree a running interpreter is reading out of.
+
+The store used to sit under the cache directory. Nothing migrates it: what was
+there is reproducible, so the first resolution after upgrading fetches into the
+new place and the old directory is left for you to delete. It is
+`${XDG_CACHE_HOME:-~/.cache}/nutshell` on Linux and
+`~/Library/Caches/nutshell` on macOS.
+
+A pin that names a version resolves in this order: `NUTSHELL_HOME` if it is
+set, then an installed interpreter if it satisfies what the tool asked for,
+then the store, then a fetch into the store, then whatever the project has
+vendored. One shared interpreter that everything uses is still the good state;
+the store is for the tools that cannot use it, and the vendored copy is the
+last resort for a machine with no network.
+
+A pin that names a branch is a different question and takes a different route:
+`NUTSHELL_HOME`, then the branch's head, then vendored. It does not consult the
+installed interpreter or the version store, because neither can answer it. A
+branch pin is not a floor, it is an identity: `dev` means the head of dev
+today, and nothing already on the machine can be assumed to be that. The remote
+is asked at most once an hour, and when it cannot be reached the last known
+revision runs and says which one it is.
+
 ---
 
 ## Quick Start
@@ -396,8 +451,8 @@ Declared in the manifest because a script that fetches its own dependencies
 decides for the whole project where code comes from, and does it somewhere
 nobody looks. One file answers "what does this project pull in".
 
-Resolution is cached globally by url and ref, so several projects naming the
-same ref share one checkout and the second pays nothing.
+Resolution goes through the store, so several projects naming the same commit
+share one checkout and the second pays nothing.
 
 `nut.lock` records the commit each dependency resolved to, and is written on
 first resolution and obeyed from then on. `ref = "main"` names a branch, and a

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -LO https://raw.githubusercontent.com/orgrinrt/nutshell/main/find-nutshell
 HERE="${BASH_SOURCE[0]%/*}"
 . "$HERE/find-nutshell"
 nutshell_find "$HERE" dev || exit 1    # a version, or a branch
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 ```
 
 It takes what the caller named, then what is installed if that satisfies, then
@@ -134,12 +134,18 @@ resolver instead and let it find one:
 HERE="${BASH_SOURCE[0]%/*}"
 . "$HERE/find-nutshell"
 nutshell_find "$HERE" dev || exit 1
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 
 use os log
 
 log_info "hello"
 ```
+
+Both source lines end in `|| exit 1`, and that is not decoration. Sourcing
+`init` can fail: on a bash older than 4 it refuses, and a `return` inside a
+sourced file returns *to* the caller rather than stopping it. Without the
+check, a script prints the refusal and then runs its whole body with nothing
+loaded, reporting success.
 
 That second form is what a project carries when it pins a version, and
 `find-nutshell` is the only file it needs beside its own source. There is no
@@ -211,7 +217,7 @@ Each script is independent. Each one has the init line:
 ```bash
 #!/usr/bin/env bash
 # scripts/build.sh
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 
 use os log fs
 
@@ -229,7 +235,7 @@ One script bootstraps, others use the clean shebang:
 ```bash
 #!/usr/bin/env bash
 # scripts/main.sh - The entry point
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 
 # PATH is already set by init, so internal scripts can use nutshell shebang
 "${0%/*}/internal/build.sh" "$@"
@@ -516,7 +522,7 @@ happens.
 ```bash
 #!/usr/bin/env bash
 # scripts/build.sh
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 
 use os log deps fs
 
@@ -543,7 +549,7 @@ log_success "Build complete!"
 ```bash
 #!/usr/bin/env bash
 # scripts/fetch-data.sh
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 
 use log http json
 
@@ -566,7 +572,7 @@ fi
 ```bash
 #!/usr/bin/env bash
 # scripts/install.sh
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 
 use log prompt fs color
 
@@ -594,7 +600,7 @@ log_success "Installation complete!"
 Every script needs this line:
 
 ```bash
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 ```
 
 Breaking it down:

--- a/README.md
+++ b/README.md
@@ -9,27 +9,51 @@ macOS ships 3.2 at `/bin/bash`, so install a current bash there first.
 
 ## Installation
 
-Add nutshell to your project:
+One nutshell on the machine, shared by everything that uses it. That is the
+good state, and the two lines below are the whole of it:
 
 ```bash
-# Option A: Git submodule (recommended)
-git submodule add https://github.com/orgrinrt/nutshell.git scripts/lib/nutshell
-
-# Option B: Download a source archive (releases ship no built artifacts).
-# 0.3.0 is the latest tag; check the releases page for newer ones.
-mkdir -p scripts/lib/nutshell
-curl -L https://github.com/orgrinrt/nutshell/archive/refs/tags/0.3.0.tar.gz \
-    | tar -xz --strip-components=1 -C scripts/lib/nutshell
+git clone https://github.com/orgrinrt/nutshell.git
+./nutshell/install
 ```
 
-That's it. No global install required. Nutshell lives in your project.
+`install` links the interpreter onto PATH, so a script can say
+`#!/usr/bin/env nutshell` and a project can find it without carrying a copy.
 
-Optionally, link the interpreter onto PATH so standalone scripts can use the
-`#!/usr/bin/env nutshell` shebang:
+### When a project needs a version the machine does not have
+
+Copy `find-nutshell` into the project and let it resolve. It is one file, it
+depends on nothing, and it is what has to be on disk before anything else can
+be found:
 
 ```bash
-./scripts/lib/nutshell/install
+# in the project
+curl -LO https://raw.githubusercontent.com/orgrinrt/nutshell/main/find-nutshell
 ```
+
+```bash
+#!/usr/bin/env bash
+HERE="${BASH_SOURCE[0]%/*}"
+. "$HERE/find-nutshell"
+nutshell_find "$HERE" dev || exit 1    # a version, or a branch
+. "$NUTSHELL_INIT"
+```
+
+It takes what the caller named, then what is installed if that satisfies, then
+the store, then fetches into the store. A pin naming a branch means that
+branch's head, asked at most once an hour.
+
+### Do not carry a copy in the tree
+
+A nutshell inside a project is a second version that drifts from the machine's
+in silence, and there is no moment where that becomes visible: it simply
+resolves modules that existed when it was added and none since, and the error
+names a missing function rather than a stale copy. It happened twice in one day
+in the projects this was written for, and both of them dropped theirs.
+
+A vendored copy at `<project>/lib/nutshell` is still the last thing
+`nutshell_find` tries, and it is there for one case: a machine with no network
+that is being rescued. Not as a way to install.
 
 ### The store
 
@@ -209,14 +233,19 @@ log_info "Building..."
 
 ## Integrating with Task Runners
 
-Nutshell scripts work with any task runner. The scripts bootstrap themselves:
+Nutshell scripts work with any task runner. The scripts bootstrap themselves,
+so the runner does not have to know where nutshell is.
+
+`nutshell-check` below is the project's own one-line wrapper: it resolves
+nutshell the same way the tool does and hands over. `check` in this repository
+is that wrapper.
 
 **deno.json:**
 ```json
 {
   "tasks": {
     "build": "./scripts/build.sh",
-    "check": "./scripts/lib/nutshell/check"
+    "check": "nutshell-check"
   }
 }
 ```
@@ -226,7 +255,7 @@ Nutshell scripts work with any task runner. The scripts bootstrap themselves:
 {
   "scripts": {
     "build": "./scripts/build.sh",
-    "check": "./scripts/lib/nutshell/check"
+    "check": "nutshell-check"
   }
 }
 ```
@@ -237,7 +266,7 @@ build:
 	./scripts/build.sh
 
 check:
-	./scripts/lib/nutshell/check
+	nutshell-check
 ```
 
 Anyone can run `deno task build` or `npm run check` without knowing nutshell exists.
@@ -274,6 +303,12 @@ use os log json http
 | `test` | Test harness (`assert_eq`, `test_run`, `test_summary`) |
 | `attr` | Attributes on definitions (`attr_has`, `attr_arg`, `attr_find`) |
 | `cli` | Subcommand dispatch with did-you-mean (`cli_command`, `cli_run`) |
+| `srcfile` | A source file read once (`nut_load_file`, `nut_defined_at`, `nut_body_of`) |
+| `checkcache` | A check's answer kept until it can change (`nut_cache_hit`, `nut_cache_read`) |
+| `priv` | Elevating for one step and stepping back (`priv_run`, `priv_as_user`) |
+| `extern` | Declared dependencies out of the store (`extern_path`, `extern_declared`) |
+| `modgraph` | What a module declares against what it calls |
+| `git` | Repository questions (`git_root`, `git_branch`, `git_is_clean`) |
 | `git` | Reading a repository (`git_trunk`, `git_changed_files`, `git_trailers`) |
 | `modgraph` | The module graph and its violations (`modgraph_build`, `modgraph_audit`) |
 | `extern` | Libraries from elsewhere (`extern_path`, `extern_resolve`) |

--- a/bin/nut-declare
+++ b/bin/nut-declare
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nut-declare - Write the lib.nut a library was already implying
+# =============================================================================
+#
+# Before lib.nut, a module name was turned into a file by trying three layouts
+# in order and taking whichever answered. That is a rule, so it can be run
+# backwards: every file those layouts would have found, under the name that
+# would have found it. What this writes therefore resolves exactly what
+# resolved yesterday, which is the point. It is a migration, not a redesign.
+#
+# It never overwrites. A lib.nut that exists is the library's own statement
+# about itself and this has no business editing it; the diff against a fresh
+# one is printed instead, which is also how you check a hand-edited file still
+# covers everything.
+#
+# Usage:
+#   nut-declare                 write ./lib.nut
+#   nut-declare path/to/lib     write path/to/lib/lib.nut
+#   nut-declare --check         print what is missing, write nothing
+#   nut-declare --print         print it, write nothing
+#
+# A file under impl/ is marked internal: those are picked at runtime by the
+# module above them and sourced directly, so they were never names anybody
+# used, and a consumer reaching one would be reaching past the thing whose
+# whole job is to choose between them.
+# =============================================================================
+
+set -uo pipefail
+
+MODE="write"
+ROOT="."
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check) MODE="check"; shift ;;
+        --print) MODE="print"; shift ;;
+        -h|--help) sed -n '3,22p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'; exit 0 ;;
+        -*) printf 'nut-declare: no such option %s\n' "$1" >&2; exit 2 ;;
+        *)  ROOT="$1"; shift ;;
+    esac
+done
+
+ROOT="${ROOT%/}"
+[[ -d "$ROOT" ]] || { printf 'nut-declare: %s is not a directory\n' "$ROOT" >&2; exit 1; }
+
+# Every module file, under the name the old resolver would have reached it by.
+# The three layouts, in the order it tried them, so a file findable two ways
+# gets the name that would have won.
+_scan() {
+    local f rel name
+    # find, not a list of globs at fixed depths. A glob per level means a
+    # module one level deeper than anyone wrote a glob for is invisible, and
+    # invisible to the check as well, because both read the same list. That is
+    # how text::impl::combo::grep_sed came to be undeclared while --check
+    # reported the library complete.
+    while IFS= read -r f; do
+        [[ -f "$f" ]] || continue
+        rel="${f#$ROOT/}"
+        # nutshell's own vendored copy is not part of the library declaring it.
+        [[ "$rel" == */nutshell/* ]] && continue
+        name="${rel#lib/}"; name="${name#libs/}"
+        name="${name%.sh}"
+        # A file at the root is named by its stem, with no directory to strip.
+        name="${name//\//::}"
+        # A file under impl/ is chosen at runtime by the module above it and
+        # sourced directly. It was never a module anybody names, and declaring
+        # it public would invite a consumer to reach past the thing whose job
+        # is to pick between them.
+        if [[ "$rel" == */impl/* ]]; then
+            printf '%s\t%s\tinternal\n' "$name" "$rel"
+        else
+            printf '%s\t%s\t\n' "$name" "$rel"
+        fi
+    done < <({
+        find "$ROOT/lib" "$ROOT/libs" -type f -name '*.sh' 2>/dev/null
+        # And a module flat at the library root, which the resolver tries last
+        # and the scan did not try at all. A migration that drops a module the
+        # resolver can reach, and a check that then certifies the drop, are one
+        # bug counted twice.
+        find "$ROOT" -maxdepth 1 -type f -name '*.sh' 2>/dev/null
+    } | sort) | sort -u
+}
+
+# A name more than one file answers to. The resolver picks by precedence and
+# the declaration would freeze whichever came out of sort, so it is reported
+# rather than silently resolved.
+_dupes() {
+    _scan | awk -F'\t' '{ print $1 }' | sort | uniq -d
+}
+
+# Every name a declaration holds. One parser for the checker, so it and the
+# resolver cannot disagree about what the file says.
+_lib_nut_modules_of() {
+    local r="$1" n _rest
+    [[ -r "${r}/lib.nut" ]] || return 1
+    while read -r n _rest || [[ -n "$n" ]]; do
+        [[ -z "$n" || "${n:0:1}" == "#" ]] && continue
+        printf '%s\n' "$n"
+    done < "${r}/lib.nut"
+}
+
+_render() {
+    local name rel
+    printf '# lib.nut - the modules %s provides.\n' "$(basename "$(cd "$ROOT" && pwd)")"
+    printf '#\n'
+    printf '# One module per line: the name a `use` writes, then the file.\n'
+    printf '# Read before any module is loaded, so it stays a format that needs\n'
+    printf '# no parser: the TOML one is itself a module.\n'
+    printf '\n'
+    local vis
+    while IFS=$'\t' read -r name rel vis; do
+        [[ -n "$name" ]] || continue
+        if [[ -n "$vis" ]]; then printf '%-24s %-28s %s\n' "$name" "$rel" "$vis"
+        else printf '%-24s %s\n' "$name" "$rel"; fi
+    done < <(_scan)
+}
+
+case "$MODE" in
+    print) _render ;;
+    dupes) _dupes ;;
+    check)
+        if [[ ! -r "$ROOT/lib.nut" ]]; then
+            printf '%s has no lib.nut. %d modules would be declared:\n\n' \
+                "$ROOT" "$(_scan | grep -c .)"
+            _scan | awk -F'\t' '{ printf "  %s\n", $1 }'
+            exit 1
+        fi
+        # Declared but absent, and present but undeclared. Both are errors a
+        # run would only have found by reaching the module.
+        rc=0
+        # The same parse the resolver does: leading space skipped, a comment is
+        # a comment wherever it starts, a missing newline on the last line does
+        # not lose it, and a line that is not a declaration is reported rather
+        # than crashing on an unset positional.
+        while read -r dname dfile dvis || [[ -n "$dname" ]]; do
+            [[ -z "$dname" || "${dname:0:1}" == "#" ]] && continue
+            if [[ -z "$dfile" ]]; then
+                printf 'not a declaration: %s\n' "$dname"; rc=1; continue
+            fi
+            case "${dvis:-}" in
+                ""|internal) ;;
+                *) printf 'unknown visibility on %s: %s\n' "$dname" "$dvis"; rc=1 ;;
+            esac
+            if [[ ! -f "$ROOT/$dfile" ]]; then
+                printf 'declared but missing: %s -> %s\n' "$dname" "$dfile"; rc=1
+            fi
+        done < "$ROOT/lib.nut"
+        while IFS=$'\t' read -r name rel _vis; do
+            # Compared as a word, not matched as a pattern. A module named
+            # `fs.impl` would otherwise match `fsXimpl` and be reported as
+            # declared when it is not.
+            _lib_nut_modules_of "$ROOT" | grep -qxF "$name" \
+                || { printf 'present but undeclared: %s (%s)\n' "$name" "$rel"; rc=1; }
+        done < <(_scan)
+        # Not `local`: this is a case arm at file scope, where `local` is a
+        # fatal error that `bash -n` does not catch.
+        d="$(_dupes)"
+        if [[ -n "$d" ]]; then
+            printf 'two files answer to one name: %s\n' "$(tr '\n' ' ' <<<"$d")"
+            rc=1
+        fi
+        (( rc == 0 )) && printf '%s: every module declared, every declaration present\n' "$ROOT"
+        exit "$rc" ;;
+    write)
+        if [[ -e "$ROOT/lib.nut" ]]; then
+            printf '%s/lib.nut already exists. Not touching it.\n\n' "$ROOT"
+            printf 'What a fresh one would say, against what is there:\n\n'
+            diff -u "$ROOT/lib.nut" <(_render) && printf '  (no difference)\n'
+            exit 0
+        fi
+        d="$(_dupes)"
+        if [[ -n "$d" ]]; then
+            printf 'Two files answer to the same name, so the declaration would\n'
+            printf 'freeze one of them and hide the other:\n\n'
+            printf '%s\n' "$d" | sed 's/^/  /'
+            printf '\nMove or rename one, then run this again.\n'
+            exit 1
+        fi
+        _render > "$ROOT/lib.nut"
+        printf 'wrote %s/lib.nut, %d modules\n' "$ROOT" "$(_scan | grep -c .)" ;;
+esac

--- a/bin/nutshell
+++ b/bin/nutshell
@@ -26,6 +26,22 @@
 # through the shebang or sourced `init` directly.
 # =============================================================================
 
+# The floor, before anything that needs it. `init` carries the same refusal,
+# and it is repeated here because this file is also an entry point: run under
+# bash 3 it would otherwise get as far as sourcing init before saying so, and
+# it used to get all the way to exit 0.
+#
+# Spelled through `case` on the version string rather than `BASH_VERSINFO`,
+# so the block itself parses under any shell.
+case "${BASH_VERSION:-}" in
+    ""|1.*|2.*|3.*)
+        printf 'nutshell needs bash 4.0 or newer.\n' >&2
+        printf '  this is: %s\n' "${BASH_VERSION:-not bash at all}" >&2
+        printf '  macOS ships 3.2 at /bin/bash. Install a current one and put\n' >&2
+        printf '  it first on PATH, or run this under it directly.\n' >&2
+        exit 1 ;;
+esac
+
 set -uo pipefail
 
 # The shebang line names whatever is on PATH, which is normally a symlink into
@@ -63,7 +79,7 @@ use extern log
 # scalar. Same shape mockspace.toml uses for the same job, because it is the
 # same job and a reader should not have to learn two spellings:
 #
-#     nutshell_version = "0.3.0"     the released form
+#     nutshell_version = "0.4.0"     the released form
 #     nutshell_branch  = "dev"       when there is no release yet
 #
 # Root level, before any [table] header. A bare key written after one belongs

--- a/bin/nutshell
+++ b/bin/nutshell
@@ -369,5 +369,10 @@ export NUTSHELL_SCRIPT NUTSHELL_SCRIPT_DIR
 
 # Sourced, not executed, so the script runs in this environment with `use`
 # already defined.
+#
+# By the absolute path, never by the bare name it was typed as: `source` with a
+# no-slash argument searches PATH first, so `nutshell test` in a directory
+# holding a script called `test` sourced `/bin/test` and reported that a binary
+# cannot be executed. The file the argument named was right there.
 # shellcheck source=/dev/null
-source "$_SCRIPT"
+source "$NUTSHELL_SCRIPT"

--- a/check
+++ b/check
@@ -21,7 +21,14 @@
 set -uo pipefail
 
 # Bootstrap nutshell (this is an entry point script)
-. "${BASH_SOURCE[0]%/*}/init"
+#
+# `|| exit 1`, because `init` refuses to load on a bash older than 4 and its
+# `return` returns to whoever sourced it: it cannot stop them. Unchecked, this
+# printed the refusal, ran its whole body with no modules loaded, found no
+# checks to run, and reported PASSED. On macOS, under `/bin/bash`, which is the
+# machine the refusal exists for. `release` gates on this command.
+# shellcheck source=/dev/null
+. "${BASH_SOURCE[0]%/*}/init" || exit 1
 
 # Load nutshell modules
 use os log string validate toml fs
@@ -348,7 +355,17 @@ _run_custom_checks() {
 _print_summary() {
     echo ""
     echo -e "${BOLD}────────────────────────────────────────${NC}"
-    
+
+    # Zero checks is not a pass. The same reasoning as `lib/test.sh` refusing a
+    # file that yields no tests: a run that examined nothing has established
+    # nothing, and "All 0 checks passed" is the sentence a broken bootstrap
+    # prints on its way to exit 0.
+    if [[ $TOTAL_CHECKS -eq 0 ]]; then
+        echo -e "${RED}${BOLD}FAILED${NC} - no checks ran at all"
+        echo "  nothing was found to run. A gate that examined nothing has not passed."
+        return 1
+    fi
+
     if [[ $FAILED_CHECKS -gt 0 ]]; then
         echo -e "${RED}${BOLD}FAILED${NC} - $FAILED_CHECKS of $TOTAL_CHECKS checks failed"
         return 1

--- a/check
+++ b/check
@@ -212,7 +212,11 @@ _run_check() {
         # check whose own source moved has to read everything again, and
         # without this the cache would keep answering with the old one's
         # opinion.
-        output=$( set +e; NUT_CACHE_CHECKER="$check_script" . "$check_script" 2>&1 )
+        # `set --` first, so the check does not inherit this function's own
+        # arguments. Sourced, `$1` was the check's path and `$2` its display
+        # name, so any check reading `$1` or `$@` silently operated on itself.
+        # Started as its own process it had none, which is what it expects.
+        output=$( set +e; set --; NUT_CACHE_CHECKER="$check_script" . "$check_script" 2>&1 )
         exit_code=$?
     else
         output=$("$check_script" 2>&1)
@@ -283,13 +287,19 @@ _run_builtin_checks() {
     echo -e "${BOLD}Built-in Checks${NC}"
     echo ""
 
-    # Once, here, so every check below inherits it rather than building its own.
+    # Once, here, so every check below inherits it rather than building its
+    # own. `get_lib_files` lives in `check-runner`, which this file does not
+    # load, so the loop was reading nothing and pre-warming zero files while
+    # its comment said otherwise.
     use srcfile 2>/dev/null || true
     use checkcache 2>/dev/null || true
-    local f
-    while IFS= read -r f; do
-        [[ -n "$f" ]] && nut_load_file "$f" 2>/dev/null
-    done < <(get_lib_files 2>/dev/null)
+    if declare -F get_lib_files >/dev/null 2>&1 \
+       && declare -F nut_load_file >/dev/null 2>&1; then
+        local f
+        while IFS= read -r f; do
+            [[ -n "$f" ]] && nut_load_file "$f" 2>/dev/null
+        done < <(get_lib_files 2>/dev/null)
+    fi
     
     for check in "${NUTSHELL_ROOT}"/examples/checks/check_*.sh; do
         [[ ! -f "$check" ]] && continue

--- a/check
+++ b/check
@@ -193,15 +193,45 @@ _run_check() {
     fi
     
     ((TOTAL_CHECKS++))
-    
+
     # Run the check
     local output
     local exit_code
-    output=$("$check_script" 2>&1)
-    exit_code=$?
+
+    # Sourced in a subshell of this process rather than started as one of its
+    # own. Eight checks meant eight nutshell startups and eight cold caches:
+    # each one re-read the same two dozen files, re-parsed the same config and
+    # re-walked the same attributes. A subshell inherits all of it and cannot
+    # write back, so the checks still cannot see each other's variables and
+    # `main` in one is not `main` in the next.
+    #
+    # A check that cannot be sourced is still run the old way, since a custom
+    # check is somebody else's file and may not be a nutshell script at all.
+    if [[ "${NUT_CHECK_ISOLATED:-0}" != "1" ]] && head -1 "$check_script" | grep -q 'env nutshell'; then
+        # Which file this check is, so the cache can notice it changing. A
+        # check whose own source moved has to read everything again, and
+        # without this the cache would keep answering with the old one's
+        # opinion.
+        output=$( set +e; NUT_CACHE_CHECKER="$check_script" . "$check_script" 2>&1 )
+        exit_code=$?
+    else
+        output=$("$check_script" 2>&1)
+        exit_code=$?
+    fi
     
-    if [[ $exit_code -eq 0 ]]; then
-        if echo "$output" | grep -q "⚠\|warning\|WARNING"; then
+    # 2 means warnings and no failures, which is what `exit_with_status`
+    # promises. The glyph grep below it is the fallback for a custom check that
+    # does not use the framework and so cannot say 2.
+    #
+    # It used to be the only mechanism, and it is not one: it reads tens of
+    # kilobytes of a child's stdout, it needs quiet mode to have left the line
+    # in, and it needs whichever `grep` is installed to read the pattern the
+    # same way. A check reporting 23 warnings was coming out as a clean pass.
+    if [[ $exit_code -eq 2 ]]; then
+        echo -e "  ${YELLOW}⚠${NC} ${check_name}"
+        ((WARNED_CHECKS++))
+    elif [[ $exit_code -eq 0 ]]; then
+        if printf '%s' "$output" | grep -q '⚠'; then
             echo -e "  ${YELLOW}⚠${NC} ${check_name}"
             ((WARNED_CHECKS++))
         else
@@ -220,12 +250,28 @@ _run_check() {
     # Truncating silently made three runs of the same check look like three
     # different answers, and cost an afternoon to work out that they were the
     # same answer shown five lines at a time. Say how many are not shown.
-    if [[ $exit_code -ne 0 ]]; then
+    # A 2 is warnings, not a failure, and there is nothing to explain.
+    if [[ $exit_code -ne 0 && $exit_code -ne 2 ]]; then
         local failures shown total
         failures="$(echo "$output" | grep -E "^\s*(✗|FAIL|ERROR|\[FAIL\]|\[ERROR\])")"
+
+        # A check that failed and said nothing is worse than one that passed
+        # wrongly, because there is no thread to pull. It happens because the
+        # quiet mode this runner sets suppresses the child's own report, so
+        # ask again with the report turned on rather than leaving the reader
+        # with a bare cross.
+        if [[ -z "$failures" ]]; then
+            failures="$(NUTSHELL_CHECK_QUIET=0 "$check_script" 2>&1 \
+                | grep -E "^\s*(✗|FAIL|ERROR|\[FAIL\]|\[ERROR\])")"
+        fi
+
         total=$(printf '%s' "$failures" | grep -c . || true)
         shown=5
-        printf '%s' "$failures" | head -"$shown" | sed 's/^/      /'
+        if [[ -z "$failures" ]]; then
+            echo "      it failed and printed nothing; run ${check_script#"${NUTSHELL_ROOT}"/} to see why"
+        else
+            printf '%s' "$failures" | head -"$shown" | sed 's/^/      /'
+        fi
         if [[ "$total" -gt "$shown" ]]; then
             echo "      ... and $((total - shown)) more; run ${check_script#"${NUTSHELL_ROOT}"/} to see them"
         fi
@@ -236,6 +282,14 @@ _run_builtin_checks() {
     echo ""
     echo -e "${BOLD}Built-in Checks${NC}"
     echo ""
+
+    # Once, here, so every check below inherits it rather than building its own.
+    use srcfile 2>/dev/null || true
+    use checkcache 2>/dev/null || true
+    local f
+    while IFS= read -r f; do
+        [[ -n "$f" ]] && nut_load_file "$f" 2>/dev/null
+    done < <(get_lib_files 2>/dev/null)
     
     for check in "${NUTSHELL_ROOT}"/examples/checks/check_*.sh; do
         [[ ! -f "$check" ]] && continue

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1,0 +1,84 @@
+# Modules
+
+A module is a file. The file is its identity, and `lib.nut` says which files a
+library offers and what to call them.
+
+## Naming one
+
+`::` separates every step, the whole way down:
+
+```sh
+use log                     # nutshell's own
+use super::guard            # this unit's, from its own lib.nut
+use shebang::tui::menu      # a declared dependency's
+```
+
+A `/` is refused. It used to work, because the part after `::` was handed to
+the filesystem unchanged, so a nested module resolved without anyone having
+designed one. Two separators in one path, one of them by accident.
+
+## Declaring them
+
+`lib.nut` sits at the root of a library. One module per line: the name a `use`
+writes, then the file, then `internal` if it is not for anybody else.
+
+```
+# lib.nut - the modules shebang provides.
+
+tui::term            libs/tui/term.sh
+tui::menu            libs/tui/menu.sh
+json::impl::jq       lib/json/impl/jq.sh      internal
+```
+
+It is a line format on purpose. `init` reads it before any module is loaded,
+and the TOML parser is itself a module: a declaration file that needs a parser
+you must load a module to obtain is a cycle at the bottom of the stack.
+
+`internal` means the library's own file, reachable by `super::` from inside and
+not by name from outside. The implementations under `impl/` are the case: the
+module above them picks one at runtime by what the machine has, and a consumer
+naming one directly is reaching past the thing whose job is to choose.
+
+## Why a declaration and not a search
+
+A module used to be found by trying `lib/<name>.sh`, then `libs/<name>.sh`,
+then `<name>.sh`, and taking whichever answered. Three guesses, in order.
+
+That has two costs. A file findable in more than one place resolves to
+whichever came first, which is not necessarily the one meant. And nothing can
+say in advance that a name will not resolve, so a missing module is found at
+the moment it is reached, mid-run, under `set -eo pipefail`, with the shell
+exiting and nothing on screen explaining why.
+
+A declaration makes the set of modules a fact rather than a search result. A
+name is in the tree or it is not, and both directions are checkable before
+anything runs.
+
+## Moving a library onto it
+
+`nut-declare` writes the declaration a library was already implying. It runs
+the old resolution backwards: every file those three layouts would have found,
+under the name that would have found it. What it writes therefore resolves
+exactly what resolved before.
+
+```sh
+nut-declare                  # write ./lib.nut
+nut-declare path/to/lib      # write one elsewhere
+nut-declare --print          # see it first
+nut-declare --check          # what disagrees, write nothing
+```
+
+It never overwrites. A `lib.nut` that exists is the library's own statement
+about itself; run against one, it prints the difference against a fresh one,
+which is also how to check a hand-edited file still covers every file.
+
+`--check` reports both directions: a declaration whose file is gone, and a file
+nothing declares. The second is the one a search could never report, because
+the file resolves perfectly well under a name the library never meant to offer.
+
+## Loading happens once per file
+
+A module reachable by two names is one module. Its own unit calls it
+`super::tui::key` and a consumer calls it `shebang::tui::key`; loading is keyed
+on the resolved file, so the second name is a no-op rather than a second
+source. `nutshell_loaded` answers by either name.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -231,3 +231,192 @@ orders, the checker's second parser, the symlink key. Written down instead:
       migration refuses to write one; a hand-edited file can still have it.
 - [ ] **`nutshell_modules` changed its output from names to paths.** Nothing
       in the tree reads it. Decide which it is and say so.
+
+## Pinning, as op wants it
+
+op, verbatim:
+
+> imports, as well as the nutshell binary itself, should be pinnable by git ref
+> (if a git dep), or a version (basically a git ref; tag). So if `dev` branch
+> is pinned, that means it's always the remote head on dev. So if the current
+> one is stale, it's evident on each call and will be fetched and updated as
+> per the pin. We should do the same thing as `renki` does, but just in bash.
+
+### The intent
+
+**A branch pin is a moving pin.** `ref = "dev"` means the remote head of `dev`,
+now, on every call: staleness is visible each time and the dependency is
+fetched and updated to match. A tag or a sha is the fixed kind. Both are "a git
+ref", and the distinction is whether the ref moves, not a separate concept.
+
+**Nutshell itself is pinnable the same way.** The interpreter is a dependency
+like any other and takes the same declaration.
+
+**`renki` is the reference**, in bash rather than whatever it is written in.
+The intent is the semantics; how much of renki's shape carries over is a
+judgement to make after reading it.
+
+op, on what the lockfile is then for:
+
+> lockfile should hold back. But if the pin is the branch itself, it's
+> implicitly meaning its head. If the pin is a specific commit or tag, then
+> that's actually something that needs to be held back by the lockfile. And
+> lockfile itself should obviously update to match each time the head moves and
+> the pinned branch head is something new
+
+So the lockfile has two jobs and which one it is doing depends on the pin. On a
+commit or a tag it holds the checkout back, which is what a lockfile is for. On
+a branch it records what the head resolved to and is rewritten every time that
+moves, which makes it a report rather than a pin.
+
+## A library that is not at the root of its repository
+
+op:
+
+> also that means nutshell should be able to depend on a nut library that is
+> not in the root of the repo, but has a path from the root. I think git has a
+> standard notation for this which should be expressible and respected on
+> nutshell's side
+
+### The intent
+
+**A dependency is a directory, not necessarily a repository.** One repository
+may carry several nut libraries and a consumer names the one it wants.
+
+On the notation: git itself has none. There is no URL form git understands that
+means "this subdirectory of that repository", because git clones repositories
+and nothing smaller. What exists is a convention borrowed by other tools, the
+double slash of go-getter and Terraform, `https://host/repo.git//sub/dir`, and
+it is theirs rather than git's. So the choice is between adopting that
+convention because people recognise it, and a second key beside `git` because
+it cannot be mistaken for something git will parse. Worth settling before it is
+built, and worth checking my claim about git rather than taking it: `git help
+clone` and `git help submodule` are where the answer is if there is one.
+
+## A shell renki
+
+op, thinking aloud rather than deciding:
+
+> I wonder if we shouldn't have a renki-sh or some subdir in the renki repo,
+> that would contain both a nut.toml for the same concept, same design, same
+> impl, but in posix compliant sh/bash. And also a raw entrypoint to source for
+> those that don't use nutshell. Could we even write attribute macros in fact,
+> on the renki rust side itself, to generate the sh version?
+
+Recorded as a question, not a mandate. What is being asked: whether the pin and
+launcher concept should exist twice, in rust and in shell, from one design; and
+whether the shell half could be generated from the rust half rather than
+written twice. The second is the interesting half and the risky one, since a
+generator that produces shell from rust attributes is a project of its own.
+
+Nothing here is scheduled.
+
+## Do not vendor the interpreter
+
+op:
+
+> Hmm. I don't think we should vendor in nutshell in the libs, honestly. Or at
+> least if there is a global nutshell interp / bin instance in path, or
+> otherwise reachable, it should be used as opposed to the vendored one, which
+> avoids random version differences between libs
+
+and, on the guard-every-call shape that comes out of it:
+
+> This problem seems like we shouldn't even have it...
+>
+> How do things like yarn 2, pnpm, cargo, deno, solve this very problem?
+
+### What those four actually do
+
+None of them keeps a per-project physical copy of anything, and none of them
+degrades when a version is wrong.
+
+**cargo** separates the toolchain from the libraries. The toolchain is resolved
+by rustup from `rust-toolchain.toml`; the libraries live in one shared
+`~/.cargo/registry` and are selected by a lockfile. A crate states the minimum
+compiler it needs with `rust-version`, and an older one is a refusal naming the
+version, never a build that half works.
+
+**pnpm** keeps one content-addressed store and makes `node_modules` a tree of
+links into it, so a version exists once on the machine however many projects
+want it. It is strict about declarations: a package may import what it declared
+and nothing else.
+
+**yarn 2** goes further and has no `node_modules` at all. One map from every
+import to a zip in the shared cache, and an undeclared import is an error.
+
+**deno** has one global cache keyed by URL with a lockfile of hashes, and the
+runtime is a single binary the project names.
+
+The two properties they share, and the two we do not have:
+
+1. **One copy per version on the machine, shared, never a copy per project.**
+   nutshell already does this for externs: `~/.cache/nutshell/externs/<key>` is
+   content-addressed by url and commit. The submodule is the exception, and it
+   is the thing that goes stale.
+2. **A wrong version is a refusal, not a degradation.** `declare -F thing ||
+   skip` at every call site is what a project writes when it does not know what
+   version it has. With a declared minimum and honest resolution the guard is
+   dead code.
+
+### The intent
+
+**The interpreter is resolved like any other dependency.** A library declares
+which nutshell it needs and a launcher on PATH finds or fetches it, the way
+rustup does for cargo and the way renki already does for its engine. A global
+one that satisfies the declaration is used in preference to anything vendored.
+
+**A dependency declares a minimum, and too old is an error at startup**, naming
+the dependency and the pin, rather than a missing function at line 426 of
+something the reader was in the middle of.
+
+Both are the same fix from two directions, and both make the guards go away.
+
+## Elevation is one step, not a mode
+
+op:
+
+> in general, I think the elevation should be nutshell api and abstracted so
+> that it only ever does a single disjoint thing elevated, then returns back to
+> original user. So it's really suDO, not just switching to su like it
+> presently behaves
+>
+> And the reason for being nutshell is that this should apply elsewhere, so we
+> don't accidentally end up writing things I expect in my home, to root's home
+> etc
+
+### The intent
+
+**One elevated step, then back.** The unit is a single thing that needs root,
+run as root, and everything around it stays the user who asked. Not a mode the
+process enters and stays in, which is what running a whole task under `sudo`
+is: `su` with extra steps.
+
+**It belongs in nutshell**, because the failure it prevents is not one tool's.
+Anything that elevates and then keeps going writes the user's files as root:
+their state directory, their cache, their config, their journal.
+
+### The evidence, from the machine, today
+
+Fetching an image needs the stick mounted, mounting needs root, so the whole
+task ran under `sudo`. The result, on the lifebook:
+
+    ~/.local/state/hulilupteri/journal        orgrinrt orgrinrt   22 lines
+    /run/hulilupteri/home/journal             root     root       10 lines
+
+Two histories of one tool, split by which user happened to run it, and the
+second one the user can no longer write: `test -w` says no. The next ordinary
+run either fails to record what it did or silently does not.
+
+Nothing was misconfigured. The tool asked for root for a reason and then kept
+it, which is the whole of the defect.
+
+### What the API has to do
+
+- run one command as root and return, with the caller's identity unchanged
+- try `sudo -n` first, so a machine needing no password never shows a prompt
+- refuse rather than hang where there is no terminal to answer a prompt on
+- name what is being elevated, so the sudo prompt and the log both say it
+- give a caller the real user's home, name and id even while the one step runs,
+  so nothing computes a path from `$HOME` at the wrong moment
+- say plainly when it cannot elevate, rather than falling back to trying anyway

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -166,3 +166,68 @@ these are reproducible claims rather than repo evidence.
 - [x] Restructured from core/ to lib/
 - [x] Checks in examples/checks/, tests in tests/
 - [x] README with usage patterns and examples
+
+## Where the linting goes, and what the attributes are
+
+op, verbatim:
+
+> I also notice the current nut.toml has duplicated patterns for detecting
+> allowing bypassing the loc stuff. I think we want to write a
+> viola-config-compliant linting engine into the nutshell (optionally sourced),
+> so machines that can just call viola from path can, but those that don't have
+> it, can run the nutshell's own linting engine specifically for bash and
+> nutshell, that only allows or works with bash and nutshell syntax and is
+> perhaps simplified too, but is viola compliant in config shape as well as
+> behaviour (in terms of output from input, not in terms of the same internal
+> steps to get there). Then the lintings and such move on to viola.toml (and if
+> viola doesn't yet support toml, it should, so that's a thing you should add
+> to agenda for someone to pick up later; it already has and supports json
+> format though, pretty sure, so that same schema should translate painlessly
+> into toml). This way the nut.toml is a bit cleaner and doesn't include
+> linting things. Also, I think the #[pub] etc should be some reusable nutshell
+> plugin/extension so depending on some workflow lib could give them, and
+> having [plugins] or [extensions] with default-attributes = enabled or
+> something like that could just make all that boilerplate happen, which all my
+> nutshell libs pretty much use by default anyway
+
+The duplication he spotted is real: `nut.toml:48` and `nut.toml:115` carry the
+same regex for the loc escape hatch, and `trivial_wrapper` is named at both
+`:45` and `:101`. One pattern, two homes, and nothing keeps them in step.
+
+- [ ] **A linting engine in nutshell, optional to source, viola-compliant by
+      config and by behaviour.** Same config in, same findings out; the steps
+      between are its own. It handles bash and nutshell only, and may be
+      simpler for it. A machine with `viola` on PATH calls that instead.
+- [ ] **Lint configuration moves to `viola.toml`.** `nut.toml` keeps what it is
+      for and stops carrying two copies of one pattern.
+- [ ] **Attributes become a plugin.** `#[pub]`, `#[allow(...)]` and the rest are
+      a reusable extension rather than something every library restates.
+      `[plugins]` or `[extensions]` with something like
+      `default-attributes = enabled` turns the boilerplate on, since every
+      nutshell library here wants it anyway.
+
+### For whoever picks up viola
+
+- [ ] **viola should read TOML.** It has JSON already, so the schema carries
+      over without redesign. Filed here because there is no agenda tool on this
+      machine to file it in; move it when there is.
+
+## Left from the module-system review
+
+Acted on: the stub recursion, the two guards keyed differently, super:: cached
+globally, the bare-`use` bypass, the missing third layout, the two precedence
+orders, the checker's second parser, the symlink key. Written down instead:
+
+- [ ] **`extern_resolve` runs inside a command substitution, so its memo dies
+      in the subshell.** `lib/extern.sh` writes `_EXTERN_RESOLVED[...]` and
+      `use` calls it as `$( )`, so every resolution pays full price. Measured
+      at 421ms for eight modules in the review. The fix is a resolver that
+      returns through a variable rather than through stdout, which touches
+      every caller.
+- [ ] **A declared path is not confined to the library root.** `../../etc/x`
+      in a `lib.nut` resolves. A declaration is written by the library's own
+      author, so this is not a trust boundary, but it should still refuse.
+- [ ] **Duplicate names inside one `lib.nut` are accepted, first wins.** The
+      migration refuses to write one; a hand-edited file can still have it.
+- [ ] **`nutshell_modules` changed its output from names to paths.** Nothing
+      in the tree reads it. Decide which it is and say so.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3,6 +3,28 @@
 ## Release blockers, from the 2026-08-14 dev-to-main readiness review
 
 Four items block a release. `./release` already refuses on the third. Findings are a reviewer's and the
+## The QA gate is fourteen seconds and op wants two
+
+Open, and recorded here because the target otherwise lives only in a state file
+that is current-only and gets overwritten.
+
+op called the gate untenable at 250 seconds and again at 37. It is 14.4 now,
+measured, on 24 files. His bar, verbatim:
+
+> We should be looking at sub 2 seconds for 24 files realistically.
+> tree-sitter based deno project can do it in milliseconds.
+
+What got it from 250 to 14 was removing forks: `lib/attr.sh` was piping every
+line of every file through `sed`, a config key was re-read per passing check
+from inside a subshell where the cache could not survive, the name-similarity
+comparison filled a whole edit-distance matrix when three rows settled it, and
+the eight checks were eight interpreter startups with eight cold caches.
+
+What is left is flat, with no hot spot, so more of the same is not the answer.
+The two candidates are `NUT_CACHE=1` being on by default once it has been
+trusted for a while, which takes a warm run to 9s, and not re-reading the same
+two dozen files in each of eight checks.
+
 two probes behind items 1 and 2 were written read-only, so **commit them alongside the fix**: until then
 these are reproducible claims rather than repo evidence.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -420,3 +420,189 @@ it, which is the whole of the defect.
 - give a caller the real user's home, name and id even while the one step runs,
   so nothing computes a path from `$HOME` at the wrong moment
 - say plainly when it cannot elevate, rather than falling back to trying anyway
+
+## The store, and versions coexisting
+
+> As for the versions of nutshell. We should have it similar as rustup or
+> pretty much any similar. Several versions can and will coexist on one machine
+> and instead of failing, we download the correct one and store it as a
+> "toolchain". Same as renki does. Unless this is how it works already. If so,
+> I don't understand how the versions can give so much trouble?
+
+> Really seems to me we should keep the libs anything depends on centrally too
+> like pnpm or yarn2. Nutshell itself just as one of them.
+
+**The intent: one central store, versions coexist, a missing one is a download
+rather than a failure, and the interpreter is an entry in that store like
+anything else.** The rustup and renki comparisons are the shape being asked
+for, not a requirement to copy either.
+
+It was not how it worked. Externs were already central and content-addressed;
+the interpreter was the exception, resolved by picking from what the machine
+happened to have and never fetching. That is the whole of the version trouble:
+`0.4.0` exists only on `dev`, nothing has tagged it, so no amount of resolving
+could find it and the fallback to the vendored copy fired every run.
+
+Settled by this work: a toolchain store keyed by version, a fetch when the
+asked-for version is not there, and both externs and toolchains under one store
+root. The externs moved from the cache directory to the data directory in the
+same change, because a cache is something a cleaner may delete at any moment
+and this is where every project's dependencies actually live.
+
+## renki-sh, or generating shell from the Rust
+
+> You know I feel more and more stern about us doing renki-sh or make nutshell
+> build a copy of the rust one natively and use that. It's no sense to reinvent
+> the wheel here. Nutshells idea is platform agnostic form that should
+> technically run anywhere with posix compliant or close enough shell and
+> utils. So this is why I have been and still am hesitant to introduce rust
+> into the mix. But if generating the bash-y version isn't likely to work from
+> the rust source, I don't know what to say here. It's just redundancy to
+> reinvent this specific wheel here
+
+**Two intents, and they are both mandates.** One: nutshell stays runnable on a
+POSIX-ish shell with no Rust anywhere in its chain. Two: the pin and lock
+semantics are not to be invented twice and left to drift apart. The vehicles
+offered, a `renki-sh` subdirectory and Rust attribute macros emitting shell, are
+proposals rather than either intent.
+
+### What the overlap actually is
+
+Counting non-comment lines, renki is 1500 of source across ten modules. What
+touches this problem at all:
+
+| module | lines | overlaps |
+| --- | --- | --- |
+| `pin.rs` | 171 | branch to rev via `git ls-remote`, TTL cached |
+| `manifest.rs` | 72 | the pin schema, a TOML shape |
+| `discover.rs` | 132 | walk up for the config file |
+| `cache.rs` | 147 | key to directory, payload is a cargo build |
+
+`tool.rs`, `engine.rs`, `registry.rs` and `selfupdate.rs`, 940 lines between
+them, are about cargo, crates.io, Rust toolchains and keeping a launcher binary
+current. None of it has a nutshell counterpart. Of the four above, `cache.rs`
+produces `cargo install` argument lists and `pin.rs` produces build attempts, so
+the shared part of each is smaller than its line count.
+
+The shared idea is about a hundred lines: branch resolves to its head, a rev or
+tag is held by the lock, resolution is cached with a TTL, the manifest is found
+by walking up. `lib/extern.sh` is 311 lines and already implements it.
+
+### On generating the shell from the Rust
+
+It does not pay, and the reason is not effort. The annotated functions would
+have to avoid generics, traits, iterators, `?`, `Result`, borrows, `PathBuf`,
+`SystemTime` and everything else in `std` with no shell counterpart. What
+remains is not Rust: it is a small language written inside Rust, compiled by a
+backend nobody else maintains, and every future edit to those functions has to
+stay inside a subset the compiler enforces nowhere. That is a compiler backend
+built to avoid a hundred lines of shell.
+
+### What to do instead: share the spec, not the code
+
+The redundancy that costs anything is semantic, not textual. Two
+implementations of one spec is ordinary. Two implementations that quietly
+disagree about what a branch pin means is the failure, and it is invisible until
+somebody's build resolves differently on two machines.
+
+So: the pin semantics get written down once, in renki, as prose plus a
+table-driven fixture set. Inputs to expected resolution, including the awkward
+ones: an annotated tag that has to peel, a branch head that moved since the
+lock, a TTL that has expired with no network, a rev pin the lock holds back, a
+tag that moved under a lock. Renki reads the fixtures in a Rust test; nutshell
+reads the same file in a shell test. Divergence is a red test in whichever one
+drifted, on the day it drifts.
+
+No Rust in nutshell's chain, no codegen backend, and the part with the real
+value, the settled semantics and the edge cases somebody had to think of once,
+is shared as data rather than copied as prose in two languages.
+
+A `renki-sh` subdirectory remains reasonable on top of that if a Rust project
+ever wants the launcher half in shell. It is a second consumer of the same
+fixtures, not a way of avoiding the second implementation.
+
+## The git ref is the version, and the constant in `init` is the parallel system
+
+> okay the problem is that you have invented a parallel disjoint system from the
+> git we target here. you have some env var / const-like for the version, but
+> that is redundant. The git tag *is* the version. If none, then its version is
+> the commit hash
+
+> you should let the nut.toml version pin handle the fetch. No reason to pin a
+> version while we are actively developing. Just pin to dev and it keeps always
+> up-to-date with latest dev, that's what we want
+
+**The intent: identity comes from git and from nowhere else.** A tag is the
+version; with no tag the commit hash is the version. A pin is a git ref, and a
+branch pin means that branch's head, always. Nothing declares a version about
+itself in a file.
+
+### What this falsifies
+
+Named before what it enables, because a closed gap reads as progress while a
+falsified claim announces nothing.
+
+- **`init:29`'s `NUTSHELL_VERSION`.** A constant somebody has to remember to
+  bump, which is why `main` says 0.2.0, `dev` says 0.4.0, and neither is a fact
+  about the code. It goes.
+- **`find-nutshell:_nutshell_version_of`.** Reads that constant out of `init`
+  without sourcing it. The whole function exists to serve the constant.
+- **The store's name-equals-contents invariant.** `nutshell_toolchains` skips a
+  directory whose `init` disagrees with its directory name. With git as the
+  identity there is nothing to disagree: the directory is a checkout and
+  `git -C dir describe --tags --always` says what it is.
+- **`_nutshell_num` and the prerelease ordering.** Already unreachable, as the
+  review found. Under git identity the question is whether a ref resolves, not
+  how a suffix sorts.
+- **`nutshell_at_least`, and `HULI_NEEDS_NUTSHELL` as a floor.** A floor is a
+  statement about the constant. A consumer pins a ref; if it needs a specific
+  tag it names that tag.
+- **`_nutshell_fetch`'s `--branch "$want"` with a version-shaped want.** Right
+  by accident, because tags here are bare. It should be resolving a ref.
+
+### What it should be instead: renki's model, read rather than paraphrased
+
+`renki/src/manifest.rs` and `renki/src/pin.rs`. Four points, each of which I got
+wrong by designing from the header instead of the code.
+
+**1. Four reference forms, and the config says which by which key it used.**
+`manifest.rs:63-71` is `Reference::{Version, Rev, Tag, Branch}`, and its own doc
+says they are not interchangeable: a version is immutable and maps to both a
+release and a tag, a rev and a tag are immutable and git-only, a branch moves
+and is the only one that has to be re-resolved. `Header::parse` at `:113-121`
+reads four separate keys, ordered most specific first, so a config carrying more
+than one has a defined answer. **There is no shape sniffing.** A tag named `dev`
+and a branch named `dev` are different pins because they came from different
+keys, and asking whether a string looks like a version is the invented system.
+
+**2. Everything resolves to something immutable, and that is the cache key.**
+`pin.rs:84-146` produces `key_rev`: `v:<version>` for a version, the bare sha
+for a rev, `tag:<t>` for a tag, and for a branch **the sha it currently points
+at**. `Resolved::git_ref` at `:72` says it outright: "a branch has already
+become the rev it pointed at". A store keyed by a branch name, or by a version
+string, is keyed by something that moves.
+
+**3. Two caches, two jobs.** The branch-head resolution is cached with a TTL
+(`resolve_branch`, `branch_resolution_path`, `fresh_resolution`); the built
+artifact is cached under the resolved sha. Conflating them is what makes a
+branch pin either never refresh or refetch on every run.
+
+**4. Offline uses the last known revision and names it.** `resolve_branch`
+falls back to `any_resolution` and prints the revision it is running from,
+because a stale head is very probably still built and sitting in the cache, and
+running from it beats refusing to run.
+
+For nutshell that means `nut.toml` carries `git` plus exactly one of `rev`,
+`tag`, `branch`, `version`, the same four keys, for the interpreter and for
+every extern alike. The store is keyed by the resolved commit. `NUTSHELL_VERSION`
+is deleted and `nutshell --version` answers from `git describe --tags --always`
+in its own checkout.
+
+**Interim state, so the next reader is not misled.** `find-nutshell` on
+`feat/toolchains` takes a branch and hulilupteri pins `dev` through it, so a
+consumer tracking a moving branch works today. Underneath it is still the
+invented system, and every one of the four points above is unimplemented: one
+key rather than four, shape sniffing rather than the key deciding, the store
+keyed by a branch name rather than by the sha it resolved to, and one cache
+doing both jobs. Treat `_nutshell_is_version` and `_nutshell_branch` as scaffolding
+that proved the consumer end, not as the design.

--- a/examples/checks/check_function_duplication.sh
+++ b/examples/checks/check_function_duplication.sh
@@ -196,6 +196,23 @@ compare_full_names() {
         count = NR
     }
     
+    # The part after the module prefix, which is where two functions in one
+    # family actually differ.
+    function tail_of(name,    t) {
+        t = name
+        if (substr(t, 1, 1) == "_") t = substr(t, 2)
+        if (index(t, "_") > 0) t = substr(t, index(t, "_") + 1)
+        return t
+    }
+
+    # Do two names share the word the module is called?
+    function same_prefix(a, b,    pa, pb) {
+        pa = (substr(a, 1, 1) == "_") ? substr(a, 2) : a
+        pb = (substr(b, 1, 1) == "_") ? substr(b, 2) : b
+        if (index(pa, "_") == 0 || index(pb, "_") == 0) return 0
+        return substr(pa, 1, index(pa, "_")) == substr(pb, 1, index(pb, "_"))
+    }
+
     END {
         # Compare each pair (only once, i < j)
         for (i = 1; i < count; i++) {
@@ -208,9 +225,23 @@ compare_full_names() {
                 
                 score = similarity(names[i], names[j])
                 
-                if (score >= threshold) {
-                    printf "MATCH|%.3f|%s|%s|%s|%s\n", score, names[i], names[j], files[i], files[j]
+                if (score < threshold) continue
+
+                # A module split across files keeps its prefix in every name,
+                # and a long shared prefix carries the score on its own:
+                # `toml_get` and `toml_set` come out at 0.875 while naming two
+                # opposite operations. So a match that survives only because of
+                # the prefix is an artefact of the naming convention, not a
+                # copy. What the two names do has to look alike as well.
+                if (same_prefix(names[i], names[j])) {
+                    t1 = tail_of(names[i]); t2 = tail_of(names[j])
+                    if (length(t1) > 0 && length(t2) > 0) {
+                        if (!can_meet_threshold(t1, t2, threshold)) continue
+                        if (similarity(t1, t2) < threshold) continue
+                    }
                 }
+
+                printf "MATCH|%.3f|%s|%s|%s|%s\n", score, names[i], names[j], files[i], files[j]
             }
         }
     }
@@ -482,4 +513,9 @@ main() {
 # the interpreter and `BASH_SOURCE[0]` is this file, and `main` was never
 # called. Six of the eight built-in checks exited 0 having done nothing, and
 # `./check` read that as a pass and printed one.
-main "$@"
+#
+# `NUT_CHECK_LOAD_ONLY` is the one way in for a test that wants the comparison
+# without a scan of the whole repository. It is an explicit opt-out rather than
+# a guess about how the file was loaded, which is the distinction the paragraph
+# above is about.
+[[ -n "${NUT_CHECK_LOAD_ONLY:-}" ]] || main "$@"

--- a/examples/checks/check_function_duplication.sh
+++ b/examples/checks/check_function_duplication.sh
@@ -139,38 +139,55 @@ compare_full_names() {
     local threshold="$2"
     
     echo "$func_data" | awk -F'|' -v threshold="$threshold" '
-    # Levenshtein distance function
-    function levenshtein(s1, s2,    len1, len2, i, j, c1, c2, cost, d, del, ins, repl, min) {
+    # Levenshtein distance, abandoned as soon as it cannot matter.
+    #
+    # `maxd` is the largest distance the caller could still accept. Past that
+    # the exact number is not wanted, so the row is checked and the whole thing
+    # abandoned rather than filled in: the answer only has to be "more than
+    # maxd", and returning maxd+1 says that.
+    #
+    # It matters because this is the whole cost of the check. 440 names is
+    # about 96,000 pairs, and the length prune below leaves most of them, each
+    # paying a full matrix. At the default threshold of 0.85 a twenty-character
+    # name accepts three edits, so three rows of no hope is the answer and the
+    # remaining seventeen were being computed for nothing.
+    #
+    # One row is kept rather than the matrix. Nothing reads the interior, and
+    # an awk associative array of len1*len2 cells per pair was most of the
+    # memory traffic.
+    function levenshtein(s1, s2, maxd,    len1, len2, i, j, c1, cost, prev, cur, best, subst) {
         len1 = length(s1)
         len2 = length(s2)
-        
+
         if (s1 == s2) return 0
         if (len1 == 0) return len2
         if (len2 == 0) return len1
-        
-        # Initialize first row and column
-        for (i = 0; i <= len1; i++) d[i, 0] = i
-        for (j = 0; j <= len2; j++) d[0, j] = j
-        
+        if (maxd == "") maxd = len1 + len2
+        # A difference in length is already that many edits.
+        if (len1 - len2 > maxd || len2 - len1 > maxd) return maxd + 1
+
+        for (j = 0; j <= len2; j++) prev[j] = j
+
         for (i = 1; i <= len1; i++) {
             c1 = substr(s1, i, 1)
+            cur[0] = i
+            best = cur[0]
             for (j = 1; j <= len2; j++) {
-                c2 = substr(s2, j, 1)
-                cost = (c1 == c2) ? 0 : 1
-                
-                del = d[i-1, j] + 1
-                ins = d[i, j-1] + 1
-                repl = d[i-1, j-1] + cost
-                
-                min = del
-                if (ins < min) min = ins
-                if (repl < min) min = repl
-                d[i, j] = min
+                cost = (c1 == substr(s2, j, 1)) ? 0 : 1
+                subst = prev[j-1] + cost
+                cur[j] = prev[j] + 1
+                if (cur[j-1] + 1 < cur[j]) cur[j] = cur[j-1] + 1
+                if (subst < cur[j]) cur[j] = subst
+                if (cur[j] < best) best = cur[j]
             }
+            # Every path through this row already costs more than the caller
+            # can accept, and a row only ever grows.
+            if (best > maxd) return maxd + 1
+            for (j = 0; j <= len2; j++) prev[j] = cur[j]
         }
-        return d[len1, len2]
+        return prev[len2]
     }
-    
+
     # Quick check: can these strings possibly have similarity >= threshold?
     function can_meet_threshold(s1, s2, threshold,    len1, len2, maxlen, minlen) {
         len1 = length(s1)
@@ -181,12 +198,16 @@ compare_full_names() {
         return ((minlen / maxlen) >= threshold)
     }
     
-    function similarity(s1, s2,    len1, len2, maxlen, dist) {
+    function similarity(s1, s2, threshold,    len1, len2, maxlen, dist, maxd) {
         len1 = length(s1)
         len2 = length(s2)
         maxlen = (len1 > len2) ? len1 : len2
         if (maxlen == 0) return 1.0
-        dist = levenshtein(s1, s2)
+        # The largest distance that could still clear the threshold. Anything
+        # past it is rejected either way, so it does not have to be counted.
+        maxd = int(maxlen * (1.0 - threshold))
+        dist = levenshtein(s1, s2, maxd)
+        if (dist > maxd) return 0.0
         return 1.0 - (dist / maxlen)
     }
     
@@ -223,7 +244,7 @@ compare_full_names() {
                 # Early exit: if lengths are too different, skip expensive Levenshtein
                 if (!can_meet_threshold(names[i], names[j], threshold)) continue
                 
-                score = similarity(names[i], names[j])
+                score = similarity(names[i], names[j], threshold)
                 
                 if (score < threshold) continue
 
@@ -237,7 +258,7 @@ compare_full_names() {
                     t1 = tail_of(names[i]); t2 = tail_of(names[j])
                     if (length(t1) > 0 && length(t2) > 0) {
                         if (!can_meet_threshold(t1, t2, threshold)) continue
-                        if (similarity(t1, t2) < threshold) continue
+                        if (similarity(t1, t2, threshold) < threshold) continue
                     }
                 }
 
@@ -284,51 +305,40 @@ compare_stripped_names() {
     local threshold="$2"
     
     echo "$func_data" | awk -F'|' -v threshold="$threshold" '
-    function levenshtein(s1, s2,    len1, len2, i, j, c1, c2, cost, d, del, ins, repl, min) {
-        len1 = length(s1)
-        len2 = length(s2)
-        
+    # The same abandoned-early distance as the first pass. See there for why.
+    function levenshtein(s1, s2, maxd,    len1, len2, i, j, c1, cost, prev, cur, best, subst) {
+        len1 = length(s1); len2 = length(s2)
         if (s1 == s2) return 0
         if (len1 == 0) return len2
         if (len2 == 0) return len1
-        
-        for (i = 0; i <= len1; i++) d[i, 0] = i
-        for (j = 0; j <= len2; j++) d[0, j] = j
-        
+        if (maxd == "") maxd = len1 + len2
+        if (len1 - len2 > maxd || len2 - len1 > maxd) return maxd + 1
+        for (j = 0; j <= len2; j++) prev[j] = j
         for (i = 1; i <= len1; i++) {
             c1 = substr(s1, i, 1)
+            cur[0] = i; best = cur[0]
             for (j = 1; j <= len2; j++) {
-                c2 = substr(s2, j, 1)
-                cost = (c1 == c2) ? 0 : 1
-                
-                del = d[i-1, j] + 1
-                ins = d[i, j-1] + 1
-                repl = d[i-1, j-1] + cost
-                
-                min = del
-                if (ins < min) min = ins
-                if (repl < min) min = repl
-                d[i, j] = min
+                cost = (c1 == substr(s2, j, 1)) ? 0 : 1
+                subst = prev[j-1] + cost
+                cur[j] = prev[j] + 1
+                if (cur[j-1] + 1 < cur[j]) cur[j] = cur[j-1] + 1
+                if (subst < cur[j]) cur[j] = subst
+                if (cur[j] < best) best = cur[j]
             }
+            if (best > maxd) return maxd + 1
+            for (j = 0; j <= len2; j++) prev[j] = cur[j]
         }
-        return d[len1, len2]
+        return prev[len2]
     }
-    
-    function can_meet_threshold(s1, s2, threshold,    len1, len2, maxlen, minlen) {
-        len1 = length(s1)
-        len2 = length(s2)
-        maxlen = (len1 > len2) ? len1 : len2
-        minlen = (len1 < len2) ? len1 : len2
-        if (maxlen == 0) return 1
-        return ((minlen / maxlen) >= threshold)
-    }
-    
-    function similarity(s1, s2,    len1, len2, maxlen, dist) {
+
+    function similarity(s1, s2, threshold,    len1, len2, maxlen, dist, maxd) {
         len1 = length(s1)
         len2 = length(s2)
         maxlen = (len1 > len2) ? len1 : len2
         if (maxlen == 0) return 1.0
-        dist = levenshtein(s1, s2)
+        maxd = int(maxlen * (1.0 - threshold))
+        dist = levenshtein(s1, s2, maxd)
+        if (dist > maxd) return 0.0
         return 1.0 - (dist / maxlen)
     }
     
@@ -363,7 +373,7 @@ compare_stripped_names() {
                 # Early exit: if lengths are too different, skip expensive Levenshtein
                 if (!can_meet_threshold(stripped[i], stripped[j], threshold)) continue
                 
-                score = similarity(stripped[i], stripped[j])
+                score = similarity(stripped[i], stripped[j], threshold)
                 
                 if (score >= threshold) {
                     printf "WARN|%.3f|%s|%s|%s|%s|%s|%s\n", score, stripped[i], original[i], stripped[j], original[j], files[i], files[j]
@@ -395,7 +405,14 @@ test_full_name_duplication() {
     echo ""
     
     local results
-    results=$(compare_full_names "$func_data" "$SIMILARITY_THRESHOLD")
+    # An awk that will not parse prints nothing and exits non-zero, and this
+    # check then reported a clean pass. That is how a reserved word used as a
+    # variable name went unnoticed: the program never ran, so nothing was
+    # similar to anything. A comparison that could not be made is not a pass.
+    if ! results=$(compare_full_names "$func_data" "$SIMILARITY_THRESHOLD"); then
+        log_fail "the name comparison could not run"
+        return 1
+    fi
     
     local failures=0
     
@@ -443,7 +460,10 @@ test_stripped_name_duplication() {
     echo ""
     
     local results
-    results=$(compare_stripped_names "$stripped_data" "$SIMILARITY_THRESHOLD")
+    if ! results=$(compare_stripped_names "$stripped_data" "$SIMILARITY_THRESHOLD"); then
+        log_fail "the stripped-name comparison could not run"
+        return 1
+    fi
     
     local warnings=0
     

--- a/examples/checks/check_public_api_docs.sh
+++ b/examples/checks/check_public_api_docs.sh
@@ -63,71 +63,118 @@ load_config() {
 # DOCUMENTATION CHECKING FUNCTIONS
 # =============================================================================
 
+# The file, once, as an array of lines.
+#
+# The scan below walks backwards from a definition and used to run `sed -n Np`
+# for each line it looked at, plus an `echo | grep` to decide what the line
+# was. That is three processes per line of every docblock in the library, and
+# it is why this check took most of a minute. Bash can hold the file and match
+# a line itself, which also means this needs no `sed` and no `grep` and works
+# on a machine that has neither.
+declare -gA _PAD_LINES=()
+declare -gA _PAD_LOADED=()
+declare -gA _PAD_AT=()
+declare -g  PAD_DOCBLOCK=""
+
+_pad_load() {
+    local file="$1"
+    [[ -n "${_PAD_LOADED[$file]:-}" ]] && return 0
+    local -a lines=()
+    # `mapfile` is a bash builtin and needs nothing installed, but it arrived
+    # in bash 4 and this reads a file a checker has to read. The loop below is
+    # the same thing on any bash, and no external tool is involved either way.
+    if [[ "$(type -t mapfile)" == "builtin" ]]; then
+        mapfile -t lines < "$file" 2>/dev/null || return 1
+    else
+        local __l
+        while IFS= read -r __l || [[ -n "$__l" ]]; do lines+=("$__l"); done < "$file" \
+            || return 1
+    fi
+    local i line
+    for (( i = 0; i < ${#lines[@]}; i++ )); do
+        line="${lines[$i]}"
+        _PAD_LINES["${file}:$((i + 1))"]="$line"
+        # Where each function is defined, recorded on the one pass rather than
+        # searched for per lookup. Searching was 440 functions times 376 lines
+        # of regex per file, which is the same shape as the greps it replaced.
+        if [[ "$line" =~ ^[[:space:]]*(function[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]*\( ]]; then
+            local n="${BASH_REMATCH[2]}"
+            [[ -n "${_PAD_AT["${file}:${n}"]:-}" ]] || _PAD_AT["${file}:${n}"]=$((i + 1))
+        fi
+    done
+    _PAD_LOADED[$file]="${#lines[@]}"
+    return 0
+}
+
+# One line of a loaded file, by number.
+_pad_line() { printf '%s' "${_PAD_LINES["${1}:${2}"]:-}"; }
+
+# Where a function is defined in a loaded file, or nothing.
+_pad_defined_at() {
+    local at="${_PAD_AT["${1}:${2}"]:-}"
+    [[ -n "$at" ]] || return 1
+    printf '%s' "$at"
+}
+
 # Extract the docblock before a function definition
 # Returns: the comment lines before the function (if any)
 get_function_docblock() {
     local file="$1"
     local func_name="$2"
-    
-    # Find the line number of the function definition
+
+    PAD_DOCBLOCK=""
+    _pad_load "$file" || return 1
+
     local func_line
-    func_line=$(grep -n "^[[:space:]]*${func_name}[[:space:]]*()[[:space:]]*{" "$file" 2>/dev/null | head -1 | cut -d: -f1)
-    
-    if [[ -z "$func_line" ]]; then
-        # Try alternate syntax
-        func_line=$(grep -n "^[[:space:]]*function[[:space:]]\+${func_name}[[:space:]]*(" "$file" 2>/dev/null | head -1 | cut -d: -f1)
-    fi
-    
-    [[ -z "$func_line" ]] && return 1
+    func_line="${_PAD_AT["${file}:${func_name}"]:-}"
+    [[ -n "$func_line" ]] || return 1
     [[ "$func_line" -lt 2 ]] && return 1
-    
+
     # Look backwards from the function definition to find comment block
-    local start_line=$((func_line - 1))
-    local docblock=""
-    local current_line=$start_line
-    
+    local docblock="" current_line=$(( func_line - 1 )) line prev
+
     while [[ $current_line -gt 0 ]]; do
-        local line
-        line=$(sed -n "${current_line}p" "$file" 2>/dev/null)
-        
-        # If line is a comment, add to docblock
-        if echo "$line" | grep -qE '^[[:space:]]*#'; then
+        line="${_PAD_LINES["${file}:${current_line}"]}"
+
+        if [[ "$line" =~ ^[[:space:]]*# ]]; then
             docblock="${line}"$'\n'"${docblock}"
-            current_line=$((current_line - 1))
-        # If line is blank, might be part of docblock, continue
+            current_line=$(( current_line - 1 ))
         elif [[ -z "${line// /}" ]]; then
-            # Check if previous line is also blank or non-comment
-            local prev_line
-            prev_line=$(sed -n "$((current_line - 1))p" "$file" 2>/dev/null)
-            if echo "$prev_line" | grep -qE '^[[:space:]]*#'; then
-                current_line=$((current_line - 1))
+            # A blank line is part of the block only when a comment is above it.
+            prev="${_PAD_LINES["${file}:$(( current_line - 1 ))"]:-}"
+            if [[ "$prev" =~ ^[[:space:]]*# ]]; then
+                current_line=$(( current_line - 1 ))
             else
                 break
             fi
         else
-            # Non-comment, non-blank line - stop
             break
         fi
     done
-    
-    echo "$docblock"
+
+    PAD_DOCBLOCK="$docblock"
+    printf '%s\n' "$docblock"
 }
 
 # Check if docblock contains an element
 docblock_has_element() {
-    local docblock="$1"
-    local element="$2"
-    
-    # Use grep -F for literal string matching (handles special chars like ->)
-    # Use -- to prevent element from being interpreted as options
-    echo "$docblock" | grep -qiF -- "$element"
+    local docblock="$1" element="$2"
+    # Literal and case-insensitive, the way `grep -qiF` was, without the two
+    # processes. `->` and the other markers carry characters a pattern would
+    # read as its own, so the needle is lowered and compared as text.
+    local hay="${docblock,,}" needle="${element,,}"
+    [[ "$hay" == *"$needle"* ]]
 }
 
 # Count comment lines in docblock
 count_doc_lines() {
-    local docblock="$1"
-    
-    echo "$docblock" | grep -cE '^[[:space:]]*#' || echo "0"
+    local docblock="$1" line n=0
+    # Counted here rather than through `echo | grep -c`, which is two processes
+    # per public function for a string this shell is already holding.
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*# ]] && n=$(( n + 1 ))
+    done <<< "$docblock"
+    printf '%s' "$n"
 }
 
 # Find all functions marked with public API annotation
@@ -144,9 +191,13 @@ find_public_api_functions() {
     name="$(attr_name_of "$PUBLIC_API_ANNOTATION")" || return
     name="${name%%$'\t'*}"
 
+    _pad_load "$file" || return
     while IFS= read -r func_name; do
         [[ -z "$func_name" ]] && continue
-        func_line=$(grep -n "^[[:space:]]*${func_name}[[:space:]]*()[[:space:]]*{" "$file" 2>/dev/null | head -1 | cut -d: -f1)
+        # Out of the loaded file rather than a `grep | head | cut`, which is
+        # three processes per public function and answers a question the file
+        # already in memory can answer.
+        func_line="$(_pad_defined_at "$file" "$func_name")" || func_line=0
         echo "${func_name}|${func_line:-0}|${rel_path}"
     done < <(attr_find "$file" "$name")
 }
@@ -189,6 +240,12 @@ test_public_api_docs() {
         
         # Find all public API functions in this file
         local public_functions
+        # Loaded here, in this shell, before anything reads it through a
+        # command substitution. A substitution is a subshell: it inherits what
+        # is already loaded and throws away anything it loads itself, so the
+        # cache below was being rebuilt once per function rather than once per
+        # file. That was most of this check's time.
+        _pad_load "$file" || true
         public_functions=$(find_public_api_functions "$file")
         
         while IFS='|' read -r func_name func_line func_file; do
@@ -197,7 +254,8 @@ test_public_api_docs() {
             
             # Get the docblock for this function
             local docblock
-            docblock=$(get_function_docblock "$file" "$func_name")
+            get_function_docblock "$file" "$func_name"
+            docblock="$PAD_DOCBLOCK"
             
             local has_error=0
             local has_warn=0

--- a/examples/checks/check_public_api_docs.sh
+++ b/examples/checks/check_public_api_docs.sh
@@ -26,6 +26,7 @@ set -uo pipefail
 
 # Load the check-runner framework (provides cfg_*, log_*, etc.)
 use check-runner
+use attr
 
 # =============================================================================
 # CONFIG-DRIVEN PARAMETERS
@@ -97,8 +98,14 @@ _pad_load() {
         # Where each function is defined, recorded on the one pass rather than
         # searched for per lookup. Searching was 440 functions times 376 lines
         # of regex per file, which is the same shape as the greps it replaced.
-        if [[ "$line" =~ ^[[:space:]]*(function[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]*\( ]]; then
-            local n="${BASH_REMATCH[2]}"
+        # `ATTR_DEFINES_PATTERN`, so this agrees with `attr` and `srcfile`
+        # about what a definition is. The pattern here was its own, and it
+        # required parentheses, so `function name {` was invisible to it: a
+        # `#[pub]` on one of those was never looked up at all and the check
+        # passed over it in silence. That is the same drift the shared pattern
+        # was made to end, in a third reader nobody moved across.
+        if [[ "$line" =~ $ATTR_DEFINES_PATTERN ]]; then
+            local n="${BASH_REMATCH[2]:-${BASH_REMATCH[3]}}"
             [[ -n "${_PAD_AT["${file}:${n}"]:-}" ]] || _PAD_AT["${file}:${n}"]=$((i + 1))
         fi
     done
@@ -164,6 +171,52 @@ docblock_has_element() {
     # read as its own, so the needle is lowered and compared as text.
     local hay="${docblock,,}" needle="${element,,}"
     [[ "$hay" == *"$needle"* ]]
+}
+
+# Whether a docblock belongs to the function it landed on.
+#
+# Attributes attach downward, so a `#[pub]` block sitting above a private
+# helper documents the helper. Where a docblock's `Usage:` names some other
+# function that is defined *later in the same file*, the block was written for
+# that one and something got inserted between them.
+#
+# Two things go wrong at once and neither is visible on its own. The named
+# function ends up undocumented, and the helper ends up marked public. Both
+# read as fine, because each of the two lines involved is correct where it sits.
+#
+# Only a `Usage:` whose first token is a bare name counts. `Usage: exit
+# "$(doctor_exit)"` is an invocation example and names `exit`, which defines
+# nothing, so it is not a mismatch.
+#
+# Prints the name the block was written for, and returns 0, when it is orphaned.
+docblock_orphaned_from() {
+    local file="$1" landed_on="$2" docblock="$3"
+    local line named at_named at_landed
+    local -a mentions=()
+
+    # Collected first, because a block may carry several `Usage:` lines and one
+    # of them naming this definition settles it. Deciding on the first line
+    # that did not match would call a two-form block an orphan of its own
+    # alternative spelling.
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*#[[:space:]]*Usage:[[:space:]]*([a-zA-Z_][a-zA-Z0-9_-]*)([[:space:]]|$) ]] \
+            || continue
+        named="${BASH_REMATCH[1]}"
+        [[ "$named" == "$landed_on" ]] && return 1
+        mentions+=("$named")
+    done <<< "$docblock"
+
+    for named in ${mentions[@]+"${mentions[@]}"}; do
+        at_named="$(_pad_defined_at "$file" "$named")" || continue
+        at_landed="$(_pad_defined_at "$file" "$landed_on")" || continue
+        # Later in the file, so the block was passed over on its way down.
+        # Earlier means the block refers back to something, which is prose.
+        [[ "$at_named" -gt "$at_landed" ]] || continue
+
+        printf '%s' "$named"
+        return 0
+    done
+    return 1
 }
 
 # Count comment lines in docblock
@@ -261,12 +314,22 @@ test_public_api_docs() {
             local has_warn=0
             local missing_required=""
             local missing_recommended=""
-            
+
+            # A block that documents a different function is worse than a
+            # missing one, because it reads as present from either end.
+            local orphan_of=""
+            if orphan_of="$(docblock_orphaned_from "$file" "$func_name" "$docblock")"; then
+                has_error=1
+                missing_required="the docblock is written for ${orphan_of}(), which is defined below this"
+            fi
+
             # Check minimum doc lines
             local doc_lines
             doc_lines=$(count_doc_lines "$docblock")
             
-            if [[ $doc_lines -lt $MIN_DOC_LINES ]]; then
+            if [[ -n "$orphan_of" ]]; then
+                : # already reported, and the count below would overwrite why
+            elif [[ $doc_lines -lt $MIN_DOC_LINES ]]; then
                 has_error=1
                 missing_required="insufficient documentation ($doc_lines lines, need $MIN_DOC_LINES)"
             else
@@ -394,6 +457,10 @@ main() {
     exit_with_status
 }
 
+# `NUT_CHECK_LOAD_ONLY` is the one way in for a test that wants the docblock
+# readers without a whole run over a repository, the same door
+# `check_function_duplication.sh` carries for the same reason.
+#
 # A check script is an entry point, so it runs.
 #
 # This used to be guarded by `[[ "${BASH_SOURCE[0]}" == "${0}" ]]`, the ordinary
@@ -403,4 +470,4 @@ main() {
 # the interpreter and `BASH_SOURCE[0]` is this file, and `main` was never
 # called. Six of the eight built-in checks exited 0 having done nothing, and
 # `./check` read that as a pass and printed one.
-main "$@"
+[[ -n "${NUT_CHECK_LOAD_ONLY:-}" ]] || main "$@"

--- a/examples/checks/check_trivial_wrappers.sh
+++ b/examples/checks/check_trivial_wrappers.sh
@@ -58,133 +58,206 @@ load_config() {
 # FUNCTION ANALYSIS
 # =============================================================================
 
+# Which functions in a file carry an exempting annotation.
+#
+# Built once per file, in the shell that runs the loop. `analyze_function` is
+# called through a command substitution, which is a subshell: anything it works
+# out is thrown away when it returns, so asking per function meant walking the
+# whole file per function, twice, and that was most of this check's time.
+declare -gA _TW_EXEMPT=()
+declare -gA _TW_EXEMPT_DONE=()
+
+tw_load_exemptions() {
+    local file="$1"
+    [[ -n "${_TW_EXEMPT_DONE[$file]:-}" ]] && return 0
+    _TW_EXEMPT_DONE[$file]=1
+    local marker name fn
+    for marker in "$(cfg_get_or "annotations.public_api" "#[pub]")" \
+                  "$(cfg_get_or "annotations.allow_trivial_wrapper_ergonomics" "DISABLED_ANNOTATION")"; do
+        [[ -n "$marker" ]] || continue
+        name="$(attr_name_of "$marker")" || continue
+        name="${name%%$'\t'*}"
+        [[ -n "$name" ]] || continue
+        while IFS= read -r fn; do
+            [[ -n "$fn" ]] && _TW_EXEMPT["${file}:${fn}"]=1
+        done < <(attr_find "$file" "$name" 2>/dev/null)
+    done
+    return 0
+}
+
 # Check if a function has an exempting annotation
-# Uses annotation patterns from config
 # Returns 0 if exempt, 1 if not
 has_exempt_annotation() {
-    local file="$1"
-    local func_name="$2"
-    
-    # Use the framework's has_trivial_wrapper_exemption which reads from config
-    has_trivial_wrapper_exemption "$file" "$func_name"
+    local file="$1" func_name="$2"
+    [[ -n "${_TW_EXEMPT_DONE[$file]:-}" ]] || return 1
+    [[ -n "${_TW_EXEMPT["${file}:${func_name}"]:-}" ]]
+}
+
+# How often every name appears, everywhere, counted once for the whole run.
+#
+# This was a `grep -c` per file per function. On 24 files and 440 functions
+# that is 10,560 greps, and `analyze_function` runs in a command substitution,
+# so nothing it worked out ever survived the return. Built here instead, in the
+# shell that runs the loop, once.
+#
+# Counts are lines-containing rather than occurrences, because that is what
+# `grep -c` gave and the thresholds were chosen against it.
+#
+# awk where there is one and the shell where there is not. This check needs awk
+# elsewhere already, so it is not a new dependency; the fallback is here so a
+# machine without it gets a slow answer rather than no answer.
+declare -gA _TW_LOCAL=()
+declare -gA _TW_GLOBAL=()
+declare -gi _TW_USAGE_DONE=0
+_TW_SEP=$'\034'
+
+_tw_count_with_awk() {
+    local key n
+    while IFS=$'\t' read -r key n; do
+        [[ -n "$key" ]] || continue
+        case "$key" in
+            G*) _TW_GLOBAL["${key#G}"]=$n ;;
+            L*) _TW_LOCAL["${key#L}"]=$n ;;
+        esac
+    done < <(get_script_files | tr '\n' '\0' | xargs -0 awk '
+        FNR == 1 { delete seen }
+        {
+            delete seen
+            line = $0
+            while (match(line, /[A-Za-z_][A-Za-z0-9_]*/)) {
+                seen[substr(line, RSTART, RLENGTH)] = 1
+                line = substr(line, RSTART + RLENGTH)
+            }
+            for (w in seen) { g[w]++; l[FILENAME "\034" w]++ }
+        }
+        END {
+            for (w in g) printf "G%s\t%d\n", w, g[w]
+            for (k in l) printf "L%s\t%d\n", k, l[k]
+        }' 2>/dev/null)
+}
+
+_tw_count_in_shell() {
+    local file line rest name n i
+    local -A onthisline=()
+    while IFS= read -r file; do
+        [[ -n "$file" ]] || continue
+        nut_load_file "$file" || continue
+        n="$(nut_file_lines "$file")"
+        for (( i = 1; i <= n; i++ )); do
+            line="$(nut_file_line "$file" "$i")"
+            onthisline=()
+            rest="$line"
+            while [[ "$rest" =~ ([A-Za-z_][A-Za-z0-9_]*) ]]; do
+                name="${BASH_REMATCH[1]}"
+                onthisline["$name"]=1
+                rest="${rest#*"$name"}"
+            done
+            for name in "${!onthisline[@]}"; do
+                _TW_GLOBAL["$name"]=$(( ${_TW_GLOBAL["$name"]:-0} + 1 ))
+                _TW_LOCAL["${file}${_TW_SEP}${name}"]=$(( ${_TW_LOCAL["${file}${_TW_SEP}${name}"]:-0} + 1 ))
+            done
+        done
+    done < <(get_script_files)
+}
+
+tw_load_usages() {
+    (( _TW_USAGE_DONE == 1 )) && return 0
+    _TW_USAGE_DONE=1
+    if command -v awk >/dev/null 2>&1 && command -v xargs >/dev/null 2>&1; then
+        _tw_count_with_awk
+    fi
+    # Nothing came back, so either there was no awk or it could not run. A
+    # count of zero everywhere would exempt every function in the library.
+    (( ${#_TW_GLOBAL[@]} == 0 )) && _tw_count_in_shell
+    return 0
 }
 
 # Count usages of a function in a specific file (excluding the definition)
 count_local_usages() {
-    local file="$1"
-    local func_name="$2"
-    
-    local count
-    count=$(grep -c "\b${func_name}\b" "$file" 2>/dev/null || echo "0")
-    count="${count//[^0-9]/}"
-    [[ -z "$count" ]] && count=0
-    
-    # Subtract 1 for the definition itself
-    count=$((count - 1))
-    [[ $count -lt 0 ]] && count=0
-    
-    echo "$count"
+    local count="${_TW_LOCAL["${1}${_TW_SEP}${2}"]:-0}"
+    count=$(( count - 1 ))
+    (( count < 0 )) && count=0
+    printf '%s' "$count"
 }
 
 # Count usages of a function across all files
 count_global_usages() {
-    local func_name="$1"
-    
-    local total=0
-    local file count
-    
-    while IFS= read -r file; do
-        count=$(grep -c "\b${func_name}\b" "$file" 2>/dev/null || echo "0")
-        count="${count//[^0-9]/}"
-        [[ -z "$count" ]] && count=0
-        total=$((total + count))
-    done < <(get_script_files)
-    
-    # Subtract 1 for the definition
-    total=$((total - 1))
-    [[ $total -lt 0 ]] && total=0
-    
-    echo "$total"
+    local total="${_TW_GLOBAL["${1:-}"]:-0}"
+    total=$(( total - 1 ))
+    (( total < 0 )) && total=0
+    printf '%s' "$total"
 }
 
 # Extract meaningful code lines from a function body
 # Excludes: comments, blank lines, local declarations, opening/closing braces
 get_meaningful_lines() {
-    local file="$1"
-    local func_name="$2"
-    
-    # Find the line number where the function starts
-    local func_line
-    func_line=$(grep -n "^[[:space:]]*${func_name}[[:space:]]*()[[:space:]]*{" "$file" 2>/dev/null | head -1 | cut -d: -f1)
-    
-    if [[ -z "$func_line" ]]; then
-        # Try alternate syntax: function name() or function name ()
-        func_line=$(grep -n "^[[:space:]]*function[[:space:]]\+${func_name}[[:space:]]*(" "$file" 2>/dev/null | head -1 | cut -d: -f1)
-    fi
-    
-    [[ -z "$func_line" ]] && return
-    
-    # Find the closing brace - simple heuristic: next line starting with }
-    # This works for most well-formatted shell functions
-    local end_line
-    end_line=$(tail -n "+$((func_line + 1))" "$file" | grep -n "^}" | head -1 | cut -d: -f1)
-    
-    if [[ -z "$end_line" ]]; then
-        # Fallback: look for } at start of line with possible whitespace
-        end_line=$(tail -n "+$((func_line + 1))" "$file" | grep -n "^[[:space:]]*}[[:space:]]*$" | head -1 | cut -d: -f1)
-    fi
-    
-    [[ -z "$end_line" ]] && return
-    
-    # Adjust end_line to be absolute (it's relative to func_line+1)
-    end_line=$((func_line + end_line))
-    
-    # Extract lines between func start and end, filter out non-meaningful lines
-    sed -n "$((func_line + 1)),$((end_line - 1))p" "$file" 2>/dev/null | \
-        grep -v '^[[:space:]]*#' | \
-        grep -v '^[[:space:]]*$' | \
-        grep -v '^[[:space:]]*local[[:space:]]' | \
-        grep -v '^[[:space:]]*readonly[[:space:]]' | \
-        grep -v '^[[:space:]]*return[[:space:]]*$' | \
-        grep -v '^[[:space:]]*return[[:space:]]\+\$?' | \
-        grep -v '^[[:space:]]*}[[:space:]]*$'
+    local -a __body=()
+    nut_body_of "$1" "$2" __body || return
+    (( ${#__body[@]} > 0 )) && printf '%s\n' "${__body[@]}"
+    return 0
 }
 
 # Count meaningful lines in a function
 count_meaningful_lines() {
-    local file="$1"
-    local func_name="$2"
-    
-    get_meaningful_lines "$file" "$func_name" | wc -l | tr -d ' '
+    local -a __body=()
+    nut_body_of "$1" "$2" __body || { printf '0'; return; }
+    printf '%s' "${#__body[@]}"
 }
 
 # Count unique variables used in function body
 count_variables_used() {
-    local file="$1"
-    local func_name="$2"
-    
-    get_meaningful_lines "$file" "$func_name" | \
-        grep -oE '\$\{?[a-zA-Z_][a-zA-Z0-9_]*' | \
-        sed 's/[${}]//g' | \
-        sort -u | \
-        wc -l | \
-        tr -d ' '
+    local -a __body=()
+    nut_body_of "$1" "$2" __body || { printf '0'; return; }
+    # A five-stage pipeline per function, in the shell instead. `grep -oE`,
+    # `sed`, `sort -u`, `wc` and `tr` is five processes to count distinct names
+    # in a handful of lines the shell is already holding.
+    local -A seen=()
+    local line rest name
+    for line in "${__body[@]}"; do
+        rest="$line"
+        while [[ "$rest" =~ \$\{?([a-zA-Z_][a-zA-Z0-9_]*) ]]; do
+            name="${BASH_REMATCH[1]}"
+            seen["$name"]=1
+            rest="${rest#*"${BASH_REMATCH[0]}"}"
+        done
+    done
+    printf '%s' "${#seen[@]}"
 }
 
 # Count tokens (complexity indicator) in function body
 count_tokens() {
-    local file="$1"
-    local func_name="$2"
-    
-    get_meaningful_lines "$file" "$func_name" | \
-        tr -s '[:space:]' '\n' | \
-        grep -v '^$' | \
-        wc -l | \
-        tr -d ' '
+    local -a __body=()
+    nut_body_of "$1" "$2" __body || { printf '0'; return; }
+    # Word splitting is the shell's own job; `tr | grep | wc | tr` is four
+    # processes to ask it.
+    local line n=0
+    local -a words=()
+    for line in "${__body[@]}"; do
+        # shellcheck disable=SC2206
+        words=($line)
+        n=$(( n + ${#words[@]} ))
+    done
+    printf '%s' "$n"
 }
 
 # Analyze a single function for trivial wrapper status
 # Returns: pass, warn, or fail
+declare -g TW_STATUS="" TW_DETAILS=""
+
+# One place that splits "status:details" into the two globals.
+_tw_set() {
+    TW_STATUS="${1%%:*}"
+    TW_DETAILS="${1#*:}"
+    return 0
+}
+
+
+# Sets TW_STATUS and TW_DETAILS rather than printing them.
+#
+# It was read through a command substitution, which is a fork, once per
+# function: 386 of them on this library and most of what the check still cost
+# after the pipelines came out. Nothing about the analysis needed a subshell;
+# it needed a return value with two parts in it.
 analyze_function() {
     local file="$1"
     local func_name="$2"
@@ -195,13 +268,13 @@ analyze_function() {
     
     # Not a trivial wrapper if more than MAX_LINES
     if [[ $line_count -gt $MAX_LINES ]]; then
-        echo "pass:not_trivial"
+        _tw_set "pass:not_trivial"
         return
     fi
     
     # Check for exempt annotation
     if has_exempt_annotation "$file" "$func_name"; then
-        echo "pass:annotated"
+        _tw_set "pass:annotated"
         return
     fi
     
@@ -213,32 +286,32 @@ analyze_function() {
     
     # Check ergonomic passes (ANY of these = pass)
     if [[ $local_usages -ge $LOCAL_USAGE_THRESHOLD ]]; then
-        echo "pass:local_usage"
+        _tw_set "pass:local_usage"
         return
     fi
     
     if [[ $global_usages -ge $GLOBAL_USAGE_THRESHOLD ]]; then
-        echo "pass:global_usage"
+        _tw_set "pass:global_usage"
         return
     fi
     
     if [[ $var_count -ge $MIN_VARS_FOR_ERGONOMIC ]]; then
-        echo "pass:ergonomic_vars"
+        _tw_set "pass:ergonomic_vars"
         return
     fi
     
     if [[ $token_count -ge $TOKEN_COMPLEXITY_PASS ]]; then
-        echo "pass:complex"
+        _tw_set "pass:complex"
         return
     fi
     
     # Warn vs fail based on token complexity
     if [[ $token_count -ge $TOKEN_COMPLEXITY_WARN ]]; then
-        echo "warn:${line_count}:${local_usages}:${global_usages}:${var_count}:${token_count}"
+        _tw_set "warn:${line_count}:${local_usages}:${global_usages}:${var_count}:${token_count}"
         return
     fi
     
-    echo "fail:${line_count}:${local_usages}:${global_usages}:${var_count}:${token_count}"
+    _tw_set "fail:${line_count}:${local_usages}:${global_usages}:${var_count}:${token_count}"
 }
 
 # Get the first meaningful line of a function (for display)
@@ -285,18 +358,43 @@ test_trivial_wrappers() {
         local file_has_issues=0
         local file_issues=""
         
+        # What this file contributed last time, if nothing that could change
+        # it has changed. One read for the whole file rather than one per
+        # function: a lookup that forks costs more than the work it saves, and
+        # the first attempt at this was measurably slower than no cache.
+        local __blob __kind __text
+        if nut_cache_hit "trivial_wrappers" "$file" 2>/dev/null \
+           && __blob="$(nut_cache_read "trivial_wrappers" "$file" 2>/dev/null)"; then
+            while IFS= read -r __line; do
+                [[ -n "$__line" ]] || continue
+                __kind="${__line%%$'\t'*}"; __text="${__line#*$'\t'}"
+                case "$__kind" in
+                    E) errors+=("$__text"); error_count=$((error_count + 1))
+                       wrapper_count=$((wrapper_count + 1)) ;;
+                    W) warnings+=("$__text"); warn_count=$((warn_count + 1))
+                       wrapper_count=$((wrapper_count + 1)) ;;
+                esac
+            done <<< "$__blob"
+            continue
+        fi
+
+
+        # In this shell, before anything reads it from a subshell.
+        nut_load_file "$file" || true
+        tw_load_exemptions "$file"
+        tw_load_usages
+
         # Get all functions in this file
         local functions
         functions=$(extract_functions "$file")
-        
+        local __record=""
+
         while IFS= read -r func_name; do
             [[ -z "$func_name" ]] && continue
             
-            local result
-            result=$(analyze_function "$file" "$func_name")
-            
-            local status="${result%%:*}"
-            local details="${result#*:}"
+            analyze_function "$file" "$func_name"
+            local status="$TW_STATUS"
+            local details="$TW_DETAILS"
             
             case "$status" in
                 pass)
@@ -320,6 +418,7 @@ test_trivial_wrappers() {
                     fi
                     
                     warnings+=("${func_name}() - ${lines} line(s), ${local_use} local / ${global_use} global usages, ${vars} vars, ${tokens} tokens")
+                    __record+="W"$'\t'"${func_name}() - ${lines} line(s), ${local_use} local / ${global_use} global usages, ${vars} vars, ${tokens} tokens"$'\n' 
                     ;;
                 fail)
                     wrapper_count=$((wrapper_count + 1))
@@ -339,10 +438,13 @@ test_trivial_wrappers() {
                     fi
                     
                     errors+=("${func_name}() - ${lines} line(s), ${local_use} local / ${global_use} global usages, ${vars} vars, ${tokens} tokens")
+                    __record+="E"$'\t'"${func_name}() - ${lines} line(s), ${local_use} local / ${global_use} global usages, ${vars} vars, ${tokens} tokens"$'\n' 
                     ;;
             esac
         done <<< "$functions"
-        
+
+        nut_cache_write "trivial_wrappers" "$file" "$__record" 2>/dev/null || true
+
         if [[ -n "$file_issues" ]] && [[ "$QUIET_MODE" != "1" ]]; then
             echo -e "$file_issues"
         fi

--- a/examples/configs/empty.nut.toml
+++ b/examples/configs/empty.nut.toml
@@ -22,7 +22,7 @@
 # key written after one belongs to that table, which is a quiet way to have a
 # pin that is never read.
 #
-#   nutshell_version = "0.3.0"    the released form
+#   nutshell_version = "0.4.0"    the released form
 #   nutshell_branch  = "dev"      when the version you need has no release yet
 #
 # Same spelling mockspace.toml uses for the same job, so a reader who knows one

--- a/find-nutshell
+++ b/find-nutshell
@@ -8,17 +8,29 @@
 # Sourced by a tool before nutshell exists, so it is plain bash and depends on
 # nothing.
 #
-# The order matters and the reason is the whole point: an installed nutshell is
-# shared by everything on the machine, and a copy inside one project is a
-# second version that drifts from it in silence. Every other package manager
-# settled this the same way. cargo keeps one shared registry and resolves the
-# toolchain separately; pnpm keeps one content-addressed store and links into
-# it; yarn 2 has no per-project tree at all. A per-project physical copy is the
-# thing that goes stale, and it went stale here twice in one day.
+# Versions coexist. A tool asks for the one it needs and gets that one, and a
+# machine carrying four of them is the ordinary state rather than a mess to
+# clean up. This is rustup's arrangement and renki's: a store of toolchains
+# keyed by version, one resolution step in front of it, and a fetch when the
+# asked-for one is not there yet.
 #
-# So: what the caller named, then what is installed, then what is vendored. The
-# vendored copy is the fallback for a machine with nothing installed, which is
-# the machine this tool is usually rescuing.
+# The order for a version pin: what the caller named, then what is installed if
+# it satisfies, then the store, then a fetch into the store, then whatever is
+# vendored. Only the last of those is a compromise, and it is there for the
+# machine with no network that this tool is usually rescuing.
+#
+# A branch pin takes a different route and it is stated here because the two
+# get conflated: what the caller named, then the branch's head, then vendored.
+# Neither the installed interpreter nor the version store can answer a branch
+# pin, so neither is consulted. Why, at `nutshell_find`.
+#
+# Preferring an installed interpreter over the store is deliberate. One shared
+# nutshell that everything uses is the good state; the store exists for the
+# tools that cannot use it, not to replace it. Every other package manager
+# settled the sharing question the same way: cargo keeps one registry and
+# resolves the toolchain separately, pnpm keeps one content-addressed store and
+# links into it, yarn 2 has no per-project tree at all. A per-project physical
+# copy is the thing that goes stale, and it went stale here twice in one day.
 #
 # Usage:
 #   . "${HERE}/find-nutshell"
@@ -64,6 +76,49 @@ _nutshell_root_of() {
 nutshell_find() {
     local root="${1:-}" want="${2:-}" cand bin
 
+    # A branch pin is not a floor, it is an identity: `dev` means the head of
+    # dev, today. Nothing already on the machine can be assumed to be that, so
+    # it is resolved against the remote first and only falls through when the
+    # remote cannot be reached. This is the shape op settled on for every other
+    # dependency, and the interpreter is not an exception to it.
+    if [[ -n "$want" ]] && ! _nutshell_is_version "$want"; then
+        # Said before anything is attempted, because the message at the bottom
+        # of this branch reports what could not be reached and nothing was.
+        # `feat/toolchains` is a legal branch name and is not a directory name
+        # here; the limit is real and it should not read as a network failure.
+        if ! _nutshell_safe_name "$want"; then
+            printf 'nutshell: %s cannot name a toolchain directory, so it cannot be pinned\n' \
+                "$want" >&2
+            printf '  a ref here is one path component: no slash, no leading dot, no space\n' >&2
+            return 1
+        fi
+        # What the caller named still wins, before the remote is asked. An
+        # override that is quietly ignored is worse than one that fails, and a
+        # test suite that exports this must not be sent to the network by every
+        # child process it starts.
+        if [[ -n "${NUTSHELL_HOME:-}" ]]; then
+            if cand="$(_nutshell_root_of "${NUTSHELL_HOME}/init")"; then
+                NUTSHELL_INIT="$cand"; NUTSHELL_FROM="NUTSHELL_HOME"
+                return 0
+            fi
+            printf 'nutshell: NUTSHELL_HOME is %s and there is no init in it\n' \
+                "$NUTSHELL_HOME" >&2
+            return 1
+        fi
+        if cand="$(_nutshell_branch "$want")"; then
+            NUTSHELL_INIT="$cand"; NUTSHELL_FROM="branch:${want}"
+            return 0
+        fi
+        if [[ -n "$root" ]] \
+           && cand="$(_nutshell_root_of "${root}/lib/nutshell/init")"; then
+            NUTSHELL_INIT="$cand"; NUTSHELL_FROM="vendored"
+            return 0
+        fi
+        printf 'nutshell: could not reach %s and there is no copy here\n' \
+            "$want" >&2
+        return 1
+    fi
+
     # 1. What the caller named. An override exists so somebody working on
     #    nutshell itself can point a tool at their checkout.
     if [[ -n "${NUTSHELL_HOME:-}" ]]; then
@@ -96,22 +151,405 @@ nutshell_find() {
                 NUTSHELL_INIT="$cand"; NUTSHELL_FROM="installed"
                 return 0
             fi
-            # Said out loud. Silently falling through to the vendored copy
-            # would hide exactly the version skew this is here to surface.
-            printf 'nutshell: the installed one at %s is %s and this needs %s; using the vendored copy\n' \
+            # Said out loud. Falling through in silence would hide exactly
+            # the version skew this is here to surface.
+            printf 'nutshell: the installed one at %s is %s and this needs %s\n' \
                 "$cand" "$(_nutshell_version_of "$cand")" "$want" >&2
         fi
     fi
 
-    # 3. What is vendored, for a machine with nothing installed.
+    # 3. The store. Several versions live here at once and the newest one that
+    #    satisfies the caller is taken, which is what makes two tools wanting
+    #    two different nutshells a non-event.
+    if cand="$(_nutshell_in_store "$want")"; then
+        NUTSHELL_INIT="$cand"; NUTSHELL_FROM="toolchain"
+        return 0
+    fi
+
+    # 4. Not there yet, so fetch it. A version that exists and is simply not on
+    #    this machine is not a failure, it is a download.
+    #
+    #    A fetch that just failed is not retried until the window is out. The
+    #    ordinary standing case is a pin at a version nobody has tagged yet,
+    #    which resolves to vendored in the end; without this it pays a network
+    #    round trip and two lines of stderr on every run of every tool.
+    if [[ -n "$want" ]] && ! _nutshell_fetch_failed_recently "$want" \
+       && cand="$(_nutshell_fetch "$want")"; then
+        NUTSHELL_INIT="$cand"; NUTSHELL_FROM="fetched"
+        return 0
+    fi
+
+    # 5. What is vendored, for a machine with no network and nothing installed.
     if [[ -n "$root" ]] && cand="$(_nutshell_root_of "${root}/lib/nutshell/init")"; then
         NUTSHELL_INIT="$cand"; NUTSHELL_FROM="vendored"
         return 0
     fi
 
-    printf 'nutshell: no interpreter found. Install one, set NUTSHELL_HOME, or run:\n' >&2
-    printf '  git submodule update --init\n' >&2
+    # Named in the order somebody would actually reach for them. The submodule
+    # advice that used to be here assumed every consumer vendored a checkout,
+    # which is the arrangement this file exists to make unnecessary.
+    printf 'nutshell: nothing here satisfies %s. Any of:\n' "${want:-any version}" >&2
+    printf '  NUTSHELL_HOME=/path/to/a/nutshell   point at a checkout\n' >&2
+    printf '  install one on PATH                 shared by everything\n' >&2
+    printf '  tag %s on the remote              so it can be fetched\n' "${want:-the version}" >&2
     return 1
+}
+
+# Does this name a version, or a branch? Versions are digits and dots, so
+# anything else is a ref. `0.4.0` and `dev` are the two shapes a pin takes.
+_nutshell_is_version() {
+    [[ "${1:-}" =~ ^[0-9]+(\.[0-9]+)*$ ]]
+}
+
+# The revision this branch was last resolved to, or nothing.
+_nutshell_branch_head() {
+    local pointer="${1}/.head" sha=""
+    [[ -r "$pointer" ]] || return 1
+    read -r sha < "$pointer" 2>/dev/null
+    [[ "$sha" =~ ^[0-9a-f]{7,40}$ ]] || return 1
+    printf '%s' "$sha"
+}
+
+# Throw away revisions of this branch that nothing has touched for a day.
+#
+# The checkouts are keyed by revision and never overwritten, so they would
+# otherwise accumulate one directory per push. A day is long enough that
+# nothing can still be sourcing out of one: resolution takes milliseconds and
+# the window it resolves inside is an hour.
+_nutshell_branch_prune() {
+    local base="$1" keep="$2" d name
+    for d in "$base"/*/; do
+        [[ -d "$d" ]] || continue
+        name="${d%/}"; name="${name##*/}"
+        [[ "$name" == "$keep" ]] && continue
+        [[ "$name" =~ ^[0-9a-f]{7,40}$ ]] || continue
+        # `find -mtime +0` is a whole day, and it is the one age test that is
+        # in POSIX. A machine without find keeps the directory, which is the
+        # harmless way to be wrong here.
+        [[ -n "$(find "$base" -maxdepth 1 -name "$name" -mtime +0 2>/dev/null)" ]] \
+            && rm -rf "${d%/}"
+    done
+    return 0
+}
+
+# The head of a branch, as a checkout in the store, refreshed when it moves.
+#
+# Kept under `branches/` so it cannot collide with the version directories,
+# whose names are checked against their own contents. A branch checkout has no
+# such invariant: the version inside it changes whenever the branch does, and
+# that is the point of pinning one.
+#
+# Under `branches/<ref>/` the checkouts are keyed by the revision they hold,
+# and `.head` names the one the branch last resolved to. That is what makes the
+# store safe to share: a revision directory is written once and never replaced,
+# so a fetch triggered by somebody else's push cannot delete the tree a running
+# interpreter is sourcing out of. It is also the shape the pin design calls for,
+# where a branch has already become the revision it pointed at before anything
+# is looked up.
+#
+# The remote is asked at most once an hour. A pin that means "the head" and
+# checks on every invocation turns a shell prompt into a network client; one
+# that never checks is not a branch pin at all.
+_nutshell_branch() {
+    local ref="$1" base stamp remote head now last known
+    _nutshell_safe_name "$ref" || return 1
+    base="$(nutshell_toolchain_dir)/branches/${ref}"
+    stamp="${base}/.checked"
+    remote="${NUTSHELL_REMOTE:-https://github.com/orgrinrt/nutshell.git}"
+
+    now="$(date +%s 2>/dev/null)" || now=0
+    last=0
+    [[ -r "$stamp" ]] && read -r last < "$stamp" 2>/dev/null
+    [[ "$last" =~ ^[0-9]+$ ]] || last=0
+    known="$(_nutshell_branch_head "$base")" || known=""
+
+    # Inside the window, what is here is what the pin means.
+    if [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]] \
+       && (( now - last < ${NUTSHELL_BRANCH_TTL:-3600} )); then
+        printf '%s' "${base}/${known}/init"
+        return 0
+    fi
+
+    command -v git >/dev/null 2>&1 || {
+        [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]] \
+            && { printf '%s' "${base}/${known}/init"; return 0; }
+        return 1
+    }
+
+    head="$(git ls-remote "$remote" "refs/heads/${ref}" 2>/dev/null)"
+    head="${head%%[[:space:]]*}"
+    if [[ ! "$head" =~ ^[0-9a-f]{7,40}$ ]]; then
+        # Offline, or no such branch. What is already here is better than
+        # nothing, and the revision it is running from is named rather than
+        # pretended about.
+        if [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]]; then
+            printf 'nutshell: could not reach %s, running %s from %s\n' \
+                "$remote" "$ref" "${known:0:12}" >&2
+            printf '%s' "${base}/${known}/init"
+            return 0
+        fi
+        return 1
+    fi
+
+    # Already fetched, whether or not this process is the one that fetched it.
+    if [[ -f "${base}/${head}/init" ]]; then
+        mkdir -p "$base" 2>/dev/null \
+            && { printf '%s\n' "$now" > "$stamp"; printf '%s\n' "$head" > "${base}/.head"; }
+        printf '%s' "${base}/${head}/init"
+        return 0
+    fi
+
+    mkdir -p "$base" 2>/dev/null || return 1
+    local tmp="${base}/.fetching.$$"
+    rm -rf "$tmp"
+    printf 'nutshell: %s moved, fetching\n' "$ref" >&2
+    if ! git clone --quiet --depth 1 --branch "$ref" "$remote" "$tmp" 2>/dev/null; then
+        rm -rf "$tmp"
+        [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]] \
+            && { printf '%s' "${base}/${known}/init"; return 0; }
+        return 1
+    fi
+
+    # The clone is named by what it actually holds, not by what the remote said
+    # a moment ago. A branch that moved between the two would otherwise be
+    # stored under a revision it does not contain.
+    local got; got="$(git -C "$tmp" rev-parse HEAD 2>/dev/null)"
+    [[ "$got" =~ ^[0-9a-f]{7,40}$ ]] || got="$head"
+
+    if ! _nutshell_adopt "$tmp" "${base}/${got}"; then
+        [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]] \
+            && { printf '%s' "${base}/${known}/init"; return 0; }
+        return 1
+    fi
+    printf '%s\n' "$now" > "$stamp"
+    printf '%s\n' "$got" > "${base}/.head"
+    _nutshell_branch_prune "$base" "$got"
+    printf '%s' "${base}/${got}/init"
+}
+
+#[pub]
+# The root both the toolchains and the externs sit under.
+#
+# The platform branch is spelled out here rather than taken from `lib/xdg.sh`,
+# which is the module that owns it. This file runs before nutshell exists and
+# cannot use a module, so the duplication is deliberate and the two are held
+# together by a test rather than by anybody remembering. Change one and the
+# suite says which other one to change.
+# Usage: nutshell_store_root -> a path
+nutshell_store_root() {
+    if [[ -n "${NUTSHELL_STORE:-}" ]]; then
+        printf '%s' "${NUTSHELL_STORE%/}"
+        return 0
+    fi
+    if [[ -n "${XDG_DATA_HOME:-}" ]]; then
+        printf '%s/nutshell' "${XDG_DATA_HOME%/}"
+        return 0
+    fi
+    case "$(uname -s 2>/dev/null)" in
+        Darwin) printf '%s/Library/Application Support/nutshell' "${HOME:-.}" ;;
+        *)      printf '%s/.local/share/nutshell' "${HOME:-.}" ;;
+    esac
+}
+
+#[pub]
+# Where toolchains live. One directory per version, each a checkout.
+#
+# Beside the externs, under the one root, because the interpreter is a
+# dependency like any other and giving it its own arrangement is what let it
+# drift out of step in the first place.
+# Usage: nutshell_toolchain_dir -> a path
+nutshell_toolchain_dir() {
+    if [[ -n "${NUTSHELL_TOOLCHAINS:-}" ]]; then
+        printf '%s' "${NUTSHELL_TOOLCHAINS%/}"
+        return 0
+    fi
+    printf '%s/toolchains' "$(nutshell_store_root)"
+}
+
+#[pub]
+# Every version in the store, newest first, one per line.
+#
+# A directory is named by the version it holds, and one whose contents report
+# something else is skipped rather than trusted. The name is what the resolver
+# looks things up by, so a directory that lies about itself would be handed
+# out for a request it does not satisfy.
+# Usage: nutshell_toolchains -> prints versions
+nutshell_toolchains() {
+    local store d v name
+    store="$(nutshell_toolchain_dir)"
+    [[ -d "$store" ]] || return 0
+    for d in "$store"/*/; do
+        [[ -f "${d}init" ]] || continue
+        name="${d%/}"; name="${name##*/}"
+        v="$(_nutshell_version_of "${d}init")" || continue
+        [[ "$v" == "$name" ]] || continue
+        printf '%s\n' "$v"
+    done | _nutshell_sort_versions
+}
+
+# Newest first. Sorting fields rather than strings, because 0.10.0 is newer
+# than 0.9.0 and every string comparison says otherwise.
+_nutshell_sort_versions() {
+    local v a b c rest
+    while IFS= read -r v; do
+        [[ -n "$v" ]] || continue
+        IFS=. read -r a b c rest <<< "$v"
+        printf '%05d.%05d.%05d\t%s\n' \
+            "$(_nutshell_num "${a:-}")" \
+            "$(_nutshell_num "${b:-}")" \
+            "$(_nutshell_num "${c:-}")" \
+            "$v"
+    done | sort -r | cut -f2-
+}
+
+# One version field as a number. Anything from the first non-digit onward is
+# dropped, so a malformed field cannot abort the whole listing on an arithmetic
+# error.
+#
+# It does not order prereleases and is not trying to. **The store is
+# release-only.** `nutshell_toolchains` skips a directory whose name is not what
+# the interpreter inside it reports, `_nutshell_version_of` reads that report as
+# digits and dots, and `_nutshell_fetch` refuses to store anything whose report
+# disagrees with the name asked for. So `0.4.0-rc1` cannot become a directory
+# here and there is nothing for an ordering to be wrong about. This is a guard
+# against a malformed name, and the tests say so.
+_nutshell_num() {
+    local n="${1:-}"
+    n="${n%%[!0-9]*}"
+    printf '%d' "$(( 10#${n:-0} ))"
+}
+
+# The newest toolchain satisfying the caller, or nothing.
+_nutshell_in_store() {
+    local want="${1:-}" store v cand
+    store="$(nutshell_toolchain_dir)"
+    [[ -d "$store" ]] || return 1
+    while IFS= read -r v; do
+        [[ -n "$v" ]] || continue
+        cand="$(_nutshell_root_of "${store}/${v}/init")" || continue
+        _nutshell_satisfies "$cand" "$want" && { printf '%s' "$cand"; return 0; }
+    done < <(nutshell_toolchains)
+    return 1
+}
+
+# Is a name safe to build a store path out of?
+#
+# Everything under the store is named by something a caller supplied, and the
+# store is then written to and removed from. A ref carrying a slash or a dot
+# pair is not a directory name here, whatever git thinks of it.
+_nutshell_safe_name() {
+    local n="${1:-}"
+    [[ -n "$n" ]] || return 1
+    case "$n" in
+        */*|*..*|.*|*[[:space:]]*) return 1 ;;
+    esac
+    return 0
+}
+
+# Where a failed fetch is remembered, so the next run does not repeat it.
+_nutshell_fail_stamp() {
+    printf '%s/failed/%s' "$(nutshell_toolchain_dir)" "$1"
+}
+
+# Did fetching this fail recently enough that trying again is just noise?
+#
+# The window is the branch one, for the same reason: a pin that cannot be
+# satisfied is the standing state until somebody pushes a tag, and asking the
+# remote about it on every invocation turns a shell prompt into a network
+# client.
+_nutshell_fetch_failed_recently() {
+    local want="${1:-}" stamp now last
+    _nutshell_safe_name "$want" || return 1
+    stamp="$(_nutshell_fail_stamp "$want")"
+    [[ -r "$stamp" ]] || return 1
+    now="$(date +%s 2>/dev/null)" || return 1
+    last=0
+    read -r last < "$stamp" 2>/dev/null
+    [[ "$last" =~ ^[0-9]+$ ]] || return 1
+    (( now - last < ${NUTSHELL_FETCH_RETRY:-3600} ))
+}
+
+# Remember that fetching this failed, so the window above has something to read.
+_nutshell_remember_failure() {
+    local want="${1:-}" stamp now
+    _nutshell_safe_name "$want" || return 0
+    stamp="$(_nutshell_fail_stamp "$want")"
+    mkdir -p "${stamp%/*}" 2>/dev/null || return 0
+    now="$(date +%s 2>/dev/null)" || now=0
+    printf '%s\n' "$now" > "$stamp" 2>/dev/null || true
+}
+
+# Put a version in the store and print its root.
+#
+# Shallow, at the tag, from wherever the caller says nutshell lives. A failure
+# here is ordinary: no git, no network, or a version nobody has tagged yet. It
+# says which, remembers it, and falls through to whatever else the machine has.
+_nutshell_fetch() {
+    local want="$1" store dir remote
+    _nutshell_safe_name "$want" || {
+        printf 'nutshell: %s is not a name a toolchain can be stored under\n' \
+            "$want" >&2
+        return 1
+    }
+    store="$(nutshell_toolchain_dir)"
+    dir="${store}/${want}"
+    remote="${NUTSHELL_REMOTE:-https://github.com/orgrinrt/nutshell.git}"
+
+    command -v git >/dev/null 2>&1 || {
+        printf 'nutshell: %s is not on this machine and there is no git to fetch it with\n' \
+            "$want" >&2
+        _nutshell_remember_failure "$want"
+        return 1
+    }
+
+    mkdir -p "$store" 2>/dev/null || return 1
+    # Into a scratch directory and moved into place, so an interrupted clone
+    # never leaves a half a toolchain behind for the next run to find and
+    # believe.
+    local tmp="${dir}.fetching.$$"
+    rm -rf "$tmp"
+    printf 'nutshell: fetching %s\n' "$want" >&2
+    if ! git clone --quiet --depth 1 --branch "$want" "$remote" "$tmp" 2>/dev/null; then
+        rm -rf "$tmp"
+        printf 'nutshell: could not fetch %s from %s\n' "$want" "$remote" >&2
+        _nutshell_remember_failure "$want"
+        return 1
+    fi
+
+    # What arrived has to be the version that was asked for. A tag that moved,
+    # or a branch name that happens to look like a version, would otherwise be
+    # stored under a name that lies about its contents.
+    local got; got="$(_nutshell_version_of "${tmp}/init")"
+    if [[ "$got" != "$want" ]]; then
+        rm -rf "$tmp"
+        printf 'nutshell: %s in %s reports itself as %s\n' "$want" "$remote" "${got:-nothing}" >&2
+        _nutshell_remember_failure "$want"
+        return 1
+    fi
+
+    _nutshell_adopt "$tmp" "$dir" || return 1
+    printf '%s' "${dir}/init"
+}
+
+# Move a fetched copy into place, or keep the one that beat us to it.
+#
+# Whoever gets there first wins and the loser throws its own copy away. The
+# store is shared by every project on the machine and nothing locks it, so a
+# second process fetching the same thing must not remove the directory a
+# running interpreter is sourcing out of. It does not have to: both copies hold
+# the same commit, so adopting the one already there is the same answer.
+#
+# `mv` onto a name that does not exist is a rename and atomic. Onto a directory
+# that does exist it moves the source *inside* it, which is the whole reason
+# this is a function: the check and the rename are not one step, so a loser can
+# still land its copy at `<dir>/<scratch>` and that gets cleaned up here.
+_nutshell_adopt() {
+    local tmp="$1" dir="$2" leaf="${1##*/}"
+    if [[ ! -e "$dir" ]]; then
+        mv "$tmp" "$dir" 2>/dev/null
+    fi
+    rm -rf "${dir}/${leaf}" "$tmp" 2>/dev/null
+    [[ -f "${dir}/init" ]]
 }
 
 # The version an interpreter reports, without loading it. Reading the file

--- a/find-nutshell
+++ b/find-nutshell
@@ -49,17 +49,28 @@ _nutshell_root_of() {
     return 1
 }
 
-# Find an interpreter. Sets NUTSHELL_INIT and NUTSHELL_FROM.
+# Find an interpreter that satisfies the caller. Sets NUTSHELL_INIT and
+# NUTSHELL_FROM.
 #
 # `<vendored-root>` is the project root, and the vendored copy is looked for at
-# `<root>/lib/nutshell/init`.
+# `<root>/lib/nutshell/init`. `<minimum>` is the oldest version the caller can
+# use, and a candidate older than it is skipped rather than taken.
+#
+# Skipped rather than taken is the whole of it. Preferring an installed
+# interpreter is right; preferring one that cannot run the caller is not, and
+# taking it and failing afterwards is how a tool ends up reporting a missing
+# function instead of a version. This is what rustup does for cargo: resolve to
+# something that satisfies the requirement, not to whichever came first.
 nutshell_find() {
-    local root="${1:-}" cand bin
+    local root="${1:-}" want="${2:-}" cand bin
 
     # 1. What the caller named. An override exists so somebody working on
     #    nutshell itself can point a tool at their checkout.
     if [[ -n "${NUTSHELL_HOME:-}" ]]; then
         if cand="$(_nutshell_root_of "${NUTSHELL_HOME}/init")"; then
+            # What the caller named is taken even when it is too old. An
+            # override that is quietly ignored is worse than one that fails,
+            # and somebody working on nutshell itself needs it honoured.
             NUTSHELL_INIT="$cand"; NUTSHELL_FROM="NUTSHELL_HOME"
             return 0
         fi
@@ -81,8 +92,14 @@ nutshell_find() {
             seen=$(( seen + 1 ))
         done
         if cand="$(_nutshell_root_of "$(cd "$(dirname "$bin")/.." && pwd)/init")"; then
-            NUTSHELL_INIT="$cand"; NUTSHELL_FROM="installed"
-            return 0
+            if _nutshell_satisfies "$cand" "$want"; then
+                NUTSHELL_INIT="$cand"; NUTSHELL_FROM="installed"
+                return 0
+            fi
+            # Said out loud. Silently falling through to the vendored copy
+            # would hide exactly the version skew this is here to surface.
+            printf 'nutshell: the installed one at %s is %s and this needs %s; using the vendored copy\n' \
+                "$cand" "$(_nutshell_version_of "$cand")" "$want" >&2
         fi
     fi
 
@@ -95,6 +112,47 @@ nutshell_find() {
     printf 'nutshell: no interpreter found. Install one, set NUTSHELL_HOME, or run:\n' >&2
     printf '  git submodule update --init\n' >&2
     return 1
+}
+
+# The version an interpreter reports, without loading it. Reading the file
+# rather than sourcing it, because a candidate that is about to be rejected must
+# not be allowed to run first.
+_nutshell_version_of() {
+    local init="$1" line
+    [[ -r "$init" ]] || return 1
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        case "$line" in
+            *NUTSHELL_VERSION=*)
+                line="${line#*NUTSHELL_VERSION=}"
+                # The quotes come off first: trimming at the first character
+                # that is not a digit or a dot would trim at the opening quote
+                # and answer with nothing.
+                line="${line#[\"\']}"
+                line="${line%%[!0-9.]*}"
+                [[ -n "$line" ]] || continue
+                printf '%s' "$line"; return 0 ;;
+        esac
+    done < "$init"
+    return 1
+}
+
+# Is this candidate new enough? No minimum means anything will do.
+_nutshell_satisfies() {
+    local init="$1" want="${2:-}" have
+    [[ -n "$want" ]] || return 0
+    have="$(_nutshell_version_of "$init")" || return 1
+    local -a w h
+    IFS=. read -r -a w <<< "$want"
+    IFS=. read -r -a h <<< "$have"
+    local i wi hi
+    for i in 0 1 2; do
+        wi="${w[$i]:-0}"; hi="${h[$i]:-0}"
+        [[ "$wi" =~ ^[0-9]+$ ]] || wi=0
+        [[ "$hi" =~ ^[0-9]+$ ]] || hi=0
+        (( hi > wi )) && return 0
+        (( hi < wi )) && return 1
+    done
+    return 0
 }
 
 # Refuse an interpreter older than the tool needs.

--- a/find-nutshell
+++ b/find-nutshell
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/find-nutshell - Where the interpreter is, in preference order
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# Sourced by a tool before nutshell exists, so it is plain bash and depends on
+# nothing.
+#
+# The order matters and the reason is the whole point: an installed nutshell is
+# shared by everything on the machine, and a copy inside one project is a
+# second version that drifts from it in silence. Every other package manager
+# settled this the same way. cargo keeps one shared registry and resolves the
+# toolchain separately; pnpm keeps one content-addressed store and links into
+# it; yarn 2 has no per-project tree at all. A per-project physical copy is the
+# thing that goes stale, and it went stale here twice in one day.
+#
+# So: what the caller named, then what is installed, then what is vendored. The
+# vendored copy is the fallback for a machine with nothing installed, which is
+# the machine this tool is usually rescuing.
+#
+# Usage:
+#   . "${HERE}/find-nutshell"
+#   nutshell_find "$HERE" || exit 1
+#   . "$NUTSHELL_INIT"
+# =============================================================================
+
+# Where the init was found, and how.
+NUTSHELL_INIT=""
+NUTSHELL_FROM=""
+
+# The root of a nutshell given its `init`, or nothing when that file is not one.
+_nutshell_root_of() {
+    [[ -f "${1:-}" ]] || return 1
+    # `init` alone is not proof: a tool with its own file of that name would be
+    # sourced and would fail somewhere less obvious.
+    #
+    # Read in the shell rather than through grep. This runs before anything is
+    # set up, on a machine that may be broken in ways that include its PATH,
+    # and a resolver that needs a tool to find the interpreter is a resolver
+    # that fails exactly when it is needed.
+    local line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        case "$line" in
+            *NUTSHELL_VERSION*) printf '%s' "$1"; return 0 ;;
+        esac
+    done < "$1"
+    return 1
+}
+
+# Find an interpreter. Sets NUTSHELL_INIT and NUTSHELL_FROM.
+#
+# `<vendored-root>` is the project root, and the vendored copy is looked for at
+# `<root>/lib/nutshell/init`.
+nutshell_find() {
+    local root="${1:-}" cand bin
+
+    # 1. What the caller named. An override exists so somebody working on
+    #    nutshell itself can point a tool at their checkout.
+    if [[ -n "${NUTSHELL_HOME:-}" ]]; then
+        if cand="$(_nutshell_root_of "${NUTSHELL_HOME}/init")"; then
+            NUTSHELL_INIT="$cand"; NUTSHELL_FROM="NUTSHELL_HOME"
+            return 0
+        fi
+        printf 'nutshell: NUTSHELL_HOME is %s and there is no init in it\n' \
+            "$NUTSHELL_HOME" >&2
+        return 1
+    fi
+
+    # 2. What is installed. Followed through its links, because the launcher on
+    #    PATH is usually a link into a checkout and the init sits beside it.
+    if bin="$(command -v nutshell 2>/dev/null)"; then
+        local seen=0
+        while [[ -L "$bin" ]] && (( seen < 20 )); do
+            local target; target="$(readlink "$bin")"
+            case "$target" in
+                /*) bin="$target" ;;
+                *)  bin="$(cd "$(dirname "$bin")" && pwd)/${target}" ;;
+            esac
+            seen=$(( seen + 1 ))
+        done
+        if cand="$(_nutshell_root_of "$(cd "$(dirname "$bin")/.." && pwd)/init")"; then
+            NUTSHELL_INIT="$cand"; NUTSHELL_FROM="installed"
+            return 0
+        fi
+    fi
+
+    # 3. What is vendored, for a machine with nothing installed.
+    if [[ -n "$root" ]] && cand="$(_nutshell_root_of "${root}/lib/nutshell/init")"; then
+        NUTSHELL_INIT="$cand"; NUTSHELL_FROM="vendored"
+        return 0
+    fi
+
+    printf 'nutshell: no interpreter found. Install one, set NUTSHELL_HOME, or run:\n' >&2
+    printf '  git submodule update --init\n' >&2
+    return 1
+}
+
+# Refuse an interpreter older than the tool needs.
+#
+# A refusal naming the version, at startup, rather than a missing function
+# somewhere in the middle of a run. That is the whole difference between this
+# and `declare -F thing >/dev/null || skip` at forty call sites: the guard is
+# what a project writes when it does not know what version it has.
+#
+# Versions are `x.y.z` and compared piece by piece, so `0.10.0` is newer than
+# `0.9.0` rather than older, which is what a text compare would say.
+nutshell_at_least() {
+    local want="${1:-}" have="${NUTSHELL_VERSION:-0.0.0}"
+    [[ -n "$want" ]] || return 0
+
+    local -a w h
+    IFS=. read -r -a w <<< "$want"
+    IFS=. read -r -a h <<< "$have"
+    local i wi hi
+    for i in 0 1 2; do
+        wi="${w[$i]:-0}"; hi="${h[$i]:-0}"
+        [[ "$wi" =~ ^[0-9]+$ ]] || wi=0
+        [[ "$hi" =~ ^[0-9]+$ ]] || hi=0
+        (( hi > wi )) && return 0
+        (( hi < wi )) && {
+            printf 'nutshell %s is here and this needs %s or newer.\n' "$have" "$want" >&2
+            printf 'It came from: %s (%s)\n' "${NUTSHELL_INIT:-unknown}" "${NUTSHELL_FROM:-unknown}" >&2
+            return 1
+        }
+    done
+    return 0
+}

--- a/find-nutshell
+++ b/find-nutshell
@@ -5,8 +5,10 @@
 # Part of nutshell - Everything you need, in a nutshell.
 # https://github.com/orgrinrt/nutshell
 #
-# Sourced by a tool before nutshell exists, so it is plain bash and depends on
-# nothing.
+# Sourced by a tool before nutshell exists, so it is plain bash and uses no
+# nutshell module. It does call `git`, `date`, `uname` and the ordinary file
+# tools; fetching an interpreter is what it is for. What it must not have is a
+# dependency on the thing it is looking for.
 #
 # Versions coexist. A tool asks for the one it needs and gets that one, and a
 # machine carrying four of them is the ordinary state rather than a mess to
@@ -42,7 +44,13 @@
 NUTSHELL_INIT=""
 NUTSHELL_FROM=""
 
-# The root of a nutshell given its `init`, or nothing when that file is not one.
+# An `init` path, given one, when the file at it really is a nutshell's.
+#
+# Named `_nutshell_root_of` and documented as returning the root. It returns
+# the init path, and every caller assigns it to `NUTSHELL_INIT`, so the
+# behaviour was right and the name and the comment were both false. Left named
+# this way rather than renamed here: this file is copied verbatim into
+# consumers and a rename is a change every copy has to take at once.
 _nutshell_root_of() {
     [[ -f "${1:-}" ]] || return 1
     # `init` alone is not proof: a tool with its own file of that name would be
@@ -210,12 +218,21 @@ _nutshell_branch_head() {
     printf '%s' "$sha"
 }
 
-# Throw away revisions of this branch that nothing has touched for a day.
+# Throw away revisions of this branch that nothing has used for a day.
 #
-# The checkouts are keyed by revision and never overwritten, so they would
-# otherwise accumulate one directory per push. A day is long enough that
-# nothing can still be sourcing out of one: resolution takes milliseconds and
-# the window it resolves inside is an hour.
+# **Used, not fetched.** Reading files inside a directory does not move its
+# mtime, so age alone measures time since the fetch, and modules load lazily
+# through `use` at call time: a program holds its revision for its whole run.
+# A TUI or a watch loop started three days ago, still running, was `rm -rf`'d
+# out from under itself by any other process that fetched a new head, and every
+# later `use` in it then failed.
+#
+# So resolution touches the directory it hands back, and the age below is time
+# since something last resolved to it. That is a `touch` per resolution, inside
+# the hour-long window, against a delete that breaks a running program.
+#
+# A day is then long enough: it means nothing has *started* using this revision
+# for a day, and a program that started before that has been touching it.
 _nutshell_branch_prune() {
     local base="$1" keep="$2" d name
     for d in "$base"/*/; do
@@ -266,6 +283,8 @@ _nutshell_branch() {
     # Inside the window, what is here is what the pin means.
     if [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]] \
        && (( now - last < ${NUTSHELL_BRANCH_TTL:-3600} )); then
+        # Touched so the prune can tell time-since-use from time-since-fetch.
+        touch "${base}/${known}" 2>/dev/null
         printf '%s' "${base}/${known}/init"
         return 0
     fi
@@ -285,6 +304,7 @@ _nutshell_branch() {
         if [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]]; then
             printf 'nutshell: could not reach %s, running %s from %s\n' \
                 "$remote" "$ref" "${known:0:12}" >&2
+            touch "${base}/${known}" 2>/dev/null
             printf '%s' "${base}/${known}/init"
             return 0
         fi
@@ -295,6 +315,7 @@ _nutshell_branch() {
     if [[ -f "${base}/${head}/init" ]]; then
         mkdir -p "$base" 2>/dev/null \
             && { printf '%s\n' "$now" > "$stamp"; printf '%s\n' "$head" > "${base}/.head"; }
+        touch "${base}/${head}" 2>/dev/null
         printf '%s' "${base}/${head}/init"
         return 0
     fi

--- a/init
+++ b/init
@@ -43,8 +43,14 @@ export PATH="${_NUTSHELL_ROOT}/bin:$PATH"
 # Module tracking
 # =============================================================================
 
-# Track loaded modules to avoid double-sourcing
+# What has been loaded, keyed by the file rather than by the words that asked
+# for it. One module is reachable by several names: its own unit calls it
+# `super::tui::key`, a consumer calls it `shebang::tui::key`, and both are the
+# same file. Keyed by the spelling, each of those loaded it again, and a module
+# without a guard of its own ran twice.
 declare -gA _NUTSHELL_LOADED=() 2>/dev/null || declare -A _NUTSHELL_LOADED=()
+# The names that reached each file, so `nutshell_loaded <name>` still answers.
+declare -gA _NUTSHELL_LOADED_AS=() 2>/dev/null || declare -A _NUTSHELL_LOADED_AS=()
 
 # nut_once
 #
@@ -57,9 +63,19 @@ declare -gA _NUTSHELL_LOADED=() 2>/dev/null || declare -A _NUTSHELL_LOADED=()
 # reads as "carry on, or stop".
 nut_once() {
     local src="${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
+    # Canonical, and the same canonical `use` keys on. Keyed on the raw string
+    # instead, a file loaded through the resolver and then sourced again by a
+    # relative path was two different keys, so the second load ran: for a
+    # module whose functions are lazy stubs, that reinstalls the stubs over the
+    # bindings an implementation had already made, and the stub then calls
+    # itself until the stack dies.
+    src="$(_nut_realpath "$src" 2>/dev/null || printf '%s' "$src")"
     local key="_NUT_ONCE_${src//[^A-Za-z0-9]/_}"
     [[ -n "${!key:-}" ]] && return 1
     printf -v "$key" '%s' 1
+    # What `use` knows and what this knows are the same fact, so record it
+    # where `use` looks as well.
+    _NUTSHELL_LOADED[$src]=1
     return 0
 }
 
@@ -89,54 +105,65 @@ nut_once() {
 use() {
     local mod
     for mod in "$@"; do
-        # Skip if already loaded
-        [[ -n "${_NUTSHELL_LOADED[$mod]:-}" ]] && continue
-        
-        # Find and source the module
-        # A namespaced module comes from a library declared in nut.toml, so
-        # resolution goes through extern rather than nutshell's own lib.
-        local mod_path
-        if [[ "$mod" == super::* ]]; then
-            # This unit's own library. `super::` is the only way a project
-            # reaches a module it wrote itself, because a bare `use` resolves
-            # nutshell's set and a namespaced one resolves a declared
-            # dependency, and a unit is neither of those to itself.
-            #
-            # Anchored on the unit's manifest rather than on the entry point,
-            # so a module three directories down reaches `lib/` the same way
-            # the entry script does and moving the entry script changes
-            # nothing.
-            # BASH_SOURCE[1] is the file that called `use`, which is the unit
-            # this `super::` belongs to. BASH_SOURCE[0] is `init` itself, and
-            # NUTSHELL_SCRIPT_DIR is the entry point; neither answers "which
-            # unit is asking".
-            local _caller="${BASH_SOURCE[1]:-}"
-            local _from
-            if [[ -n "$_caller" && "$_caller" == */* ]]; then
-                _from="$(cd "${_caller%/*}" 2>/dev/null && pwd)"
-            else
-                _from="$PWD"
-            fi
-            mod_path="$(_use_super_resolve "${mod#super::}" "$_from")" || return 1
-        elif [[ "$mod" == *"::"* ]]; then
-            use extern || return 1
-            mod_path="$(extern_resolve "$mod")" || return 1
-        else
-            mod_path="${_NUTSHELL_ROOT}/lib/${mod}.sh"
+        # A name already known to point at a loaded file, answered without
+        # touching the filesystem.
+        #
+        # Not for `super::`, which is relative to whoever wrote it: two units
+        # each with their own lib/guard.sh both say `super::guard` and mean
+        # different files. Cached globally, the second unit's `use` matched the
+        # first unit's entry, loaded nothing, and returned 0 -- the module
+        # simply was not there, and nothing said so.
+        if [[ "$mod" != super::* ]]; then
+            [[ -n "${_NUTSHELL_LOADED_AS[$mod]:-}" ]] && continue
         fi
+        
+        # Where it is. One resolver, so `use` and `nut_reload` cannot come to
+        # different conclusions about what a name means.
+        #
+        # BASH_SOURCE[1] is the file that wrote the `use`, which is the unit a
+        # `super::` belongs to. BASH_SOURCE[0] is init itself and
+        # NUTSHELL_SCRIPT_DIR is the entry point; neither answers "which unit
+        # is asking".
+        local mod_path
+        mod_path="$(_use_resolve "$mod" "${BASH_SOURCE[1]:-}")" || return 1
+
         if [[ -f "$mod_path" ]]; then
+            # The file decides identity, so a module reached by two names is
+            # loaded once. Canonical, because a relative path and an absolute
+            # one naming the same file are the same module.
+            local _real
+            _real="$(_nut_realpath "$mod_path")" || _real="$mod_path"
+
+            if [[ -n "${_NUTSHELL_LOADED[$_real]:-}" ]]; then
+                # Recorded under a key that carries the unit, so one unit's
+                # answer is never handed to another's question.
+                if [[ "$mod" == super::* ]]; then
+                    _NUTSHELL_LOADED_AS["${_real}::${mod}"]="$_real"
+                else
+                    _NUTSHELL_LOADED_AS[$mod]="$_real"
+                fi
+                continue
+            fi
+
             # Marked before sourcing, not after. A module that declares its own
             # dependencies can be part of a cycle, and marking afterwards means
             # neither module in one is ever recorded as loaded while it is being
             # loaded, so the pair recurses until the stack gives out. Marking
             # first makes the second entry a no-op, which is what "already
             # loading" should mean.
-            _NUTSHELL_LOADED[$mod]=1
+            _NUTSHELL_LOADED[$_real]=1
+            if [[ "$mod" == super::* ]]; then
+                _NUTSHELL_LOADED_AS["${_real}::${mod}"]="$_real"
+            else
+                _NUTSHELL_LOADED_AS[$mod]="$_real"
+            fi
             if ! source "$mod_path"; then
                 # Failed to load, so it is not loaded. Leaving the mark would
                 # make a later retry silently succeed against a module that was
                 # never sourced.
-                unset "_NUTSHELL_LOADED[$mod]"
+                unset "_NUTSHELL_LOADED[$_real]"
+                unset "_NUTSHELL_LOADED_AS[$mod]"
+                unset "_NUTSHELL_LOADED_AS[${_real}::${mod}]"
                 return 1
             fi
         else
@@ -145,6 +172,227 @@ use() {
             return 1
         fi
     done
+}
+
+# _lib_nut_lookup <root> <module-path>
+#
+# The file a library says a module lives in, from the `lib.nut` at its root.
+#
+# A library declares what it provides, in one place, instead of the resolver
+# guessing among three layouts and taking whichever answered first. That guess
+# is why a module could be found in the wrong place and why nothing could say,
+# before running, that a name would not resolve. A declaration turns "no file
+# answered" into "not in the tree", which is checkable without running
+# anything.
+#
+# The format is one module per line, `<module-path> <file>`, because this is
+# read before any module is loaded and the TOML parser is itself a module. A
+# declaration file needing a parser you must load a module to obtain is a cycle
+# at the very bottom of the stack.
+#
+#   # anything after a hash is a comment
+#   log                 lib/log.sh
+#   tui::term           libs/tui/term.sh
+#   json::impl::jq      lib/json/impl/jq.sh      internal
+#
+# `internal` means the library's own file, reachable by `super::` from inside
+# and not by name from outside. Files picked at runtime by capability, like the
+# json and fs implementations, are that: they are sourced directly by the
+# module that chooses between them, and were never modules anybody names.
+# The third argument, when given, is the visibility a caller is allowed to
+# reach: `any` from inside the unit, `public` from outside it.
+_lib_nut_lookup() {
+    local root="$1" want="$2" reach="${3:-any}" name file vis
+    [[ -r "${root}/lib.nut" ]] || return 1
+    # `|| [[ -n "$name" ]]`, so a file whose last line has no newline keeps
+    # its last declaration. Without it the module simply is not there, and the
+    # checker agreed because it read the file another way.
+    while read -r name file vis || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        [[ "$name" == "$want" ]] || continue
+        [[ -n "$file" ]] || return 1
+        if [[ "$reach" == "public" && "${vis:-}" == "internal" ]]; then
+            echo "nutshell: '${want}' is internal to that library" >&2
+            return 1
+        fi
+        printf '%s/%s' "$root" "$file"
+        return 0
+    done < "${root}/lib.nut"
+    return 1
+}
+
+# _lib_nut_modules <root>
+#
+# Every module a library declares, one per line. For the checker, and for an
+# error that can list what was actually available.
+_lib_nut_modules() {
+    local root="$1" name _rest
+    [[ -r "${root}/lib.nut" ]] || return 1
+    while read -r name _rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        printf '%s\n' "$name"
+    done < "${root}/lib.nut"
+}
+
+# _use_resolve <mod> [caller-file]
+#
+# The file a module name points at, without loading it. `use` and `nut_reload`
+# both need this answer and had one copy each, which is how they came to
+# disagree about which file a name meant.
+_use_resolve() {
+    local mod="$1" caller="${2:-}" mod_path=""
+    # A caller named outright wins. `use` reads the frame that wrote it, which
+    # is right when a file wrote it and wrong when nut_reload did: the frame is
+    # then init, and a `super::` resolves against nutshell instead of the unit
+    # that asked.
+    [[ -n "${_NUT_SUPER_FROM:-}" ]] && caller="$_NUT_SUPER_FROM"
+    if [[ "$mod" == super::* ]]; then
+        local _from
+        if [[ -n "$caller" && "$caller" == */* ]]; then
+            _from="$(cd "${caller%/*}" 2>/dev/null && pwd)"
+        else
+            _from="$PWD"
+        fi
+        mod_path="$(_use_super_resolve "${mod#super::}" "$_from")" || return 1
+    elif [[ "$mod" == *"::"* ]]; then
+        mod_path="$(_lib_nut_lookup "$_NUTSHELL_ROOT" "$mod" 2>/dev/null)" || mod_path=""
+        if [[ -z "$mod_path" ]]; then
+            use extern || return 1
+            mod_path="$(extern_resolve "$mod")" || return 1
+        fi
+    else
+        # nutshell's own, through its own declaration. Straight to
+        # lib/<name>.sh, a bare `use json/impl/jq` reached an internal file by
+        # spelling a path, which is around the declaration and around the bar
+        # that says a consumer may not have it.
+        if [[ "$mod" == */* ]]; then
+            echo "nutshell: '${mod}' separates modules with '/'" >&2
+            echo "  use '::' the whole way down: ${mod//\//::}" >&2
+            return 1
+        fi
+        mod_path="$(_lib_nut_lookup "$_NUTSHELL_ROOT" "$mod" 2>/dev/null)" || mod_path=""
+        [[ -n "$mod_path" ]] || mod_path="${_NUTSHELL_ROOT}/lib/${mod}.sh"
+    fi
+    [[ -n "$mod_path" ]] || return 1
+    printf '%s' "$mod_path"
+}
+
+#[pub]
+# Load a module even if it is already loaded.
+#
+# For one shape: a function that is a stub until an implementation replaces it.
+# The implementation is chosen at the first call, and if something has since
+# put the stub back over the binding, the implementation has to run again to
+# make it. `use` will not, by design, and that is right for every other case.
+#
+# Rare on purpose. If a module needs reloading for any other reason, the thing
+# to fix is why it does not survive being loaded once.
+# Usage: nut_reload super::text::impl::grep_match
+nut_reload() {
+    # The unit that wrote this call, carried through the `use` below so a
+    # `super::` means what it meant where it was written.
+    local _NUT_SUPER_FROM="${BASH_SOURCE[1]:-}"
+    local mod
+    for mod in "$@"; do
+        # Forget the file, and every name that reached it, then load again.
+        #
+        # By file, not by the name this caller happens to use: a module loaded
+        # under one name and reloaded under another would otherwise forget
+        # nothing, `use` would answer "already loaded", and the stub that asked
+        # for the reload would still be the stub.
+        local file="${_NUTSHELL_LOADED_AS[$mod]:-}"
+        if [[ -z "$file" ]]; then
+            local _p; _p="$(_use_resolve "$mod" "${BASH_SOURCE[1]:-}")" || _p=""
+            [[ -n "$_p" ]] && file="$(_nut_realpath "$_p" 2>/dev/null || printf '%s' "$_p")"
+        fi
+        if [[ -n "$file" ]]; then
+            unset "_NUTSHELL_LOADED[$file]"
+            local k
+            for k in "${!_NUTSHELL_LOADED_AS[@]}"; do
+                [[ "${_NUTSHELL_LOADED_AS[$k]}" == "$file" ]] && unset "_NUTSHELL_LOADED_AS[$k]"
+            done
+            # nut_once has its own record of the same fact.
+            local once="_NUT_ONCE_${file//[^A-Za-z0-9]/_}"
+            unset "$once"
+        fi
+        use "$mod" || return 1
+    done
+    return 0
+}
+
+# nut_lazy_guard <name>
+#
+# For a function that loads an implementation and then calls the name that
+# implementation was supposed to rebind. If it was not rebound, that call is
+# the function calling itself, and it does so until the shell runs out of
+# stack: no message, no exit status, the process simply disappears.
+#
+# It used to be safe because `source` re-runs a file every time. `use` loads a
+# file once, so the day the implementation is already loaded and the stub is
+# somehow back in place, the stub is on its own.
+#
+# Called at the top of the stub. Returns 1 when the stub is re-entering itself,
+# with an error that names the module rather than nothing at all.
+nut_lazy_guard() {
+    local name="$1" key="_NUT_LAZY_${1//[^A-Za-z0-9]/_}"
+    if [[ -n "${!key:-}" ]]; then
+        printf '[ERROR] %s: its implementation loaded but did not define %s\n' "$name" "$name" >&2
+        printf '        the module was probably re-sourced over a binding it had already made\n' >&2
+        return 1
+    fi
+    return 0
+}
+
+# _nut_realpath <path>
+#
+# One spelling for one file. `use` and `nut_once` are two guards for the same
+# property, and they keyed it differently: `use` on a canonicalised path,
+# `nut_once` on whatever string `BASH_SOURCE` happened to hold. So a module
+# loaded once through the resolver and then sourced again by a relative path
+# passed the second guard, ran again, and reinstalled its lazy stubs over
+# bindings the implementation had already made.
+_nut_realpath() {
+    local p="$1" d b
+    [[ -n "$p" ]] || return 1
+    d="${p%/*}"; b="${p##*/}"
+    [[ "$d" == "$p" ]] && d="."
+    # -P, so the key is the physical file. `cd` without it gives the logical
+    # path, which leaves a symlinked module and its target as two different
+    # keys and therefore two loads of one file.
+    if cd -P "$d" 2>/dev/null; then
+        d="$PWD"
+        cd - >/dev/null 2>&1 || true
+        # And the leaf, if that is a link too.
+        if [[ -L "${d}/${b}" ]]; then
+            local t; t="$(readlink "${d}/${b}")"
+            case "$t" in
+                /*) printf '%s' "$t"; return 0 ;;
+                *)  b="$t" ;;
+            esac
+        fi
+        printf '%s/%s' "$d" "$b"
+        return 0
+    fi
+    printf '%s' "$p"
+}
+
+# _use_mod_fragment <rest>
+#
+# The path fragment a module path names. `::` separates modules the whole way
+# down, so `tui::key` is the `key` module of the `tui` group and reads the same
+# as the `shebang::` that got you there.
+#
+# A `/` is refused rather than translated. It worked for a while, because the
+# tail was handed to the filesystem unchanged, and a separator that works by
+# accident is one that half the call sites end up using.
+_use_mod_fragment() {
+    local rest="$1"
+    if [[ "$rest" == */* ]]; then
+        echo "nutshell: '${rest}' separates modules with '/'" >&2
+        echo "  use '::' the whole way down: ${rest//\//::}" >&2
+        return 1
+    fi
+    printf '%s' "${rest//:://}"
 }
 
 # _use_super_resolve <rest>
@@ -158,6 +406,8 @@ use() {
 # something the author did not write and did not mean.
 _use_super_resolve() {
     local rest="$1" from="$2" root candidate dir
+    local declared="$rest"
+    rest="$(_use_mod_fragment "$rest")" || return 1
 
     # Walk up from the file that wrote the `use`, not from the entry point.
     #
@@ -184,7 +434,25 @@ _use_super_resolve() {
         echo "  super:: names this unit's own lib/, and the manifest is what marks the unit" >&2
         return 1
     fi
-    for candidate in "${root}/lib/${rest}.sh" "${root}/libs/${rest}.sh" "${root}/${rest}.sh"; do
+    # What the unit declares, if it declares anything. A library with a lib.nut
+    # is answered from it and nowhere else: falling back to a search would put
+    # the guessing back under the declaration and hide a wrong entry.
+    if [[ -r "${root}/lib.nut" ]]; then
+        candidate="$(_lib_nut_lookup "$root" "$declared")" || {
+            echo "nutshell: '${declared}' is not in this unit's lib.nut" >&2
+            echo "  it declares: $(_lib_nut_modules "$root" | tr '\n' ' ')" >&2
+            return 1
+        }
+        [[ -f "$candidate" ]] && { printf '%s' "$candidate"; return 0; }
+        echo "nutshell: lib.nut declares '${declared}' at ${candidate#$root/}, which is not there" >&2
+        return 1
+    fi
+
+    # libs, then lib, then the root. The same order extern uses: the two had
+    # one each, `lib` first here and `libs` first there, so a library with both
+    # resolved differently depending on who was asking. Only the undeclared
+    # path reaches this now, and it exists to be migrated away from.
+    for candidate in "${root}/libs/${rest}.sh" "${root}/lib/${rest}.sh" "${root}/${rest}.sh"; do
         [[ -f "$candidate" ]] && { printf '%s' "$candidate"; return 0; }
     done
     echo "nutshell: this unit has no module '${rest}'" >&2
@@ -255,6 +523,10 @@ export -f use
 # Check if a module is loaded
 # Usage: if nutshell_loaded json; then ...
 nutshell_loaded() {
+    # By name, because that is what a caller has. The name is looked up to a
+    # file first, so a module loaded as `super::x` answers yes when asked about
+    # `dep::x` too, which is the same module.
+    [[ -n "${_NUTSHELL_LOADED_AS[$1]:-}" ]] && return 0
     [[ -n "${_NUTSHELL_LOADED[$1]:-}" ]]
 }
 export -f nutshell_loaded

--- a/init
+++ b/init
@@ -37,11 +37,14 @@ _nutshell_refuse_old_bash() {
     printf '  first on PATH, or run this under it directly.\n' >&2
 }
 
+# `return` here returns to whoever sourced this and cannot stop them, so the
+# caller has to check. Every example in the readme ends its source line in
+# `|| exit 1` for that reason, and both consumers do the same.
 case "${BASH_VERSION:-}" in
-    "")        _nutshell_refuse_old_bash; return 1 2>/dev/null || exit 1 ;;
-    1.*|2.*|3.*) _nutshell_refuse_old_bash; return 1 2>/dev/null || exit 1 ;;
+    ""|1.*|2.*|3.*)
+        _nutshell_refuse_old_bash
+        return 1 2>/dev/null || exit 1 ;;
 esac
-
 # Prevent multiple inclusion
 [[ -n "${_NUTSHELL_INIT:-}" ]] && return 0
 _NUTSHELL_INIT=1

--- a/init
+++ b/init
@@ -26,7 +26,7 @@ _NUTSHELL_ROOT="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 
 # Export for use by modules
 export NUTSHELL_ROOT="${_NUTSHELL_ROOT}"
-export NUTSHELL_VERSION="0.3.0"
+export NUTSHELL_VERSION="0.4.0"
 
 # Script identity belongs to the interpreter invocation, not to ancestry. The
 # interpreter exports NUTSHELL_SCRIPT and NUTSHELL_SCRIPT_DIR after this file

--- a/init
+++ b/init
@@ -258,6 +258,13 @@ _use_resolve() {
         mod_path="$(_lib_nut_lookup "$_NUTSHELL_ROOT" "$mod" 2>/dev/null)" || mod_path=""
         if [[ -z "$mod_path" ]]; then
             use extern || return 1
+            # Where the asking file lives, so extern can find that unit's
+            # manifest rather than searching from wherever the process happens
+            # to have been started.
+            local _NUT_ASKING_FROM=""
+            if [[ -n "$caller" && "$caller" == */* ]]; then
+                _NUT_ASKING_FROM="$(cd "${caller%/*}" 2>/dev/null && pwd)"
+            fi
             mod_path="$(extern_resolve "$mod")" || return 1
         fi
     else

--- a/init
+++ b/init
@@ -13,6 +13,35 @@
 #
 # =============================================================================
 
+# =============================================================================
+# The floor, before anything that needs it
+# =============================================================================
+#
+# Everything below this point needs bash 4: associative arrays, `declare -g`,
+# `[[ =~ ]]` with `BASH_REMATCH`. macOS ships 3.2 at `/bin/bash` and that is
+# the machine this is most often reached from, so the refusal has to be here
+# and it has to be loud.
+#
+# It used to be neither. `declare -A` failed twice, `_NUTSHELL_LOADED` was not
+# an associative array, the first `use` died on an unbound variable, and the
+# interpreter **exited 0**. A Makefile, a task runner or CI read that as
+# success. Measured on bash 3.2.57: three errors and `EXIT=0`.
+#
+# Written so any shell can read it. `${BASH_VERSINFO...}` is a bash-only
+# expansion, so it is spelled through `case` on `$BASH_VERSION`, which is a
+# plain string, and the whole block parses under `sh` and under bash 3.
+_nutshell_refuse_old_bash() {
+    printf 'nutshell needs bash 4.0 or newer.\n' >&2
+    printf '  this is: %s\n' "${BASH_VERSION:-not bash at all}" >&2
+    printf '  macOS ships 3.2 at /bin/bash. Install a current one and put it\n' >&2
+    printf '  first on PATH, or run this under it directly.\n' >&2
+}
+
+case "${BASH_VERSION:-}" in
+    "")        _nutshell_refuse_old_bash; return 1 2>/dev/null || exit 1 ;;
+    1.*|2.*|3.*) _nutshell_refuse_old_bash; return 1 2>/dev/null || exit 1 ;;
+esac
+
 # Prevent multiple inclusion
 [[ -n "${_NUTSHELL_INIT:-}" ]] && return 0
 _NUTSHELL_INIT=1

--- a/lib.nut
+++ b/lib.nut
@@ -36,5 +36,7 @@ text::impl::perl_match   lib/text/impl/perl_match.sh  internal
 text::impl::perl_replace lib/text/impl/perl_replace.sh internal
 text::impl::sed_replace  lib/text/impl/sed_replace.sh internal
 toml                     lib/toml.sh
+toml::json               lib/toml/json.sh
+toml::write              lib/toml/write.sh
 validate                 lib/validate.sh
 xdg                      lib/xdg.sh

--- a/lib.nut
+++ b/lib.nut
@@ -7,6 +7,7 @@
 array                    lib/array.sh
 attr                     lib/attr.sh
 check-runner             lib/check-runner.sh
+checkcache               lib/checkcache.sh
 cli                      lib/cli.sh
 color                    lib/color.sh
 deps                     lib/deps.sh
@@ -27,6 +28,7 @@ nutshell                 nutshell.sh
 os                       lib/os.sh
 priv                     lib/priv.sh
 prompt                   lib/prompt.sh
+srcfile                  lib/srcfile.sh
 string                   lib/string.sh
 test                     lib/test.sh
 text                     lib/text.sh

--- a/lib.nut
+++ b/lib.nut
@@ -25,6 +25,7 @@ log                      lib/log.sh
 modgraph                 lib/modgraph.sh
 nutshell                 nutshell.sh
 os                       lib/os.sh
+priv                     lib/priv.sh
 prompt                   lib/prompt.sh
 string                   lib/string.sh
 test                     lib/test.sh

--- a/lib.nut
+++ b/lib.nut
@@ -1,0 +1,40 @@
+# lib.nut - the modules nutshell provides.
+#
+# One module per line: the name a `use` writes, then the file.
+# Read before any module is loaded, so it stays a format that needs
+# no parser: the TOML one is itself a module.
+
+array                    lib/array.sh
+attr                     lib/attr.sh
+check-runner             lib/check-runner.sh
+cli                      lib/cli.sh
+color                    lib/color.sh
+deps                     lib/deps.sh
+extern                   lib/extern.sh
+fs                       lib/fs.sh
+fs::impl::perl_stat      lib/fs/impl/perl_stat.sh     internal
+fs::impl::stat_bsd       lib/fs/impl/stat_bsd.sh      internal
+fs::impl::stat_gnu       lib/fs/impl/stat_gnu.sh      internal
+git                      lib/git.sh
+http                     lib/http.sh
+json                     lib/json.sh
+json::impl::jq           lib/json/impl/jq.sh          internal
+json::impl::perl         lib/json/impl/perl.sh        internal
+json::impl::python       lib/json/impl/python.sh      internal
+log                      lib/log.sh
+modgraph                 lib/modgraph.sh
+nutshell                 nutshell.sh
+os                       lib/os.sh
+prompt                   lib/prompt.sh
+string                   lib/string.sh
+test                     lib/test.sh
+text                     lib/text.sh
+text::impl::awk_replace  lib/text/impl/awk_replace.sh internal
+text::impl::combo::grep_sed lib/text/impl/combo/grep_sed.sh internal
+text::impl::grep_match   lib/text/impl/grep_match.sh  internal
+text::impl::perl_match   lib/text/impl/perl_match.sh  internal
+text::impl::perl_replace lib/text/impl/perl_replace.sh internal
+text::impl::sed_replace  lib/text/impl/sed_replace.sh internal
+toml                     lib/toml.sh
+validate                 lib/validate.sh
+xdg                      lib/xdg.sh

--- a/lib/attr.sh
+++ b/lib/attr.sh
@@ -44,6 +44,31 @@ nut_once || return 0
 # parenthesised argument, `]`. Anything else is an ordinary comment.
 readonly ATTR_PATTERN='^[[:space:]]*#\[[a-z_][a-z0-9_]*(\(.*\))?\][[:space:]]*$'
 
+# What a function definition looks like, in one place.
+#
+# Both spellings bash accepts, and both were being missed. `function name {`
+# has no parentheses at all; `name ()` puts a space before them. A `#[pub]` on
+# either was invisible, so the public-API check skipped those functions in
+# silence rather than reporting them undocumented.
+#
+# One pattern because there were two, here and in `srcfile`, and they had
+# already drifted apart: this one took no hyphen and no `function` keyword,
+# that one took both. A definition is one thing and the readers of it agree
+# about what it is.
+#
+# Group 2 is the name after `function`, group 3 the name before `()`. Exactly
+# one of them matches.
+readonly ATTR_DEFINES_PATTERN='^[[:space:]]*(function[[:space:]]+([a-zA-Z_][a-zA-Z0-9_-]*)|([a-zA-Z_][a-zA-Z0-9_-]*)[[:space:]]*\(\))'
+
+#[pub]
+# The function a line defines, or nothing. The one answer both this module and
+# `srcfile` use, so a definition means the same thing to each.
+# Usage: attr_defines_on "foo() {" -> prints "foo"
+attr_defines_on() {
+    [[ "${1:-}" =~ $ATTR_DEFINES_PATTERN ]] || return 1
+    printf '%s' "${BASH_REMATCH[2]:-${BASH_REMATCH[3]}}"
+}
+
 # The three below are matched with bash's own regex rather than by piping each
 # line through `sed`.
 #
@@ -72,11 +97,7 @@ _attr_arg() {
 }
 
 # _attr_defines <line> -> the function name this line defines, or nothing
-_attr_defines() {
-    local l="$1"
-    [[ "$l" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\) ]] || return 1
-    printf '%s' "${BASH_REMATCH[1]}"
-}
+_attr_defines() { attr_defines_on "${1:-}"; }
 
 # attr_on <file> <function>
 #
@@ -100,8 +121,8 @@ attr_on() {
         # The helper stays for callers and for the tests; the loop cannot
         # afford it.
         defines=""
-        [[ "$line" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\) ]] \
-            && defines="${BASH_REMATCH[1]}"
+        [[ "$line" =~ $ATTR_DEFINES_PATTERN ]] \
+            && defines="${BASH_REMATCH[2]:-${BASH_REMATCH[3]}}"
         if [[ -n "$defines" ]]; then
             if [[ "$defines" == "$want" ]]; then
                 for line in "${pending[@]}"; do
@@ -184,8 +205,8 @@ attr_find() {
         fi
 
         defines=""
-        [[ "$line" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\) ]] \
-            && defines="${BASH_REMATCH[1]}"
+        [[ "$line" =~ $ATTR_DEFINES_PATTERN ]] \
+            && defines="${BASH_REMATCH[2]:-${BASH_REMATCH[3]}}"
         if [[ -n "$defines" ]]; then
             [[ "$pending" -eq 1 ]] && printf '%s\n' "$defines"
             pending=0

--- a/lib/attr.sh
+++ b/lib/attr.sh
@@ -44,19 +44,38 @@ nut_once || return 0
 # parenthesised argument, `]`. Anything else is an ordinary comment.
 readonly ATTR_PATTERN='^[[:space:]]*#\[[a-z_][a-z0-9_]*(\(.*\))?\][[:space:]]*$'
 
+# The three below are matched with bash's own regex rather than by piping each
+# line through `sed`.
+#
+# `attr_on` walks every line of a file and asks `_attr_defines` about each one.
+# At a fork per line, times two subshells for the substitution and the pipe,
+# times every function a checker looks up, that was a quarter of a million
+# processes on one library and it made the QA gate take four minutes. Bash can
+# match a line against a pattern without leaving the process, and this needs no
+# `sed` and no `awk`, so it also works on a machine that has neither. The two
+# readers below were a `cut | grep` and an `awk` over this module's own output
+# and are bash for the same reason: a module this low should not need a
+# userland to answer a question about a comment.
+
 # _attr_name <line> -> the attribute's name
 _attr_name() {
-    printf '%s' "$1" | sed -E 's/^[[:space:]]*#\[//; s/(\(.*\))?\][[:space:]]*$//'
+    local l="$1"
+    [[ "$l" =~ ^[[:space:]]*#\[([a-zA-Z_][a-zA-Z0-9_]*) ]] || return 1
+    printf '%s' "${BASH_REMATCH[1]}"
 }
 
 # _attr_arg <line> -> what was inside the parentheses, or nothing
 _attr_arg() {
-    printf '%s' "$1" | sed -nE 's/^[[:space:]]*#\[[a-z_][a-z0-9_]*\((.*)\)\][[:space:]]*$/\1/p'
+    local l="$1"
+    [[ "$l" =~ ^[[:space:]]*#\[[a-z_][a-z0-9_]*\((.*)\)\][[:space:]]*$ ]] || return 1
+    printf '%s' "${BASH_REMATCH[1]}"
 }
 
 # _attr_defines <line> -> the function name this line defines, or nothing
 _attr_defines() {
-    printf '%s' "$1" | sed -nE 's/^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\).*/\1/p'
+    local l="$1"
+    [[ "$l" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\) ]] || return 1
+    printf '%s' "${BASH_REMATCH[1]}"
 }
 
 # attr_on <file> <function>
@@ -76,12 +95,21 @@ attr_on() {
             continue
         fi
 
-        defines="$(_attr_defines "$line")"
+        # Matched here rather than through `_attr_defines`, because a command
+        # substitution is a subshell and this runs on every line of the file.
+        # The helper stays for callers and for the tests; the loop cannot
+        # afford it.
+        defines=""
+        [[ "$line" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\) ]] \
+            && defines="${BASH_REMATCH[1]}"
         if [[ -n "$defines" ]]; then
             if [[ "$defines" == "$want" ]]; then
                 for line in "${pending[@]}"; do
-                    name="$(_attr_name "$line")"
-                    arg="$(_attr_arg "$line")"
+                    name=""; arg=""
+                    [[ "$line" =~ ^[[:space:]]*#\[([a-zA-Z_][a-zA-Z0-9_]*) ]] \
+                        && name="${BASH_REMATCH[1]}"
+                    [[ "$line" =~ ^[[:space:]]*#\[[a-z_][a-z0-9_]*\((.*)\)\][[:space:]]*$ ]] \
+                        && arg="${BASH_REMATCH[1]}"
                     if [[ -n "$arg" ]]; then
                         printf '%s\t%s\n' "$name" "$arg"
                     else
@@ -110,7 +138,11 @@ attr_on() {
 #[pub]
 # Usage: attr_has lib/string.sh str_trim pub -> returns 0 when marked
 attr_has() {
-    attr_on "$1" "$2" 2>/dev/null | cut -f1 | grep -qx "$3"
+    local want="$3" line
+    while IFS= read -r line; do
+        [[ "${line%%$'\t'*}" == "$want" ]] && return 0
+    done < <(attr_on "$1" "$2" 2>/dev/null)
+    return 1
 }
 
 # attr_arg <file> <function> <attribute>
@@ -118,7 +150,14 @@ attr_has() {
 #[pub]
 # Usage: attr_arg lib/foo.sh big_fn allow -> prints "loc = 400"
 attr_arg() {
-    attr_on "$1" "$2" 2>/dev/null | awk -F'\t' -v a="$3" '$1 == a { print $2; exit }'
+    local want="$3" line
+    while IFS= read -r line; do
+        if [[ "${line%%$'\t'*}" == "$want" ]]; then
+            [[ "$line" == *$'\t'* ]] && printf '%s' "${line#*$'\t'}"
+            return 0
+        fi
+    done < <(attr_on "$1" "$2" 2>/dev/null)
+    return 1
 }
 
 # attr_find <file> <attribute>
@@ -132,14 +171,21 @@ attr_find() {
     local file="$1" want="$2"
     local line pending=0 defines name
 
+    # Matched inline for the same reason `attr_on` does: a command substitution
+    # is a subshell, and this runs on every line of the file. The test suite
+    # calls it once per test file and a checker calls it once per source file.
     while IFS= read -r line; do
         if [[ "$line" =~ $ATTR_PATTERN ]]; then
-            name="$(_attr_name "$line")"
+            name=""
+            [[ "$line" =~ ^[[:space:]]*#\[([a-zA-Z_][a-zA-Z0-9_]*) ]] \
+                && name="${BASH_REMATCH[1]}"
             [[ "$name" == "$want" ]] && pending=1
             continue
         fi
 
-        defines="$(_attr_defines "$line")"
+        defines=""
+        [[ "$line" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\) ]] \
+            && defines="${BASH_REMATCH[1]}"
         if [[ -n "$defines" ]]; then
             [[ "$pending" -eq 1 ]] && printf '%s\n' "$defines"
             pending=0

--- a/lib/check-runner.sh
+++ b/lib/check-runner.sh
@@ -555,9 +555,6 @@ get_script_files() {
 # ANNOTATION CHECKING
 # =============================================================================
 
-# Check if a function has a specific annotation
-#[pub]
-# Usage: has_annotation "file" "func_name" "annotation_pattern" -> returns 0/1
 # attr_name_of <annotation>
 #
 # The attribute name inside a configured marker: `#[pub]` gives `pub`. Prints
@@ -593,6 +590,9 @@ attr_name_of() {
 # The window was a second, quieter bug: ten lines is enough for a terse
 # function and not for a documented one, so whether an annotation was seen
 # depended on how much prose sat under it.
+#
+#[pub]
+# Usage: has_annotation "file" "func_name" "annotation_pattern" -> returns 0/1
 has_annotation() {
     local file="$1" func_name="$2" annotation="$3"
 

--- a/lib/check-runner.sh
+++ b/lib/check-runner.sh
@@ -37,6 +37,7 @@ NUTSHELL_DEFAULTS_FILE="${NUTSHELL_ROOT}/examples/configs/empty.nut.toml"
 # that loads its dependencies invisibly is exactly the case that check exists
 # to catch, so the framework running it must not be the one exception.
 use log validate toml attr string
+use srcfile
 
 # =============================================================================
 # PATHS - Determined after config is loaded
@@ -44,6 +45,8 @@ use log validate toml attr string
 
 # These are set by _framework_init after config discovery
 REPO_ROOT=""
+# Whether a passing check prints a line. Resolved once by `_framework_init`.
+declare -g SHOW_PASSING="true"
 LIB_DIR=""
 CONFIG_FILE=""
 
@@ -253,21 +256,68 @@ _find_config_file() {
     return 1
 }
 
-# Find repo root by looking for common markers
-_find_repo_root() {
-    local dir="$_CHECK_RUNNER_DIR"
-    
-    while [[ "$dir" != "/" ]]; do
-        # Check for repo markers
-        if [[ -d "$dir/.git" ]] || [[ -f "$dir/nut.toml" ]] || [[ -f "$dir/Cargo.toml" ]] || [[ -f "$dir/package.json" ]]; then
-            echo "$dir"
+# Walk up from a directory to the first repository marker above it.
+#
+# `<levels>` bounds how far up may answer. Unbounded is right for the
+# interpreter finding itself and wrong for finding the project being checked,
+# because there is usually some repository somewhere above any directory.
+_walk_to_marker() {
+    local dir="${1:-}" left="${2:-}"
+    [[ -d "$dir" ]] || return 1
+    dir="$(cd "$dir" && pwd)" || return 1
+    [[ "$left" =~ ^[0-9]+$ ]] || left=""
+
+    while [[ -n "$dir" && "$dir" != "/" ]]; do
+        if [[ -n "$left" ]] && (( left < 0 )); then return 1; fi
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/nut.toml" ]] \
+           || [[ -f "$dir/Cargo.toml" ]] || [[ -f "$dir/package.json" ]]; then
+            printf '%s' "$dir"
             return 0
         fi
         dir="$(dirname "$dir")"
+        [[ -n "$left" ]] && left=$(( left - 1 ))
     done
-    
-    # Fall back to nutshell root if nothing else found
-    echo "$NUTSHELL_ROOT"
+    return 1
+}
+
+# The repository being checked.
+#
+# From where the check was invoked, not from where this file happens to sit.
+# Walking up from this file finds whichever nutshell is running the check, so
+# every consumer was having nutshell's own source graded against the
+# consumer's thresholds. It looked like a passing gate and no consumer's code
+# had ever been read. `paths.exclude` could not help: the walk started inside
+# the directory the consumer was excluding.
+#
+# It is not only a vendoring problem. A consumer resolving nutshell out of the
+# store gets the same answer, because a store checkout carries a `.git` too.
+_find_repo_root() {
+    local root
+
+    # What the caller named. A config file states which repository it is the
+    # config for, and its directory is that repository.
+    if [[ -n "${NUTSHELL_CONFIG:-}" ]] && [[ -f "$NUTSHELL_CONFIG" ]]; then
+        root="$(cd "$(dirname "$NUTSHELL_CONFIG")" && pwd)" && {
+            printf '%s' "$root"; return 0
+        }
+    fi
+
+    # Where the check was run from. `./check` at a project root, or anywhere
+    # inside it, both mean that project.
+    #
+    # Bounded, because the walk does not stop at the first thing that is not a
+    # project: run from a scratch directory under a `$HOME` that is itself a
+    # dotfiles repository, an unbounded walk grades the dotfiles repository.
+    # `NUTSHELL_CHECK_DEPTH` is the number of levels above the invocation that
+    # may answer, and four is deep enough for `crates/foo/src/bar` and shallow
+    # enough that a stray ancestor cannot.
+    root="$(_walk_to_marker "$PWD" "${NUTSHELL_CHECK_DEPTH:-4}")" \
+        && { printf '%s' "$root"; return 0; }
+
+    # Nothing above the invocation directory says it is a repository, so there
+    # is nothing to check but the interpreter itself.
+    root="$(_walk_to_marker "$_CHECK_RUNNER_DIR")" && { printf '%s' "$root"; return 0; }
+    printf '%s' "$NUTSHELL_ROOT"
 }
 
 # =============================================================================
@@ -306,6 +356,9 @@ _framework_init() {
         LIB_DIR="${REPO_ROOT}/${lib_dir_config}"
     fi
     
+    # Resolved here so the loggers do not go back to the file. See `log_pass`.
+    SHOW_PASSING="$(cfg_get_or "output.show_passing" "true")"
+
     # Cache exclude paths
     cfg_get_array "paths.exclude" NUT_EXCLUDE_PATHS || NUT_EXCLUDE_PATHS=()
     
@@ -409,11 +462,16 @@ log_test() {
 log_pass() {
     TESTS_PASSED=$((TESTS_PASSED + 1))
     TESTS_RUN=$((TESTS_RUN + 1))
-    
-    local show_passing
-    show_passing="$(cfg_get_or "output.show_passing" "true")"
-    
-    if is_truthy "$show_passing"; then
+
+    # Read once, at init, rather than per passing check.
+    #
+    # This ran a full TOML parse every time a check passed. `cfg_get_or` does
+    # cache, but a check runs its per-item work inside a command substitution
+    # and a subshell's cache dies when it returns, so the cache never held.
+    # Traced over one run of the docs check: 318 config lookups, 312 of them
+    # this one key, each re-parsing the whole file line by line and character
+    # by character. It was most of the run.
+    if is_truthy "$SHOW_PASSING"; then
         echo -e "${GREEN}  ✓${NC} $*"
     fi
 }
@@ -459,16 +517,31 @@ _is_excluded() {
 # Get all files matching include patterns, excluding configured paths
 #[pub]
 # Usage: get_lib_files -> prints file paths, one per line
+declare -g _NUT_LIB_FILES_CACHED=""
+declare -g _NUT_LIB_FILES=""
+
 get_lib_files() {
     _framework_init
-    
+
+    # The list, once. `find` per include pattern, per call, and the callers ask
+    # per function: 210 invocations in one run of the wrapper check alone. The
+    # tree does not change while a check runs.
+    if [[ -n "$_NUT_LIB_FILES_CACHED" ]]; then
+        printf '%s\n' "$_NUT_LIB_FILES"
+        return 0
+    fi
+
     local pattern file
-    for pattern in "${NUT_INCLUDE_PATTERNS[@]}"; do
-        while IFS= read -r -d '' file; do
-            _is_excluded "$file" && continue
-            echo "$file"
-        done < <(find "$LIB_DIR" -name "$pattern" -type f -print0 2>/dev/null)
-    done | sort -u
+    _NUT_LIB_FILES="$(
+        for pattern in "${NUT_INCLUDE_PATTERNS[@]}"; do
+            while IFS= read -r -d '' file; do
+                _is_excluded "$file" && continue
+                printf '%s\n' "$file"
+            done < <(find "$LIB_DIR" -name "$pattern" -type f -print0 2>/dev/null)
+        done | sort -u
+    )"
+    _NUT_LIB_FILES_CACHED=1
+    printf '%s\n' "$_NUT_LIB_FILES"
 }
 
 # Get all script files (same as lib files for nutshell)
@@ -716,10 +789,21 @@ print_summary() {
 }
 
 # Exit with appropriate code based on test results
+#
+# The 2 is what this always said it did and never did. Its own usage line
+# promised "2 on warnings only" while the body had two branches and returned 0
+# for a run with warnings in it, so the only way the runner could tell a warning
+# from a clean pass was to grep the child's output for the glyph it prints.
+#
+# That is why a check with 23 warnings could be reported as a clean pass: the
+# grep is over tens of kilobytes of a child's stdout, it depends on quiet mode
+# leaving the line in, on which `grep` is installed, and on the glyph surviving
+# the pipe. A verdict belongs in an exit code.
 #[pub]
 # Usage: exit_with_status -> does not return; exits 0 clean, 1 on failures, 2 on warnings only
 exit_with_status() {
     [[ $TESTS_FAILED -gt 0 ]] && exit 1
+    [[ $TESTS_WARNED -gt 0 ]] && exit 2
     exit 0
 }
 

--- a/lib/checkcache.sh
+++ b/lib/checkcache.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/checkcache - A check's answer for a file, kept until it can change
+# =============================================================================
+# Part of nutshell. https://github.com/orgrinrt/nutshell
+#
+# A check's finding about a file is a pure function of two things: the file,
+# and the check that read it. Neither changes between two runs of the gate, and
+# the overwhelming case is that nothing changed at all, so the overwhelming
+# case should cost nothing.
+#
+# **The checker is part of the key, not just the file.** A check that gains a
+# step, or tightens a threshold, has to read every file again; a cache over the
+# file alone would keep answering with the old check's opinion and there would
+# be no way to tell. The config counts for the same reason: the thresholds come
+# out of `nut.toml` and they are what the answer was measured against.
+#
+# Freshness is decided with `-nt` rather than by hashing. A hash is a process
+# per file, which is the cost this is trying to avoid; the file test is a stat
+# the shell does itself. The trade is that touching a file without changing it
+# re-runs the check, which is the harmless direction to be wrong in.
+#
+# Usage:
+#   use checkcache
+#
+#   if nut_cache_hit "$check" "$file"; then
+#       nut_cache_read "$check" "$file"      # the findings, as they were
+#   else
+#       findings="$(work_it_out "$file")"
+#       nut_cache_write "$check" "$file" "$findings"
+#   fi
+# =============================================================================
+
+[[ -n "${_NUTSHELL_CHECKCACHE_SH:-}" ]] && return 0
+readonly _NUTSHELL_CHECKCACHE_SH=1
+
+if ! declare -F use >/dev/null 2>&1; then
+    printf 'nutshell: source nutshell first\n' >&2
+    return 1
+fi
+
+# Off by default until a caller turns it on, because a cache that is wrong is
+# worse than a check that is slow.
+declare -g NUT_CACHE_ENABLED="${NUT_CACHE:-0}"
+
+# Where an answer is kept. Under the store, beside the toolchains and externs,
+# because it is derived data about this machine and not part of any project.
+_nut_cache_root() {
+    if [[ -n "${NUT_CACHE_DIR:-}" ]]; then
+        printf '%s' "${NUT_CACHE_DIR%/}"
+        return 0
+    fi
+    if declare -F nutshell_store_root >/dev/null 2>&1; then
+        printf '%s/checks' "$(nutshell_store_root)"
+        return 0
+    fi
+    printf '%s/nutshell/checks' "${XDG_CACHE_HOME:-${HOME:-/tmp}/.cache}"
+}
+
+# One file's answer, for one check. The path a source file flattens to.
+_nut_cache_path() {
+    local check="${1:-}" file="${2:-}" flat
+    [[ -n "$check" && -n "$file" ]] || return 1
+    flat="${file//\//_}"
+    flat="${flat//[^A-Za-z0-9._-]/_}"
+    printf '%s/%s/%s' "$(_nut_cache_root)" "${check//[^A-Za-z0-9._-]/_}" "$flat"
+}
+
+#[pub]
+# Is there an answer for this file that nothing has invalidated?
+#
+# Fresh means newer than the file, newer than the check that produced it, and
+# newer than the config the thresholds came from. Any of the three moving means
+# the answer could be different and has to be worked out again.
+# Usage: nut_cache_hit <check> <file> -> returns 0 on a usable answer
+nut_cache_hit() {
+    [[ "${NUT_CACHE_ENABLED:-0}" == "1" ]] || return 1
+    local check="${1:-}" file="${2:-}" entry
+    entry="$(_nut_cache_path "$check" "$file")" || return 1
+    [[ -f "$entry" ]] || return 1
+    [[ -e "$file" ]] || return 1
+    [[ "$entry" -nt "$file" ]] || return 1
+
+    # The check itself. Named by the caller, because only it knows which file
+    # it is; a check that does not say cannot be cached.
+    local src="${NUT_CACHE_CHECKER:-}"
+    [[ -n "$src" && -e "$src" ]] || return 1
+    [[ "$entry" -nt "$src" ]] || return 1
+
+    # And the thresholds it measured against.
+    if [[ -n "${CONFIG_FILE:-}" && -e "${CONFIG_FILE}" ]]; then
+        [[ "$entry" -nt "$CONFIG_FILE" ]] || return 1
+    fi
+    return 0
+}
+
+#[pub]
+# The answer that was kept. Nothing, and non-zero, when there is none.
+# Usage: nut_cache_read <check> <file> -> prints what was cached
+nut_cache_read() {
+    local entry; entry="$(_nut_cache_path "$1" "$2")" || return 1
+    [[ -r "$entry" ]] || return 1
+    cat "$entry"
+}
+
+#[pub]
+# Keep an answer. A failure to write is not a failure of the check: the run
+# still has the answer, it just will not have it next time.
+# Usage: nut_cache_write <check> <file> <findings>
+nut_cache_write() {
+    [[ "${NUT_CACHE_ENABLED:-0}" == "1" ]] || return 0
+    local entry; entry="$(_nut_cache_path "$1" "$2")" || return 0
+    mkdir -p "${entry%/*}" 2>/dev/null || return 0
+    printf '%s' "${3:-}" > "$entry" 2>/dev/null || return 0
+    return 0
+}
+
+#[pub]
+# Throw the whole thing away.
+# Usage: nut_cache_clear [check]
+nut_cache_clear() {
+    local root; root="$(_nut_cache_root)"
+    if [[ -n "${1:-}" ]]; then
+        rm -rf "${root}/${1//[^A-Za-z0-9._-]/_}"
+    else
+        rm -rf "$root"
+    fi
+    return 0
+}

--- a/lib/checkcache.sh
+++ b/lib/checkcache.sh
@@ -15,10 +15,27 @@
 # be no way to tell. The config counts for the same reason: the thresholds come
 # out of `nut.toml` and they are what the answer was measured against.
 #
-# Freshness is decided with `-nt` rather than by hashing. A hash is a process
-# per file, which is the cost this is trying to avoid; the file test is a stat
-# the shell does itself. The trade is that touching a file without changing it
-# re-runs the check, which is the harmless direction to be wrong in.
+# Freshness is a recorded stamp, not `-nt`.
+#
+# `-nt` only sees mtime moving forward, and `tar -x`, `rsync -a`, `cp -p` and
+# `touch -t` all move it backward. A review reproduced it: content replaced
+# wholesale, mtime set to 2000, and the cache served "no findings" for the new
+# file. That is the one direction a cache must never be wrong in, and the
+# header used to assert it could not happen.
+#
+# So an entry records what its inputs were, and a hit needs every one to match:
+# the file's mtime and size, the same for the check script and the config, the
+# newest mtime anywhere under the interpreter, and a format number.
+#
+# The interpreter is in there because a check is not one file. Editing
+# `lib/srcfile.sh` changes what `check_trivial_wrappers` reports while touching
+# neither the check nor the config, and op's ruling is explicit that a check
+# gaining a step has to read everything again.
+#
+# The stamps come from one `stat` for every input at once rather than one per
+# file, because a fork per lookup is the cost this exists to avoid, and the
+# first version of this cache was measurably slower than no cache for exactly
+# that reason.
 #
 # Usage:
 #   use checkcache
@@ -43,6 +60,59 @@ fi
 # worse than a check that is slow.
 declare -g NUT_CACHE_ENABLED="${NUT_CACHE:-0}"
 
+# Bumped when the entry format or the meaning of a stamp changes, so entries
+# written by an older nutshell are misses rather than lies.
+declare -g _NUT_CACHE_FORMAT=2
+
+declare -gA _NUT_CACHE_STAMP=()
+declare -g  _NUT_CACHE_BASE=""
+
+# `<mtime> <size>` for a set of paths, in one call.
+_nut_cache_stat_into() {
+    local out line path
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        _NUT_CACHE_STAMP["${line#* * }"]="${line%% * *} ${line#* }"
+    done < <(
+        if stat -f '%m %z %N' "$@" 2>/dev/null; then :
+        else stat -c '%Y %s %n' "$@" 2>/dev/null; fi
+    )
+    return 0
+}
+
+# The stamp for one path, or nothing when it could not be read.
+_nut_cache_stamp_of() {
+    local p="${1:-}" v
+    [[ -n "$p" ]] || return 1
+    v="${_NUT_CACHE_STAMP[$p]:-}"
+    if [[ -z "$v" ]]; then
+        _nut_cache_stat_into "$p"
+        v="${_NUT_CACHE_STAMP[$p]:-}"
+    fi
+    [[ -n "$v" ]] || return 1
+    printf '%s' "${v%% *} ${v##* }"
+}
+
+# What every entry shares: the interpreter's newest file and the format.
+#
+# One `find` per run, not per file. Editing any module under the interpreter
+# moves it and every entry becomes a miss, which is the coarse but correct
+# answer to "the checker is more than one file".
+_nut_cache_base() {
+    [[ -n "$_NUT_CACHE_BASE" ]] && { printf '%s' "$_NUT_CACHE_BASE"; return 0; }
+    local root="${NUTSHELL_ROOT:-}" newest=""
+    if [[ -n "$root" && -d "$root/lib" ]]; then
+        newest="$(find "$root/lib" -type f -newer "$root/lib" -print 2>/dev/null | head -1)"
+        newest="$(
+            if stat -f '%m' "$root/lib" "$root/init" 2>/dev/null; then :
+            else stat -c '%Y' "$root/lib" "$root/init" 2>/dev/null; fi
+        )"
+        newest="${newest//$'\n'/-}"
+    fi
+    _NUT_CACHE_BASE="f${_NUT_CACHE_FORMAT}:${newest:-none}"
+    printf '%s' "$_NUT_CACHE_BASE"
+}
+
 # Where an answer is kept. Under the store, beside the toolchains and externs,
 # because it is derived data about this machine and not part of any project.
 _nut_cache_root() {
@@ -57,61 +127,83 @@ _nut_cache_root() {
     printf '%s/nutshell/checks' "${XDG_CACHE_HOME:-${HOME:-/tmp}/.cache}"
 }
 
-# One file's answer, for one check. The path a source file flattens to.
+# One file's answer, for one check.
+#
+# The path is percent-encoded rather than flattened. Replacing every `/` with
+# `_` maps `lib/toml/json.sh` and `lib/toml_json.sh` onto one entry, and the
+# answer for one is then served for the other.
+_nut_cache_escape() {
+    local in="${1:-}" out="" i c
+    for (( i = 0; i < ${#in}; i++ )); do
+        c="${in:i:1}"
+        case "$c" in
+            [A-Za-z0-9._-]) out+="$c" ;;
+            *) printf -v c '%%%02X' "'$c"; out+="$c" ;;
+        esac
+    done
+    printf '%s' "$out"
+}
+
 _nut_cache_path() {
-    local check="${1:-}" file="${2:-}" flat
+    local check="${1:-}" file="${2:-}"
     [[ -n "$check" && -n "$file" ]] || return 1
-    flat="${file//\//_}"
-    flat="${flat//[^A-Za-z0-9._-]/_}"
-    printf '%s/%s/%s' "$(_nut_cache_root)" "${check//[^A-Za-z0-9._-]/_}" "$flat"
+    printf '%s/%s/%s' "$(_nut_cache_root)" \
+        "$(_nut_cache_escape "$check")" "$(_nut_cache_escape "$file")"
+}
+
+# Everything an entry's freshness depends on, as one line.
+_nut_cache_key() {
+    local file="${1:-}" src="${NUT_CACHE_CHECKER:-}" cfg="${CONFIG_FILE:-}"
+    local sf sc sg
+    sf="$(_nut_cache_stamp_of "$file")" || return 1
+    sc="$(_nut_cache_stamp_of "$src")"  || return 1
+    sg="$(_nut_cache_stamp_of "$cfg")"  || return 1
+    printf '%s|%s|%s|%s' "$(_nut_cache_base)" "$sf" "$sc" "$sg"
 }
 
 #[pub]
 # Is there an answer for this file that nothing has invalidated?
 #
-# Fresh means newer than the file, newer than the check that produced it, and
-# newer than the config the thresholds came from. Any of the three moving means
-# the answer could be different and has to be worked out again.
+# Every input has to be exactly as it was: the file, the check script, the
+# config, the interpreter, and the entry format. Any of them unreadable is a
+# miss rather than a hit, because an input that cannot be checked has not been
+# checked.
+#
+# `NUT_CACHE_CHECKER` and `CONFIG_FILE` are both required. The config used to
+# be tested only when the variable happened to be set, so an unset one skipped
+# the test and the entry hit anyway.
 # Usage: nut_cache_hit <check> <file> -> returns 0 on a usable answer
 nut_cache_hit() {
     [[ "${NUT_CACHE_ENABLED:-0}" == "1" ]] || return 1
-    local check="${1:-}" file="${2:-}" entry
+    local check="${1:-}" file="${2:-}" entry want have
     entry="$(_nut_cache_path "$check" "$file")" || return 1
     [[ -f "$entry" ]] || return 1
-    [[ -e "$file" ]] || return 1
-    [[ "$entry" -nt "$file" ]] || return 1
-
-    # The check itself. Named by the caller, because only it knows which file
-    # it is; a check that does not say cannot be cached.
-    local src="${NUT_CACHE_CHECKER:-}"
-    [[ -n "$src" && -e "$src" ]] || return 1
-    [[ "$entry" -nt "$src" ]] || return 1
-
-    # And the thresholds it measured against.
-    if [[ -n "${CONFIG_FILE:-}" && -e "${CONFIG_FILE}" ]]; then
-        [[ "$entry" -nt "$CONFIG_FILE" ]] || return 1
-    fi
-    return 0
+    want="$(_nut_cache_key "$file")" || return 1
+    IFS= read -r have < "$entry" 2>/dev/null || return 1
+    [[ "$have" == "$want" ]]
 }
 
 #[pub]
-# The answer that was kept. Nothing, and non-zero, when there is none.
+# The answer that was kept, without its stamp line.
 # Usage: nut_cache_read <check> <file> -> prints what was cached
 nut_cache_read() {
     local entry; entry="$(_nut_cache_path "$1" "$2")" || return 1
     [[ -r "$entry" ]] || return 1
-    cat "$entry"
+    tail -n +2 "$entry"
 }
 
 #[pub]
-# Keep an answer. A failure to write is not a failure of the check: the run
-# still has the answer, it just will not have it next time.
+# Keep an answer, with the stamp of everything it depended on. A failure to
+# write is not a failure of the check: the run still has the answer, it just
+# will not have it next time.
 # Usage: nut_cache_write <check> <file> <findings>
 nut_cache_write() {
     [[ "${NUT_CACHE_ENABLED:-0}" == "1" ]] || return 0
-    local entry; entry="$(_nut_cache_path "$1" "$2")" || return 0
+    local entry key
+    entry="$(_nut_cache_path "$1" "$2")" || return 0
+    key="$(_nut_cache_key "$2")" || return 0
     mkdir -p "${entry%/*}" 2>/dev/null || return 0
-    printf '%s' "${3:-}" > "$entry" 2>/dev/null || return 0
+    { printf '%s\n' "$key"; printf '%s' "${3:-}"; } > "$entry" 2>/dev/null || return 0
     return 0
 }
 
@@ -121,7 +213,7 @@ nut_cache_write() {
 nut_cache_clear() {
     local root; root="$(_nut_cache_root)"
     if [[ -n "${1:-}" ]]; then
-        rm -rf "${root}/${1//[^A-Za-z0-9._-]/_}"
+        rm -rf "${root}/$(_nut_cache_escape "$1")"
     else
         rm -rf "$root"
     fi

--- a/lib/checkcache.sh
+++ b/lib/checkcache.sh
@@ -66,6 +66,57 @@ declare -g _NUT_CACHE_FORMAT=2
 
 declare -gA _NUT_CACHE_STAMP=()
 declare -g  _NUT_CACHE_BASE=""
+declare -g  _NUT_CACHE_STAT=""
+
+# Which `stat` this machine has, decided once by what it prints rather than by
+# what it returns.
+#
+# BSD spells the format `-f` and GNU spells it `-c`. Choosing with
+# `stat -f ... || stat -c ...` looks right and is not: on GNU, `-f` is not a
+# format flag at all, it asks for file-system status, and it does not
+# recognise `%m`. It can therefore exit 0 having printed something that is not
+# an mtime, the `||` never fires, and every stamp on Linux is garbage that
+# compares equal to itself. Invalidation stops, silently, on the platform most
+# of this runs on.
+#
+# So the probe reads the answer back. A format is accepted when it produces a
+# line whose first field is a plain number, which neither flavour produces for
+# the other's spelling.
+#
+# Prints `-f` or `-c`, or nothing when neither works.
+_nut_cache_stat_flag() {
+    [[ -n "$_NUT_CACHE_STAT" ]] && { printf '%s' "${_NUT_CACHE_STAT#none}"; return 0; }
+
+    local probe="${NUTSHELL_ROOT:-.}/init" out
+    [[ -f "$probe" ]] || probe="${BASH_SOURCE[0]}"
+
+    local flag fmt
+    for flag in -f -c; do
+        case "$flag" in
+            -f) fmt='%m' ;;
+            -c) fmt='%Y' ;;
+        esac
+        out="$(stat "$flag" "$fmt" "$probe" 2>/dev/null)" || continue
+        out="${out%%[!0-9]*}"
+        if [[ -n "$out" ]]; then
+            _NUT_CACHE_STAT="$flag"
+            printf '%s' "$flag"
+            return 0
+        fi
+    done
+
+    _NUT_CACHE_STAT="none"
+    return 1
+}
+
+# The `<mtime> <size> <path>` format for whichever `stat` this is.
+_nut_cache_stat_fmt() {
+    case "$(_nut_cache_stat_flag)" in
+        -f) printf '%%m %%z %%N' ;;
+        -c) printf '%%Y %%s %%n' ;;
+        *)  return 1 ;;
+    esac
+}
 
 # `<mtime> <size>` for a set of paths, in one call.
 _nut_cache_stat_into() {
@@ -82,8 +133,10 @@ _nut_cache_stat_into() {
         [[ -n "$path" ]] || continue
         _NUT_CACHE_STAMP["$path"]="${mtime} ${size}"
     done < <(
-        if stat -f '%m %z %N' "$@" 2>/dev/null; then :
-        else stat -c '%Y %s %n' "$@" 2>/dev/null; fi
+        local flag fmt
+        flag="$(_nut_cache_stat_flag)" || exit 0
+        fmt="$(_nut_cache_stat_fmt)"   || exit 0
+        stat "$flag" "$fmt" "$@" 2>/dev/null
     )
     return 0
 }
@@ -118,9 +171,10 @@ _nut_cache_base() {
         # changes what a check reports while touching nothing else.
         #
         # One `find` and one batched `stat`, per run rather than per file.
-        newest="$(
-            find "$root/lib" "$root/init" -type f -exec stat -f '%m' {} + 2>/dev/null \
-            || find "$root/lib" "$root/init" -type f -exec stat -c '%Y' {} + 2>/dev/null
+        local flag fmt
+        flag="$(_nut_cache_stat_flag)" && case "$flag" in -f) fmt='%m' ;; *) fmt='%Y' ;; esac
+        [[ -n "${flag:-}" ]] && newest="$(
+            find "$root/lib" "$root/init" -type f -exec stat "$flag" "$fmt" {} + 2>/dev/null
         )"
         newest="$(printf '%s\n' "$newest" | sort -rn | head -1)"
     fi

--- a/lib/checkcache.sh
+++ b/lib/checkcache.sh
@@ -69,10 +69,18 @@ declare -g  _NUT_CACHE_BASE=""
 
 # `<mtime> <size>` for a set of paths, in one call.
 _nut_cache_stat_into() {
-    local out line path
+    local line mtime size path
     while IFS= read -r line; do
         [[ -n "$line" ]] || continue
-        _NUT_CACHE_STAMP["${line#* * }"]="${line%% * *} ${line#* }"
+        # `<mtime> <size> <path>`, split from the front. Taking the size with
+        # `${v##* }` takes the last field, which is the path, so the size was
+        # stat'd and then thrown away and a content change landing on the same
+        # mtime hit. Two `git checkout`s inside one second do that, and so does
+        # `touch -r`.
+        mtime="${line%% *}"; line="${line#* }"
+        size="${line%% *}";  path="${line#* }"
+        [[ -n "$path" ]] || continue
+        _NUT_CACHE_STAMP["$path"]="${mtime} ${size}"
     done < <(
         if stat -f '%m %z %N' "$@" 2>/dev/null; then :
         else stat -c '%Y %s %n' "$@" 2>/dev/null; fi
@@ -90,7 +98,8 @@ _nut_cache_stamp_of() {
         v="${_NUT_CACHE_STAMP[$p]:-}"
     fi
     [[ -n "$v" ]] || return 1
-    printf '%s' "${v%% *} ${v##* }"
+    # Already `<mtime> <size>`; there is nothing to re-parse out of it.
+    printf '%s' "$v"
 }
 
 # What every entry shares: the interpreter's newest file and the format.
@@ -102,12 +111,18 @@ _nut_cache_base() {
     [[ -n "$_NUT_CACHE_BASE" ]] && { printf '%s' "$_NUT_CACHE_BASE"; return 0; }
     local root="${NUTSHELL_ROOT:-}" newest=""
     if [[ -n "$root" && -d "$root/lib" ]]; then
-        newest="$(find "$root/lib" -type f -newer "$root/lib" -print 2>/dev/null | head -1)"
+        # The newest *file*, not the directory's own mtime. A directory's mtime
+        # moves when an entry is added or removed and not when a file inside it
+        # is edited, so stat'ing `lib` caught `git pull` and a new module and
+        # missed the case this exists for: editing `lib/srcfile.sh` in place
+        # changes what a check reports while touching nothing else.
+        #
+        # One `find` and one batched `stat`, per run rather than per file.
         newest="$(
-            if stat -f '%m' "$root/lib" "$root/init" 2>/dev/null; then :
-            else stat -c '%Y' "$root/lib" "$root/init" 2>/dev/null; fi
+            find "$root/lib" "$root/init" -type f -exec stat -f '%m' {} + 2>/dev/null \
+            || find "$root/lib" "$root/init" -type f -exec stat -c '%Y' {} + 2>/dev/null
         )"
-        newest="${newest//$'\n'/-}"
+        newest="$(printf '%s\n' "$newest" | sort -rn | head -1)"
     fi
     _NUT_CACHE_BASE="f${_NUT_CACHE_FORMAT}:${newest:-none}"
     printf '%s' "$_NUT_CACHE_BASE"

--- a/lib/checkcache.sh
+++ b/lib/checkcache.sh
@@ -79,34 +79,43 @@ declare -g  _NUT_CACHE_STAT=""
 # compares equal to itself. Invalidation stops, silently, on the platform most
 # of this runs on.
 #
-# So the probe reads the answer back. A format is accepted when it produces a
-# line whose first field is a plain number, which neither flavour produces for
-# the other's spelling.
+# So the probe reads the answer back, against a file whose size it already
+# knows. Requiring only "starts with a digit" would rest on a premise nothing
+# here can check: that no `stat` ever leads its wrong-flag output with a
+# number. GNU prints the literal `%m` and a stub might print a block count, and
+# the difference decides whether Linux gets working invalidation.
+#
+# A written file of known length removes the premise. A format is accepted when
+# it returns that exact length, which only the right spelling can do.
 #
 # Prints `-f` or `-c`, or nothing when neither works.
 _nut_cache_stat_flag() {
     [[ -n "$_NUT_CACHE_STAT" ]] && { printf '%s' "${_NUT_CACHE_STAT#none}"; return 0; }
 
-    local probe="${NUTSHELL_ROOT:-.}/init" out
-    [[ -f "$probe" ]] || probe="${BASH_SOURCE[0]}"
+    local probe out flag fmt rc=1
+    probe="$(mktemp "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")" || { _NUT_CACHE_STAT="none"; return 1; }
+    # Ten bytes, no trailing newline, so the size is known exactly.
+    printf '0123456789' > "$probe"
 
-    local flag fmt
     for flag in -f -c; do
         case "$flag" in
-            -f) fmt='%m' ;;
-            -c) fmt='%Y' ;;
+            -f) fmt='%m %z' ;;
+            -c) fmt='%Y %s' ;;
         esac
         out="$(stat "$flag" "$fmt" "$probe" 2>/dev/null)" || continue
-        out="${out%%[!0-9]*}"
-        if [[ -n "$out" ]]; then
-            _NUT_CACHE_STAT="$flag"
-            printf '%s' "$flag"
-            return 0
-        fi
+        # `<mtime> <size>`, and the size has to be the one just written.
+        [[ "$out" == *' '* ]] || continue
+        [[ "${out%% *}" =~ ^[0-9]+$ ]] || continue
+        [[ "${out##* }" == "10" ]] || continue
+        _NUT_CACHE_STAT="$flag"
+        rc=0
+        break
     done
 
-    _NUT_CACHE_STAT="none"
-    return 1
+    rm -f "$probe"
+    [[ "$rc" -eq 0 ]] || { _NUT_CACHE_STAT="none"; return 1; }
+    printf '%s' "$_NUT_CACHE_STAT"
+    return 0
 }
 
 # The `<mtime> <size> <path>` format for whichever `stat` this is.

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -148,10 +148,38 @@ extern_declared() {
     printf '%s %s' "$url" "${ref:-HEAD}"
 }
 
+# Resolved paths, by name, for the life of this process.
+#
+# Every `use <dep>::<module>` resolves the dependency again: the manifest is
+# re-read, the lockfile re-read, the mirror and the worktree each asked whether
+# git will answer for them. None of that can change while a script runs, and a
+# program taking five modules out of one library paid it five times -- about
+# four hundred milliseconds before anything of its own happened.
+declare -gA _EXTERN_RESOLVED=()
+
+#[pub]
+# Forget what has been resolved. For a caller that has changed a lockfile and
+# wants the next lookup to see it, and for tests.
+# Usage: extern_forget [name]
+extern_forget() {
+    if [[ -n "${1:-}" ]]; then unset '_EXTERN_RESOLVED[$1]'; else _EXTERN_RESOLVED=(); fi
+}
+
 #[pub]
 # Usage: extern_path shebang -> prints the checkout, fetching it once if needed
 extern_path() {
     local name="$1" spec url ref mirror commit dir
+
+    if [[ -n "${_EXTERN_RESOLVED[$name]:-}" ]]; then
+        # Still checked, because a cached path whose checkout has been removed
+        # is worse than no cache: the caller gets a directory git will not
+        # answer for and no explanation.
+        if _extern_is_repo "${_EXTERN_RESOLVED[$name]}"; then
+            printf '%s' "${_EXTERN_RESOLVED[$name]}"
+            return 0
+        fi
+        unset '_EXTERN_RESOLVED[$name]'
+    fi
     spec="$(extern_declared "$name")" || return 1
     url="${spec%% *}"
     ref="${spec##* }"
@@ -174,6 +202,7 @@ extern_path() {
         _extern_guard "$dir" _extern_lay_out "$name" "$mirror" "$url" "$commit" "$dir" || return 1
     fi
 
+    _EXTERN_RESOLVED["$name"]="$dir"
     printf '%s' "$dir"
 }
 

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -178,6 +178,17 @@ extern_declared() {
 # git will answer for them. None of that can change while a script runs, and a
 # program taking five modules out of one library paid it five times -- about
 # four hundred milliseconds before anything of its own happened.
+# What has been resolved this process.
+#
+# It reads as a working memo and has never been one: everything that writes to
+# it is reached through a command substitution, so the assignment happens in a
+# subshell and is gone when that returns. The per-process property callers
+# actually get comes from `init`'s loaded-module table short-circuiting the
+# `use` before this is reached.
+#
+# Left in place rather than deleted, because `extern_forget` is a public door
+# onto it and removing that is a change for consumers. Marked so the next
+# person to optimise this path does not find it and believe it.
 declare -gA _EXTERN_RESOLVED=()
 
 #[pub]
@@ -319,6 +330,12 @@ _extern_guard() {
     local dir="$1"; shift
     local lock="${dir}.lock" waited=0
 
+    # The parent, first. `mkdir "$lock"` is the lock, so it must not have a
+    # second reason to fail: a missing parent directory failed it exactly the
+    # way contention does, and the loop below then waited out the full eleven
+    # minutes for a lock nobody was holding.
+    mkdir -p "${lock%/*}" 2>/dev/null || true
+
     while ! mkdir "$lock" 2>/dev/null; do
         # Ready means ready, so a waiter never returns a half-written tree.
         _extern_is_repo "$dir" && return 0
@@ -351,7 +368,15 @@ _extern_guard() {
         fi
     done
 
-    printf '%s' "$$" > "${lock}/pid" 2>/dev/null
+    # `$BASHPID`, not `$$`.
+    #
+    # This runs inside a command substitution: `init` calls `extern_resolve`
+    # in `$( )`, which calls `extern_path`, which calls this. `$$` in a
+    # subshell is the *parent's* pid, so the lock recorded a process that
+    # outlives the one holding it. A subshell that died mid-clone left a lock
+    # naming a pid that `kill -0` still says is alive, and the takeover branch
+    # below never fired: the next process sat out the full wait instead.
+    printf '%s' "$BASHPID" > "${lock}/pid" 2>/dev/null
 
     local rc=0
     if ! _extern_is_repo "$dir"; then

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -401,7 +401,31 @@ extern_resolve() {
     rest="${spec#*::}"
     [[ "$name" == "$spec" ]] && return 1
 
+    # `::` separates modules the whole way down. A `/` is refused rather than
+    # handed to the filesystem, which is what made it work by accident.
+    if [[ "$rest" == */* ]]; then
+        log_error "'${spec}' separates modules with '/'; use '::': ${spec//\//::}"
+        return 1
+    fi
+    local declared="${spec#*::}"
+    rest="${rest//:://}"
+
     root="$(extern_path "$name")" || return 1
+
+    # A library that declares its modules is answered from the declaration and
+    # from nowhere else. Falling back to a search would put the guessing back
+    # underneath the declaration, where a wrong entry resolves anyway and
+    # nothing says so.
+    if [[ -r "${root}/lib.nut" ]]; then
+        local from_nut
+        if from_nut="$(_lib_nut_lookup "$root" "$declared" public)"; then
+            [[ -f "$from_nut" ]] && { printf '%s' "$from_nut"; return 0; }
+            log_error "${name}'s lib.nut declares '${declared}' at ${from_nut#$root/}, which is not there"
+            return 1
+        fi
+        log_error "'${declared}' is not among the modules ${name} declares"
+        return 1
+    fi
 
     # Two shapes, tried in order: a library laid out as `libs/<group>/<mod>.sh`,
     # and a flat `lib/<mod>.sh` like nutshell's own. Nothing else is guessed at,

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -122,9 +122,11 @@ extern_lock_write() {
 
     tmp="${lock}.tmp.$$"
     {
-        printf '# nut.lock - resolved dependency commits. Generated; commit it.\n'
+        printf '# nut.lock - what each dependency resolved to. Generated; commit it.\n'
         printf '#\n'
-        printf '# Delete an entry to take the newest commit on its ref again.\n'
+        printf '# A commit or a tag in nut.toml is a pin, and this holds the checkout\n'
+        printf '# there. A branch is a pin on that branch, meaning its head, and this\n'
+        printf '# records what the head was and is rewritten whenever it moves.\n'
 
         # Every other entry, carried across unchanged.
         if [[ -f "$lock" ]]; then
@@ -176,7 +178,7 @@ extern_forget() {
 #[pub]
 # Usage: extern_path shebang -> prints the checkout, fetching it once if needed
 extern_path() {
-    local name="$1" spec url ref mirror commit dir
+    local name="$1" spec url ref mirror commit dir out
 
     if [[ -n "${_EXTERN_RESOLVED[$name]:-}" ]]; then
         # Still checked, because a cached path whose checkout has been removed
@@ -194,10 +196,25 @@ extern_path() {
 
     mirror="$(_extern_mirror "$name" "$url" "$ref")" || return 1
 
-    commit="$(extern_locked "$name")" || commit=""
-    if [[ -z "$commit" ]]; then
-        commit="$(git -C "$mirror" rev-parse HEAD 2>/dev/null)" || return 1
+    # What the ref means decides whether the lock has anything to say. A branch
+    # is the remote's head of that branch now, so a recorded commit is a note
+    # about the past rather than a pin, and the lock is written rather than
+    # read. A tag or a revision names one commit, so the lock is the answer.
+    local kind="" resolved=""
+    if out="$(extern_resolve_ref "$url" "$ref")"; then
+        kind="${out%% *}"; resolved="${out#* }"
+    fi
+
+    if [[ "$kind" == "moving" ]]; then
+        commit="$resolved"
         extern_lock_write "$name" "$commit"
+    else
+        commit="$(extern_locked "$name")" || commit=""
+        if [[ -z "$commit" ]]; then
+            commit="${resolved:-$(_extern_ref_commit "$mirror" "$ref")}" || return 1
+            [[ -n "$commit" ]] || return 1
+            extern_lock_write "$name" "$commit"
+        fi
     fi
 
     dir="$(_extern_cache_root)/$(_extern_key "${url}@${commit}")"
@@ -371,6 +388,169 @@ _extern_mirror() {
 
     _extern_guard "$dir" _extern_fetch "$name" "$url" "$ref" "$dir" || return 1
     printf '%s' "$dir"
+}
+
+# -----------------------------------------------------------------------------
+# What a ref means
+# -----------------------------------------------------------------------------
+#
+# Two kinds, and the difference is whether the ref moves. A branch names the
+# remote's head of that branch, now, so the dependency comes up to it on every
+# run. A tag or a revision names one commit forever.
+#
+# A branch pin that locks itself the first time is not a pin on a branch, it is
+# a pin on whatever that branch happened to be. That is how a consumer ended up
+# holding its dependency's first commit while months of work went past it, and
+# the only symptom was a module that would not resolve.
+#
+# Asking the remote is a round trip, so the answer is kept for an hour: long
+# enough that a script in a loop does not talk to the network every time, short
+# enough that somebody who just pushed sees it on the next run.
+
+declare -gi EXTERN_BRANCH_TTL="${EXTERN_BRANCH_TTL:-3600}"
+
+# What the remote calls this ref. Prints "heads <sha>" or "tags <sha>", and
+# nothing when the remote has neither.
+#
+# The full refspec on both sides, because a bare name matches a tag as well as
+# a branch and which one wins is otherwise down to the order the remote lists
+# them. A branch wins where both exist: it is the one somebody meant to track.
+_extern_remote_ref() {
+    local url="$1" ref="$2" line sha
+    [[ -n "$ref" ]] || return 1
+
+    while IFS= read -r line; do
+        [[ "$line" == *"refs/heads/${ref}" ]] || continue
+        sha="${line%%[[:space:]]*}"
+        [[ -n "$sha" ]] && { printf 'heads %s' "$sha"; return 0; }
+    done < <(git ls-remote "$url" "refs/heads/${ref}" 2>/dev/null)
+
+    # `^{}` is the commit an annotated tag points at, and it is the one to
+    # build from; the bare line is the tag object itself.
+    local peeled="" plain=""
+    while IFS= read -r line; do
+        sha="${line%%[[:space:]]*}"
+        case "$line" in
+            *"refs/tags/${ref}^{}") peeled="$sha" ;;
+            *"refs/tags/${ref}")    plain="$sha"  ;;
+        esac
+    done < <(git ls-remote "$url" "refs/tags/${ref}" 2>/dev/null)
+    [[ -n "$peeled" ]] && { printf 'tags %s' "$peeled"; return 0; }
+    [[ -n "$plain" ]]  && { printf 'tags %s' "$plain";  return 0; }
+    return 1
+}
+
+# Where a branch resolution is remembered.
+_extern_resolution_path() {
+    printf '%s/branch-%s' "$(_extern_cache_root)" "$(_extern_key "${1}@${2}")"
+}
+
+_extern_read_resolution() {
+    local f="$1" ts sha
+    [[ -r "$f" ]] || return 1
+    { IFS= read -r ts; IFS= read -r sha; } < "$f" || return 1
+    [[ -n "$sha" ]] || return 1
+    printf '%s %s' "${ts:-0}" "$sha"
+}
+
+# The remembered resolution, if it is younger than the window.
+_extern_fresh_resolution() {
+    local out ts sha now
+    out="$(_extern_read_resolution "$1")" || return 1
+    ts="${out%% *}"; sha="${out#* }"
+    [[ "$ts" =~ ^[0-9]+$ ]] || return 1
+    now="$(date -u +%s 2>/dev/null)" || return 1
+    (( now - ts <= EXTERN_BRANCH_TTL )) || return 1
+    printf '%s' "$sha"
+}
+
+# The remembered resolution whatever its age, for when the remote cannot be
+# asked at all.
+_extern_any_resolution() {
+    local out; out="$(_extern_read_resolution "$1")" || return 1
+    printf '%s' "${out#* }"
+}
+
+_extern_remember_resolution() {
+    local f="$1" sha="$2"
+    fs_mkdir "${f%/*}" 2>/dev/null || return 0
+    printf '%s\n%s\n' "$(date -u +%s 2>/dev/null || printf 0)" "$sha" > "$f" 2>/dev/null || true
+    return 0
+}
+
+#[pub]
+# What a declared ref resolves to right now, and whether it can move.
+#
+# Prints "moving <sha>" for a branch and "fixed <sha>" for a tag or a
+# revision. A branch is asked of the remote, at most once an hour. Offline, the
+# last answer is used and said out loud: a revision that was the head an hour
+# ago is very probably still in the cache, and running from it beats refusing
+# to run on a machine somebody is in the middle of fixing.
+# Where a fixed ref and the lockfile disagree, the lockfile wins and the
+# checkout goes to the commit it names. That is what a lockfile is for and it is
+# right when an upstream tag has moved under a project that already resolved it.
+# It also means a hand-edited or damaged lock silently redirects a tag pin:
+# nothing checks that the locked commit is reachable from the ref, and deleting
+# the entry is how you ask for the ref to be resolved again.
+# Usage: extern_resolve_ref <url> <ref> -> prints "moving <sha>" or "fixed <sha>"
+extern_resolve_ref() {
+    local url="$1" ref="$2" out kind sha f
+
+    # A revision is itself, and asking a remote about it tells nobody anything.
+    if [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+        printf 'fixed %s' "$ref"
+        return 0
+    fi
+
+    f="$(_extern_resolution_path "$url" "$ref")"
+    if sha="$(_extern_fresh_resolution "$f")"; then
+        printf 'moving %s' "$sha"
+        return 0
+    fi
+
+    if out="$(_extern_remote_ref "$url" "$ref")"; then
+        kind="${out%% *}"; sha="${out#* }"
+        if [[ "$kind" == "heads" ]]; then
+            _extern_remember_resolution "$f" "$sha"
+            printf 'moving %s' "$sha"
+        else
+            printf 'fixed %s' "$sha"
+        fi
+        return 0
+    fi
+
+    if sha="$(_extern_any_resolution "$f")"; then
+        log_warn "could not ask ${url} about ${ref}; using the revision it named before" >&2
+        printf 'moving %s' "$sha"
+        return 0
+    fi
+    return 1
+}
+
+# Bring a mirror up to date with its ref. Best effort: a machine with no
+# network still has whatever it cloned, and a stale answer beats no answer for
+# a tool whose whole point is working on a machine that is broken.
+_extern_refresh() {
+    local mirror="$1" ref="$2"
+    [[ -n "$ref" ]] || return 0
+    # `--depth 1` because the mirror is only ever read at one commit, and the
+    # clone that made it was shallow too.
+    git -C "$mirror" fetch --quiet --depth 1 origin "$ref" 2>/dev/null || return 0
+    return 0
+}
+
+# What a ref points at in a mirror. FETCH_HEAD first, since that is what the
+# refresh just wrote; then the remote branch; then HEAD, which is the answer
+# for a mirror that was cloned at a sha.
+_extern_ref_commit() {
+    local mirror="$1" ref="$2" c
+    for c in FETCH_HEAD "origin/${ref}" "$ref" HEAD; do
+        [[ -n "$ref" || "$c" == "HEAD" ]] || continue
+        if git -C "$mirror" rev-parse --verify --quiet "${c}^{commit}" >/dev/null 2>&1; then
+            git -C "$mirror" rev-parse "${c}^{commit}" 2>/dev/null && return 0
+        fi
+    done
+    return 1
 }
 
 # _extern_fetch <name> <url> <ref> <dir>

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -76,9 +76,22 @@ _extern_manifest() {
     return 1
 }
 
+# Where fetched dependencies live: one central, content-addressed store shared
+# by every project on the machine, the same arrangement pnpm and yarn 2 settled
+# on. Two projects on the same commit of the same dependency have one copy of
+# it between them, and a project tree carries no dependency of its own.
+#
+# Under data rather than cache, deliberately. A cache is something a cleaner is
+# entitled to delete at any moment; this is where the dependencies of every
+# project on the machine actually live, and losing it offline breaks all of
+# them at once. `NUTSHELL_STORE` overrides it.
 _extern_cache_root() {
+    if [[ -n "${NUTSHELL_STORE:-}" ]]; then
+        printf '%s/externs' "${NUTSHELL_STORE%/}"
+        return 0
+    fi
     xdg_set_app_name nutshell
-    printf '%s/externs' "$(xdg_app_cache)"
+    printf '%s/externs' "$(xdg_app_data)"
 }
 
 # -----------------------------------------------------------------------------

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -57,7 +57,15 @@ use toml xdg fs log validate
 # manifest is the right answer for it.
 _extern_manifest() {
     local start dir
-    for start in "${NUTSHELL_SCRIPT_DIR:-}" "${PWD}"; do
+    # The file that wrote the `use`, first. NUTSHELL_SCRIPT_DIR is unset on
+    # purpose (a process that sources init would inherit an ancestor's), which
+    # left only PWD: so a tool installed on PATH and run from anywhere else
+    # could not find its own nut.toml, and every `use dep::x` in it failed.
+    #
+    # _NUT_ASKING_FROM is set per call by `use`, from BASH_SOURCE, so it says
+    # which unit is asking rather than which process was started. Same
+    # anchoring `super::` uses, for the same reason.
+    for start in "${_NUT_ASKING_FROM:-}" "${NUTSHELL_SCRIPT_DIR:-}" "${PWD}"; do
         [[ -z "$start" ]] && continue
         dir="$start"
         while [[ "$dir" != "/" && -n "$dir" ]]; do

--- a/lib/fs.sh
+++ b/lib/fs.sh
@@ -250,33 +250,39 @@ fs_basename_no_ext() {
 # Get file size in bytes
 # Usage: fs_size "/path/to/file" -> "12345"
 fs_size() {
+    nut_lazy_guard fs_size || return 1
+    local _NUT_LAZY_fs_size=1
     # First call: decide which implementation to use
     local impl=""
     
     if deps_has "stat"; then
         local variant="${_TOOL_VARIANT[stat]:-unknown}"
         case "$variant" in
-            gnu)     impl="stat_gnu.sh" ;;
-            bsd)     impl="stat_bsd.sh" ;;
+            gnu)     impl="stat_gnu" ;;
+            bsd)     impl="stat_bsd" ;;
             *)
                 # Unknown variant; try perl if available
                 if deps_has "perl"; then
-                    impl="perl_stat.sh"
+                    impl="perl_stat"
                 else
                     # Guess based on OS
                     case "$(uname -s)" in
-                        Darwin*) impl="stat_bsd.sh" ;;
-                        *)       impl="stat_gnu.sh" ;;
+                        Darwin*) impl="stat_bsd" ;;
+                        *)       impl="stat_gnu" ;;
                     esac
                 fi
                 ;;
         esac
     elif deps_has "perl"; then
-        impl="perl_stat.sh"
+        impl="perl_stat"
     fi
     
     if [[ -n "$impl" ]]; then
-        source "${_FS_IMPL_DIR}/${impl}"
+        # Named, not sourced by an assembled path. The resolver knows where
+        # the module is, loads it once however many callers arrive, and the
+        # declaration covers it; a hand-rolled `source` has none of that, and
+        # fails at the moment it is reached rather than before the run.
+        nut_reload "super::fs::impl::${impl}"
     else
         # No tool available
         fs_size() {
@@ -293,31 +299,37 @@ fs_size() {
 # Get file modification time (epoch seconds)
 # Usage: fs_mtime "/path/to/file" -> "1234567890"
 fs_mtime() {
+    nut_lazy_guard fs_mtime || return 1
+    local _NUT_LAZY_fs_mtime=1
     # First call: decide which implementation to use
     local impl=""
     
     if deps_has "stat"; then
         local variant="${_TOOL_VARIANT[stat]:-unknown}"
         case "$variant" in
-            gnu)     impl="stat_gnu.sh" ;;
-            bsd)     impl="stat_bsd.sh" ;;
+            gnu)     impl="stat_gnu" ;;
+            bsd)     impl="stat_bsd" ;;
             *)
                 if deps_has "perl"; then
-                    impl="perl_stat.sh"
+                    impl="perl_stat"
                 else
                     case "$(uname -s)" in
-                        Darwin*) impl="stat_bsd.sh" ;;
-                        *)       impl="stat_gnu.sh" ;;
+                        Darwin*) impl="stat_bsd" ;;
+                        *)       impl="stat_gnu" ;;
                     esac
                 fi
                 ;;
         esac
     elif deps_has "perl"; then
-        impl="perl_stat.sh"
+        impl="perl_stat"
     fi
     
     if [[ -n "$impl" ]]; then
-        source "${_FS_IMPL_DIR}/${impl}"
+        # Named, not sourced by an assembled path. The resolver knows where
+        # the module is, loads it once however many callers arrive, and the
+        # declaration covers it; a hand-rolled `source` has none of that, and
+        # fails at the moment it is reached rather than before the run.
+        nut_reload "super::fs::impl::${impl}"
     else
         fs_mtime() {
             echo "[ERROR] fs_mtime: no stat tool available" >&2

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -72,11 +72,13 @@ fi
 # `_JSON_IMPL` a decision taken once at load rather than a value the dispatch
 # reads, which is what lets a caller move it and lets the tests exercise all
 # three rather than whichever the machine happened to pick.
-readonly _JSON_IMPL_DIR="${BASH_SOURCE[0]%/*}/json/impl"
-
-deps_has jq && source "${_JSON_IMPL_DIR}/jq.sh"
-{ deps_has python3 || deps_has python; } && source "${_JSON_IMPL_DIR}/python.sh"
-deps_has perl && source "${_JSON_IMPL_DIR}/perl.sh"
+# Named, not sourced by a path this file assembles. A hand-rolled `source`
+# goes around the resolver, so the file is loaded again for every caller that
+# reaches it, the declaration does not cover it, and nothing can tell before
+# running that the path was wrong.
+deps_has jq                             && use super::json::impl::jq
+{ deps_has python3 || deps_has python; } && use super::json::impl::python
+deps_has perl                           && use super::json::impl::perl
 
 
 # -----------------------------------------------------------------------------

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -10,6 +10,7 @@
 # Environment:
 #   LOG_LEVEL - debug|info|warn|error (default: info)
 #   LOG_COLOR - auto|always|never (default: auto)
+#   LOG_MARKS - auto|icon|text|none (default: auto)
 # =============================================================================
 
 # Prevent multiple inclusion
@@ -62,6 +63,185 @@ _log_format() {
     else
         printf '[%s] %s\n' "$level" "$message"
     fi
+}
+
+# -----------------------------------------------------------------------------
+# Marks and depth
+# -----------------------------------------------------------------------------
+#
+# A run of forty lines where one went wrong should not need reading forty times
+# to find it. Two things make that work, and both are about skimming.
+#
+# Every line can start with a mark saying what kind of line it is, in one
+# column, so the eye scans down rather than across. Icons where the terminal
+# can draw them, words where it cannot, and the caller may insist on either.
+#
+# And a line sits at the depth of the step it belongs to. `log_step` already
+# opened a heading and `log_substep` indented one line under it; what was
+# missing was nesting past one level and a way to close a step with how it
+# went. What produced a message is then a matter of looking left.
+
+LOG_MARKS="${LOG_MARKS:-auto}"
+
+declare -gi LOG_DEPTH=0
+declare -gi LOG_WARNINGS=0
+declare -gi LOG_FAILURES=0
+
+_LOG_MARKS_SET=0
+_LOG_M_OK="+"; _LOG_M_BAD="x"; _LOG_M_WARN="!"; _LOG_M_STEP=">"; _LOG_M_FLAT=" "
+
+# Can this terminal draw a character outside ASCII? A locale that is not UTF-8
+# renders one as several bytes of noise, and the linux console before a font is
+# loaded is where that happens, which is where a recovery script runs.
+_log_unicode_ok() {
+    case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+        *UTF-8*|*utf8*|*UTF8*|*utf-8*) ;;
+        *) return 1 ;;
+    esac
+    [[ "${TERM:-}" != "linux" ]]
+}
+
+_log_marks_init() {
+    (( _LOG_MARKS_SET == 1 )) && return 0
+    _LOG_MARKS_SET=1
+    case "$LOG_MARKS" in
+        none) _LOG_M_OK=" "; _LOG_M_BAD=" "; _LOG_M_WARN=" "; _LOG_M_STEP=" " ;;
+        text) _LOG_M_OK="+"; _LOG_M_BAD="x"; _LOG_M_WARN="!"; _LOG_M_STEP=">" ;;
+        icon) _log_marks_unicode ;;
+        *)    _log_unicode_ok && _log_marks_unicode ;;
+    esac
+}
+
+_log_marks_unicode() {
+    printf -v _LOG_M_OK   '%b' '\u2713'
+    printf -v _LOG_M_BAD  '%b' '\u2717'
+    printf -v _LOG_M_WARN '%b' '\u26a0'
+    printf -v _LOG_M_STEP '%b' '\u203a'
+}
+
+#[pub]
+# Choose how lines are marked, overriding what was detected.
+# Usage: log_marks icon | text | none | auto
+log_marks() { LOG_MARKS="${1:-auto}"; _LOG_MARKS_SET=0; _log_marks_init; }
+
+#[pub]
+# Forget the depth and the counts, for a caller starting a fresh run.
+# Usage: log_reset
+log_reset() { LOG_DEPTH=0; LOG_WARNINGS=0; LOG_FAILURES=0; }
+
+_log_pad() {
+    local n=$(( LOG_DEPTH * 2 ))
+    (( n > 0 )) || return 0
+    printf '%*s' "$n" ''
+}
+
+# One marked line. The mark sits outside the indent, so every mark in a run is
+# in the same column however deep its line is.
+_log_marked() {
+    local mark="$1" color="$2" text="$3" reset=""
+    _log_marks_init
+    _log_should_color && reset='\033[0m' || color=""
+    printf '%b%s%b %s%s\n' "$color" "$mark" "$reset" "$(_log_pad)" "$text"
+}
+
+#[pub]
+# Open a step. Everything after it is indented under it until it is ended.
+# Unlike log_step, which is a flat heading, these nest.
+# Usage: log_open "Partitioning"
+log_open() {
+    _log_should_emit info || { LOG_DEPTH=$(( LOG_DEPTH + 1 )); return 0; }
+    _log_marks_init
+    local bold="" reset=""
+    if _log_should_color; then bold='\033[1m'; reset='\033[0m'; fi
+    _log_marked "$_LOG_M_STEP" '\033[0;36m' "$(printf '%b%s%b' "$bold" "$*" "$reset")"
+    LOG_DEPTH=$(( LOG_DEPTH + 1 ))
+}
+
+#[pub]
+# Close the step, with how it went: ok, warn, fail, or nothing for silence.
+# Usage: log_close ok "3 partitions"
+log_close() {
+    (( LOG_DEPTH > 0 )) && LOG_DEPTH=$(( LOG_DEPTH - 1 ))
+    local how="${1:-}"; shift 2>/dev/null || true
+    case "$how" in
+        ok)   log_ok   "$@" ;;
+        warn) log_warned "$@" ;;
+        fail) log_failed "$@" ;;
+        "")   return 0 ;;
+        *)    log_flat "$how" "$@" ;;
+    esac
+}
+
+#[pub]
+# It worked. Marked, indented, and counted.
+# Usage: log_ok "made an ESP at /dev/sdb1"
+log_ok() {
+    _log_should_emit info || return 0
+    _log_marked "$_LOG_M_OK" '\033[0;32m' "$*"
+}
+
+#[pub]
+# Worth a look, and the run goes on.
+# Usage: log_warned "the free region is tight"
+log_warned() {
+    LOG_WARNINGS=$(( LOG_WARNINGS + 1 ))
+    _log_should_emit warn || return 0
+    _log_marked "$_LOG_M_WARN" '\033[0;33m' "$*"
+}
+
+#[pub]
+# It did not work.
+# Usage: log_failed "could not set the esp flag"
+log_failed() {
+    LOG_FAILURES=$(( LOG_FAILURES + 1 ))
+    _log_should_emit error || return 0
+    _log_marked "$_LOG_M_BAD" '\033[0;31m' "$*"
+}
+
+#[pub]
+# Something true that is neither good nor bad. Unmarked, so a run of these does
+# not read as a run of results.
+# Usage: log_flat "sgdisk: 3 partitions"
+log_flat() {
+    _log_should_emit info || return 0
+    _log_marked "$_LOG_M_FLAT" "" "$*"
+}
+
+#[pub]
+# Run a command as a step: its output indented under it, and a mark on the end
+# saying how it went. Returns what the command returned, which is the reason to
+# use it rather than printing around it.
+# Usage: log_run "writing the table" sgdisk --zap-all /dev/sdb
+log_run() {
+    local label="$1"; shift
+    log_open "$label"
+    local line rc=""
+    while IFS= read -r line; do
+        # The status travels in the stream, because a pipeline loses it and a
+        # runner that reports success on a failed command is worse than none.
+        # Read, never printed: a marker, not output.
+        if [[ "${line:0:1}" == $'\037' ]]; then rc="${line:1}"; break; fi
+        log_flat "$line"
+    done < <("$@" 2>&1; printf '\037%d\n' "$?")
+    [[ "$rc" =~ ^[0-9]+$ ]] || rc=1
+    if (( rc == 0 )); then log_close ok "$label"
+    else log_close fail "${label} (exit ${rc})"; fi
+    return "$rc"
+}
+
+#[pub]
+# How the run went overall: fail if anything failed, warn if anything warned,
+# ok otherwise. Counted even when LOG_LEVEL hid the line, because the verdict
+# is about what happened rather than about what was displayed.
+#
+# The counts live in the shell that logged. A run inside `$( )` or one side of
+# a pipe is a subshell, and what it counted does not come back; capture the
+# text or keep the count, not both from the same call.
+# Usage: log_worst -> ok | warn | fail
+log_worst() {
+    (( LOG_FAILURES > 0 )) && { printf 'fail'; return 0; }
+    (( LOG_WARNINGS > 0 )) && { printf 'warn'; return 0; }
+    printf 'ok'
 }
 
 # -----------------------------------------------------------------------------

--- a/lib/priv.sh
+++ b/lib/priv.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/priv.sh - Doing one thing as root, and then not being root
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# Elevation is a step, not a mode. `priv_run` takes one command, runs that as
+# root, and returns with the caller unchanged. Nothing else in the process
+# becomes root and nothing after it is.
+#
+# The failure this exists to prevent is quiet and it is not one tool's. A
+# program that needs root for one thing, gets it by being started under `sudo`,
+# and then keeps going writes the user's own files as root: their state
+# directory, their cache, their config, their history. It happened here. One
+# tool ended up with two journals, `~/.local/state/<tool>/journal` owned by the
+# person and a second one owned by root, and the person could no longer write
+# the second.
+#
+# Running a whole program under `sudo` is `su` with extra steps. This is the
+# other thing, the one the name always meant: do this, as root, now.
+#
+# Usage:
+#   use priv
+#
+#   priv_run "mount the stick" mount /dev/sda2 /mnt/stick || return 1
+#
+#   # Where a path belongs to the person, ask rather than reading $HOME.
+#   printf '%s/.local/state\n' "$(priv_user_home)"
+# =============================================================================
+
+nut_once || return 0
+
+use log
+
+# Who this actually is, worked out once and before anything elevates.
+#
+# Read at load time on purpose. A caller asking later, from inside something
+# that has already elevated, would be told about root, and the whole point is
+# to answer about the person.
+declare -g PRIV_USER="${PRIV_USER:-}"
+declare -g PRIV_HOME="${PRIV_HOME:-}"
+declare -g PRIV_UID="${PRIV_UID:-}"
+
+_priv_learn_user() {
+    [[ -z "$PRIV_UID" ]] || return 0
+
+    # `SUDO_USER` is set when this process was itself started under sudo, and
+    # then it names the person rather than root. That case is the one this
+    # module is trying to make unnecessary, and it still has to be answered
+    # correctly while it exists.
+    if [[ "$(id -u 2>/dev/null)" == "0" && -n "${SUDO_USER:-}" ]]; then
+        PRIV_USER="$SUDO_USER"
+        PRIV_UID="${SUDO_UID:-}"
+        [[ -n "$PRIV_UID" ]] || PRIV_UID="$(id -u "$PRIV_USER" 2>/dev/null)"
+        PRIV_HOME="$(_priv_home_of "$PRIV_USER")"
+        return 0
+    fi
+
+    PRIV_USER="$(id -un 2>/dev/null)"
+    PRIV_UID="$(id -u 2>/dev/null)"
+    PRIV_HOME="${HOME:-$(_priv_home_of "$PRIV_USER")}"
+}
+
+# A user's home from the password database rather than from the environment,
+# because the environment is what is wrong in the case this is for.
+_priv_home_of() {
+    # Initialised, not merely declared: `local x` leaves it unset, and a caller
+    # running under `set -u` gets an error rather than an empty string.
+    local u="$1" line=""
+    [[ -n "$u" ]] || return 1
+    if command -v getent >/dev/null 2>&1; then
+        line="$(getent passwd "$u" 2>/dev/null)" || line=""
+    fi
+    if [[ -z "$line" && -r /etc/passwd ]]; then
+        while IFS= read -r line; do
+            [[ "$line" == "${u}:"* ]] && break
+            line=""
+        done < /etc/passwd
+    fi
+    if [[ -n "$line" ]]; then
+        # name:passwd:uid:gid:gecos:home:shell
+        local IFS=:
+        # shellcheck disable=SC2206
+        local -a f=($line)
+        [[ -n "${f[5]:-}" ]] && { printf '%s' "${f[5]}"; return 0; }
+    fi
+    # A mac keeps its users elsewhere, and `dscl` is how you ask.
+    if command -v dscl >/dev/null 2>&1; then
+        local h; h="$(dscl . -read "/Users/${u}" NFSHomeDirectory 2>/dev/null)" || h=""
+        h="${h#*: }"
+        [[ -n "$h" ]] && { printf '%s' "$h"; return 0; }
+    fi
+    return 1
+}
+
+_priv_learn_user
+
+#[pub]
+# The person who started this, whatever has elevated since.
+# Usage: priv_user -> a name
+priv_user() { _priv_learn_user; printf '%s' "$PRIV_USER"; }
+#[pub]
+# Usage: priv_uid -> a number
+priv_uid()  { _priv_learn_user; printf '%s' "$PRIV_UID"; }
+#[pub]
+# Their home, from the password database rather than from `$HOME`.
+#
+# `$HOME` is exactly what is wrong inside something that elevated, so anything
+# building a path the person will look for asks this instead.
+# Usage: priv_user_home -> a path
+priv_user_home() { _priv_learn_user; printf '%s' "$PRIV_HOME"; }
+
+#[pub]
+# Is this already root?
+# Usage: priv_is_root
+priv_is_root() { [[ "$(id -u 2>/dev/null)" == "0" ]]; }
+
+#[pub]
+# Can this ask for root at all, and how?
+#
+# Prints the command that would do it, or nothing. `doas` as well as `sudo`,
+# because a machine that has chosen one usually does not have the other.
+# Usage: priv_how -> "sudo", "doas", or nothing
+priv_how() {
+    priv_is_root && { printf 'already'; return 0; }
+    local c
+    for c in sudo doas; do
+        command -v "$c" >/dev/null 2>&1 && { printf '%s' "$c"; return 0; }
+    done
+    return 1
+}
+
+#[pub]
+# Would asking for root need a password right now?
+#
+# Answers without asking for one. A caller that wants to warn before a prompt
+# appears, or to decide whether an unattended run can proceed, asks this.
+# Usage: priv_needs_password
+priv_needs_password() {
+    priv_is_root && return 1
+    local how; how="$(priv_how)" || return 0
+    case "$how" in
+        sudo) sudo -n true 2>/dev/null && return 1 ;;
+        doas) doas -n true 2>/dev/null && return 1 ;;
+    esac
+    return 0
+}
+
+#[pub]
+# Run one command as root, then return.
+#
+# The first argument says what it is for, in words, so the log and the prompt
+# both name the thing rather than the mechanism. Everything after it is the
+# command and its arguments, passed through without a shell, so nothing here
+# has to think about quoting and a caller cannot accidentally build one string
+# out of a path with a space in it.
+#
+# Returns whatever the command returned. Refuses, without running anything,
+# when there is no way to elevate, or when a password would be needed and
+# there is no terminal to type it on: a prompt nobody can answer is a program
+# that hangs, and the machines this runs on are often being fixed over a pipe.
+# Usage: priv_run "mount the stick" mount /dev/sda2 /mnt
+priv_run() {
+    local what="${1:-a privileged step}"; shift || true
+    (( $# > 0 )) || { log_error "priv_run: nothing to run"; return 2; }
+
+    if priv_is_root; then
+        "$@"
+        return $?
+    fi
+
+    local how
+    how="$(priv_how)" || {
+        log_error "${what}: this needs root and there is no sudo or doas here"
+        return 2
+    }
+
+    if priv_needs_password && ! _priv_can_prompt; then
+        log_error "${what}: this needs root, and there is no terminal to ask for a password on"
+        return 2
+    fi
+
+    # Said before the prompt appears, so an unexpected password request has a
+    # sentence beside it explaining what asked for it.
+    if priv_needs_password; then
+        log_info "${what}: asking for your password for this one step"
+    fi
+
+    case "$how" in
+        sudo) sudo -- "$@" ;;
+        doas) doas -- "$@" ;;
+        *)    "$@" ;;
+    esac
+}
+
+# Is there a terminal a password could be typed on?
+_priv_can_prompt() {
+    [[ -t 0 || -t 1 || -t 2 ]] && return 0
+    # An askpass helper is a terminal by another name.
+    [[ -n "${SUDO_ASKPASS:-}" ]] && return 0
+    return 1
+}
+
+#[pub]
+# Give a file back to the person after something elevated made it.
+#
+# The other half of the split this module is about. A file root wrote into a
+# place the person owns is a file they cannot change afterwards, and the
+# symptom arrives much later than the cause.
+# Usage: priv_return <path>...
+priv_return() {
+    local u; u="$(priv_user)"
+    [[ -n "$u" && "$u" != "root" ]] || return 0
+    priv_is_root || return 0
+    local p
+    for p in "$@"; do
+        [[ -e "$p" ]] || continue
+        chown -R "$u" "$p" 2>/dev/null || true
+    done
+}

--- a/lib/priv.sh
+++ b/lib/priv.sh
@@ -111,6 +111,74 @@ priv_uid()  { _priv_learn_user; printf '%s' "$PRIV_UID"; }
 # Usage: priv_user_home -> a path
 priv_user_home() { _priv_learn_user; printf '%s' "$PRIV_HOME"; }
 
+# One argument, quoted so any POSIX shell reads it back as itself.
+#
+# Not `printf %q`. That emits bash's ANSI-C form for anything holding a tab, a
+# newline or a control character, and `$'...'` is a bashism: dash, which is
+# `/bin/sh` on Debian and Ubuntu, reads `$'\t'` as the four characters and the
+# path arrives silently wrong. This function's whole job is writing a person's
+# files as that person, so a mangled path is root writing somewhere nobody
+# asked it to.
+#
+# Single quotes take everything literally, so the only character needing work
+# is the single quote itself: close, escape it outside the quotes, reopen.
+_priv_sq() {
+    local s="${1:-}"
+    printf "'%s'" "${s//\'/\'\\\'\'}"
+}
+
+#[pub]
+# Run one step as the person, from inside something that elevated.
+#
+# The other direction from `priv_run`, and the half that stops root's
+# fingerprints ending up on a person's files. `priv_return` repairs ownership
+# after the fact; this never creates the problem. Prefer it: a chown pass has
+# to be told every path, and the one it was not told about is the one nobody
+# notices.
+#
+# The cases that need it are the ones where the tool is root because some other
+# step needed root, and this step does not: git in somebody's checkout, a file
+# written into their home, anything reading their configuration.
+#
+# A no-op when not root, and a no-op when the person is root, so a caller does
+# not have to ask which it is.
+# Usage: priv_as_user "reading your checkout" git -C "$d" status
+priv_as_user() {
+    local what="${1:-a step}"; shift || true
+    (( $# > 0 )) || { log_error "priv_as_user: nothing to run"; return 2; }
+
+    local u; u="$(priv_user)"
+    if ! priv_is_root || [[ -z "$u" || "$u" == "root" ]]; then
+        "$@"
+        return $?
+    fi
+
+    local c
+    for c in runuser sudo su; do
+        command -v "$c" >/dev/null 2>&1 || continue
+        case "$c" in
+            # runuser is the one built for this: root to another user, no
+            # password, no login shell in the way.
+            runuser) runuser -u "$u" -- "$@"; return $? ;;
+            sudo)    sudo -n -u "$u" -- "$@"; return $? ;;
+            # Last, and through a shell, so the arguments have to be quoted
+            # back into one string. Every other route avoids that.
+            su)
+                local q="" a
+                for a in "$@"; do q+="${q:+ }$(_priv_sq "$a")"; done
+                # No `-s`. That flag is util-linux; BSD and macOS `su` is
+                # `su [-] [-flm] [login [args]]` and refuses it, and this is
+                # the branch a busybox rescue console actually takes.
+                su "$u" -c "$q"
+                return $?
+                ;;
+        esac
+    done
+
+    log_error "${what}: cannot step down to ${u}; there is no runuser, sudo or su"
+    return 2
+}
+
 #[pub]
 # Is this already root?
 # Usage: priv_is_root

--- a/lib/priv.sh
+++ b/lib/priv.sh
@@ -153,14 +153,19 @@ priv_as_user() {
         return $?
     fi
 
+    # `doas` is in here because `priv_run` already handles it. Without it a
+    # machine that can elevate cannot step back down, which is precisely the
+    # failure this function exists to prevent: OpenBSD and some Alpine
+    # installs carry doas and none of the other three.
     local c
-    for c in runuser sudo su; do
+    for c in runuser sudo doas su; do
         command -v "$c" >/dev/null 2>&1 || continue
         case "$c" in
             # runuser is the one built for this: root to another user, no
             # password, no login shell in the way.
             runuser) runuser -u "$u" -- "$@"; return $? ;;
             sudo)    sudo -n -u "$u" -- "$@"; return $? ;;
+            doas)    doas -u "$u" -- "$@"; return $? ;;
             # Last, and through a shell, so the arguments have to be quoted
             # back into one string. Every other route avoids that.
             su)
@@ -175,7 +180,7 @@ priv_as_user() {
         esac
     done
 
-    log_error "${what}: cannot step down to ${u}; there is no runuser, sudo or su"
+    log_error "${what}: cannot step down to ${u}; there is no runuser, sudo, doas or su"
     return 2
 }
 

--- a/lib/srcfile.sh
+++ b/lib/srcfile.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/srcfile - A source file, read once, asked many times
+# =============================================================================
+# Part of nutshell. https://github.com/orgrinrt/nutshell
+#
+# Every checker reads the same files and asks the same four questions about
+# them: where is this function, where does it end, what is in its body, what is
+# on line N. Each of those used to be a pipeline: `grep | head | cut` for a
+# definition, `tail | grep | head | cut` for its end, a seven-stage `grep -v`
+# chain for a body. Thousands of processes per run, and every checker starting
+# again from nothing.
+#
+# Usage:
+#   use srcfile
+#
+#   nut_load_file lib/log.sh          # once, in the shell that loops
+#   nut_defined_at lib/log.sh log_info
+#   nut_body_of    lib/log.sh log_info BODY
+# =============================================================================
+
+[[ -n "${_NUTSHELL_SRCFILE_SH:-}" ]] && return 0
+readonly _NUTSHELL_SRCFILE_SH=1
+
+declare -gA _NUT_FILE_BODY=()
+declare -gA _NUT_FILE_AT=()
+declare -gA _NUT_FILE_N=()
+
+#[pub]
+# Read a file into the cache, once. Later calls for it do nothing.
+# Usage: nut_load_file <file>
+nut_load_file() {
+    local file="${1:-}"
+    [[ -n "${_NUT_FILE_N[$file]:-}" ]] && return 0
+    [[ -r "$file" ]] || return 1
+
+    local -a lines=()
+    if [[ "$(type -t mapfile)" == "builtin" ]]; then
+        mapfile -t lines < "$file" 2>/dev/null || return 1
+    else
+        local l
+        while IFS= read -r l || [[ -n "$l" ]]; do lines+=("$l"); done < "$file" || return 1
+    fi
+
+    local i line name
+    for (( i = 0; i < ${#lines[@]}; i++ )); do
+        line="${lines[$i]}"
+        _NUT_FILE_BODY["${file}:$((i + 1))"]="$line"
+        if [[ "$line" =~ ^[[:space:]]*(function[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_-]*)[[:space:]]*\( ]]; then
+            name="${BASH_REMATCH[2]}"
+            [[ -n "${_NUT_FILE_AT["${file}:${name}"]:-}" ]] \
+                || _NUT_FILE_AT["${file}:${name}"]=$((i + 1))
+        fi
+    done
+    _NUT_FILE_N[$file]="${#lines[@]}"
+    return 0
+}
+
+#[pub]
+# One line of a loaded file, by number. Nothing when it is not there.
+# Usage: nut_file_line <file> <n> -> prints the line
+nut_file_line() { printf '%s' "${_NUT_FILE_BODY["${1}:${2}"]:-}"; }
+
+#[pub]
+# How many lines a loaded file has.
+# Usage: nut_file_lines <file> -> prints a count
+nut_file_lines() { printf '%s' "${_NUT_FILE_N[${1}]:-0}"; }
+
+#[pub]
+# The line a function is defined on, or nothing.
+# Usage: nut_defined_at <file> <function> -> prints a line number
+nut_defined_at() {
+    local at="${_NUT_FILE_AT["${1}:${2}"]:-}"
+    [[ -n "$at" ]] || return 1
+    printf '%s' "$at"
+}
+
+#[pub]
+# Where a function's body ends: the first line that closes it at column one, or
+# closes it alone on its own line. The same heuristic the checks used, without
+# the `tail | grep | head | cut` it took four processes to express.
+# Usage: nut_ends_at <file> <function> -> prints a line number
+nut_ends_at() {
+    local file="$1" start end n line
+    start="$(nut_defined_at "$file" "$2")" || return 1
+    n="${_NUT_FILE_N[$file]:-0}"
+    for (( end = start + 1; end <= n; end++ )); do
+        line="${_NUT_FILE_BODY["${file}:${end}"]}"
+        [[ "$line" == "}" ]] && { printf '%s' "$end"; return 0; }
+        [[ "$line" =~ ^[[:space:]]*\}[[:space:]]*$ ]] && { printf '%s' "$end"; return 0; }
+    done
+    return 1
+}
+
+#[pub]
+# The lines of a function's body that carry something.
+#
+# Comments, blanks, bare declarations and a bare `return` are dropped, which is
+# what a seven-stage `grep -v` chain was doing per function.
+# Usage: nut_body_of <file> <function> <array-name>
+nut_body_of() {
+    local file="$1" fn="$2" out="$3" start end i line
+    [[ "$out" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 2
+    eval "$out=()"
+    start="$(nut_defined_at "$file" "$fn")" || return 1
+    end="$(nut_ends_at "$file" "$fn")" || return 1
+    for (( i = start + 1; i < end; i++ )); do
+        line="${_NUT_FILE_BODY["${file}:${i}"]}"
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line//[[:space:]]/}" ]] && continue
+        [[ "$line" =~ ^[[:space:]]*(local|readonly)[[:space:]] ]] && continue
+        [[ "$line" =~ ^[[:space:]]*return[[:space:]]*$ ]] && continue
+        [[ "$line" =~ ^[[:space:]]*return[[:space:]]+\$\?[[:space:]]*$ ]] && continue
+        [[ "$line" =~ ^[[:space:]]*\}[[:space:]]*$ ]] && continue
+        eval "$out+=(\"\$line\")"
+    done
+    return 0
+}
+

--- a/lib/srcfile.sh
+++ b/lib/srcfile.sh
@@ -22,6 +22,9 @@
 [[ -n "${_NUTSHELL_SRCFILE_SH:-}" ]] && return 0
 readonly _NUTSHELL_SRCFILE_SH=1
 
+# For `ATTR_DEFINES_PATTERN`: one answer about what a definition is.
+use attr
+
 declare -gA _NUT_FILE_BODY=()
 declare -gA _NUT_FILE_AT=()
 declare -gA _NUT_FILE_N=()
@@ -46,8 +49,12 @@ nut_load_file() {
     for (( i = 0; i < ${#lines[@]}; i++ )); do
         line="${lines[$i]}"
         _NUT_FILE_BODY["${file}:$((i + 1))"]="$line"
-        if [[ "$line" =~ ^[[:space:]]*(function[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_-]*)[[:space:]]*\( ]]; then
-            name="${BASH_REMATCH[2]}"
+        # The shared pattern, so a definition means the same thing here as it
+        # does to `attr`. The two had drifted: this one missed
+        # `function name {` and that one missed both a hyphen and a space
+        # before the parentheses.
+        if [[ "$line" =~ $ATTR_DEFINES_PATTERN ]]; then
+            name="${BASH_REMATCH[2]:-${BASH_REMATCH[3]}}"
             [[ -n "${_NUT_FILE_AT["${file}:${name}"]:-}" ]] \
                 || _NUT_FILE_AT["${file}:${name}"]=$((i + 1))
         fi

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -201,6 +201,27 @@ test_run() {
     local name output rc
     _TEST_MARK_DIR="$(_test_mark_dir)" || return 1
 
+    # A file that yields no tests at all, counted before any filter. The same
+    # reasoning as the assert-nothing check below, one level up: a file nobody
+    # can run occupies the place a real one would be noticed missing from, and
+    # `[OK] 0 passed` reads as a pass.
+    #
+    # It is not hypothetical. Renaming `attr_find` breaks the discovery this
+    # very loop uses, so every file in the suite yields nothing and the run
+    # reports green over a library that no longer loads.
+    local found=0
+    while IFS= read -r name; do
+        [[ -n "$name" ]] && found=$(( found + 1 ))
+    done < <(attr_find "$file" test)
+
+    if [[ "$found" -eq 0 ]]; then
+        _TEST_FAILED+=1
+        _TEST_FAILURES+=("${file##*/}: no #[test] found in the file")
+        log_tagged "FAIL" red "${file##*/}"
+        log_substep "no #[test] found. An empty file reports a pass otherwise."
+        return 1
+    fi
+
     while IFS= read -r name; do
         [[ -z "$name" ]] && continue
         [[ -n "${TEST_FILTER:-}" && "$name" != *"$TEST_FILTER"* ]] && continue

--- a/lib/text.sh
+++ b/lib/text.sh
@@ -158,12 +158,14 @@ text_lines() {
 # Find lines matching pattern
 # Usage: text_grep "pattern" "file" -> prints matching lines
 text_grep() {
+    nut_lazy_guard text_grep || return 1
+    local _NUT_LAZY_text_grep=1
     # First call: decide which implementation to use
     if deps_has "grep"; then
-        source "${_TEXT_IMPL_DIR}/grep_match.sh"
+        nut_reload super::text::impl::grep_match
         _TEXT_MATCH_IMPL="grep"
     elif deps_has "perl"; then
-        source "${_TEXT_IMPL_DIR}/perl_match.sh"
+        nut_reload super::text::impl::perl_match
         _TEXT_MATCH_IMPL="perl"
     else
         # No tool available; define a failing function
@@ -182,12 +184,14 @@ text_grep() {
 # Check if file contains pattern
 # Usage: text_contains "pattern" "file" -> returns 0 (true) or 1 (false)
 text_contains() {
+    nut_lazy_guard text_contains || return 1
+    local _NUT_LAZY_text_contains=1
     # First call: decide which implementation to use
     if deps_has "grep"; then
-        source "${_TEXT_IMPL_DIR}/grep_match.sh"
+        nut_reload super::text::impl::grep_match
         _TEXT_MATCH_IMPL="grep"
     elif deps_has "perl"; then
-        source "${_TEXT_IMPL_DIR}/perl_match.sh"
+        nut_reload super::text::impl::perl_match
         _TEXT_MATCH_IMPL="perl"
     else
         text_contains() {
@@ -204,12 +208,14 @@ text_contains() {
 # Count occurrences of pattern in file
 # Usage: text_count_matches "pattern" "file" -> "5"
 text_count_matches() {
+    nut_lazy_guard text_count_matches || return 1
+    local _NUT_LAZY_text_count_matches=1
     # First call: decide which implementation to use
     if deps_has "grep"; then
-        source "${_TEXT_IMPL_DIR}/grep_match.sh"
+        nut_reload super::text::impl::grep_match
         _TEXT_MATCH_IMPL="grep"
     elif deps_has "perl"; then
-        source "${_TEXT_IMPL_DIR}/perl_match.sh"
+        nut_reload super::text::impl::perl_match
         _TEXT_MATCH_IMPL="perl"
     else
         text_count_matches() {
@@ -236,22 +242,24 @@ text_count_matches() {
 #   3. perl
 #   4. awk (slowest, uses temp file)
 text_replace() {
+    nut_lazy_guard text_replace || return 1
+    local _NUT_LAZY_text_replace=1
     # First call: decide which implementation to use based on available tools
     local impl=""
     
     # Prefer combo when both grep and sed are available
     # The combo checks if pattern exists before invoking sed (optimization)
     if deps_has_all "grep" "sed"; then
-        source "${_TEXT_COMBO_DIR}/grep_sed.sh"
+        nut_reload super::text::impl::combo::grep_sed
         _TEXT_REPLACE_IMPL="grep_sed"
     elif deps_has "sed"; then
-        source "${_TEXT_IMPL_DIR}/sed_replace.sh"
+        nut_reload super::text::impl::sed_replace
         _TEXT_REPLACE_IMPL="sed"
     elif deps_has "perl"; then
-        source "${_TEXT_IMPL_DIR}/perl_replace.sh"
+        nut_reload super::text::impl::perl_replace
         _TEXT_REPLACE_IMPL="perl"
     elif deps_has "awk"; then
-        source "${_TEXT_IMPL_DIR}/awk_replace.sh"
+        nut_reload super::text::impl::awk_replace
         _TEXT_REPLACE_IMPL="awk"
     else
         # No tool available
@@ -278,8 +286,10 @@ text_replace() {
 # More efficient than sed alone when only a subset of lines need changes.
 # Falls back to sed-only if grep is not available.
 text_filtered_replace() {
+    nut_lazy_guard text_filtered_replace || return 1
+    local _NUT_LAZY_text_filtered_replace=1
     if deps_has_all "grep" "sed"; then
-        source "${_TEXT_COMBO_DIR}/grep_sed.sh"
+        nut_reload super::text::impl::combo::grep_sed
     else
         # Fallback: just do a regular replace (filter is ignored)
         # This is less efficient but still works
@@ -302,8 +312,10 @@ text_filtered_replace() {
 # 
 # Useful for extracting and reformatting specific lines without modifying the file.
 text_extract_transform() {
+    nut_lazy_guard text_extract_transform || return 1
+    local _NUT_LAZY_text_extract_transform=1
     if deps_has_all "grep" "sed"; then
-        source "${_TEXT_COMBO_DIR}/grep_sed.sh"
+        nut_reload super::text::impl::combo::grep_sed
     else
         # Fallback using separate grep and sed calls
         text_extract_transform() {
@@ -335,8 +347,10 @@ text_extract_transform() {
 # 
 # Useful for scoped counting, e.g., count TODOs only in comment lines.
 text_count_in_matches() {
+    nut_lazy_guard text_count_in_matches || return 1
+    local _NUT_LAZY_text_count_in_matches=1
     if deps_has_all "grep" "sed"; then
-        source "${_TEXT_COMBO_DIR}/grep_sed.sh"
+        nut_reload super::text::impl::combo::grep_sed
     else
         # Fallback
         text_count_in_matches() {

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -62,6 +62,20 @@ _toml_trim_into() {
 _toml_clean_into() {
     _toml_valid_target "$1" || return 2
     local __toml_out="$1" __toml_line="$2"
+
+    # The ordinary line has no quote and no `#` in it, and then there is
+    # nothing to scan for: the quote rules below only matter when a quote or a
+    # comment character is present. Deciding that costs one test; the loop
+    # costs six commands per character.
+    #
+    # This is the hottest path in the library. Config lookups go through it for
+    # every line of the file, and a trace of one QA run showed 1.4 million
+    # executions of the loop below, which was most of the run.
+    case "$__toml_line" in
+        *'"'*|*"'"*|*'#'*) ;;
+        *) _toml_trim_into "$__toml_out" "$__toml_line"; return ;;
+    esac
+
     local __toml_acc="" __toml_i __toml_c __toml_q=0 __toml_qc=""
     for (( __toml_i = 0; __toml_i < ${#__toml_line}; __toml_i++ )); do
         __toml_c="${__toml_line:__toml_i:1}"

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -66,7 +66,18 @@ _toml_clean_into() {
     for (( __toml_i = 0; __toml_i < ${#__toml_line}; __toml_i++ )); do
         __toml_c="${__toml_line:__toml_i:1}"
         if [[ $__toml_q -eq 1 ]]; then
-            [[ "$__toml_c" == "$__toml_qc" ]] && __toml_q=0
+            # The same escaped-quote rule as `_toml_clean_line`. It was fixed
+            # there and not here, and this is the copy on the hot path: every
+            # read of a value, every section listing and the JSON conversion go
+            # through it, so the truncation stayed for all of them.
+            if [[ "$__toml_c" == "\\" && "$__toml_qc" == '"' \
+                  && $(( __toml_i + 1 )) -lt ${#__toml_line} ]]; then
+                __toml_acc+="$__toml_c"
+                __toml_i=$(( __toml_i + 1 ))
+                __toml_c="${__toml_line:__toml_i:1}"
+            elif [[ "$__toml_c" == "$__toml_qc" ]]; then
+                __toml_q=0
+            fi
         elif [[ "$__toml_c" == '"' || "$__toml_c" == "'" ]]; then
             __toml_q=1; __toml_qc="$__toml_c"
         elif [[ "$__toml_c" == "#" ]]; then
@@ -89,7 +100,17 @@ _toml_clean_line() {
     for (( i = 0; i < ${#line}; i++ )); do
         char="${line:i:1}"
         if [[ "$in_quotes" -eq 1 ]]; then
-            [[ "$char" == "$quote" ]] && in_quotes=0
+            # An escaped quote inside a basic string does not close it. Read as
+            # a terminator, the rest of the value falls outside the string and
+            # a `#` in it truncates the line. TOML gives a literal string no
+            # escapes at all, so the backslash only counts inside `"`.
+            if [[ "$char" == "\\" && "$quote" == '"' && $(( i + 1 )) -lt ${#line} ]]; then
+                out+="$char"
+                i=$(( i + 1 ))
+                char="${line:i:1}"
+            elif [[ "$char" == "$quote" ]]; then
+                in_quotes=0
+            fi
         elif [[ "$char" == '"' || "$char" == "'" ]]; then
             in_quotes=1
             quote="$char"
@@ -102,6 +123,57 @@ _toml_clean_line() {
     str_trim "$out"
 }
 
+# Decode the escapes a TOML basic string is allowed to carry.
+#
+# Only a basic string has them: a literal string is taken as typed, which is
+# the whole difference between the two forms. Without this a value written
+# with an escaped quote or a backslash reads back with the backslashes still
+# in it, so a path or a piece of prose does not survive a write and a read.
+_toml_unescape() {
+    local s="$1"
+    # Nothing to do, and this is on the path of every value in every file.
+    if [[ "$s" != *\\* ]]; then
+        printf '%s' "$s"
+        return 0
+    fi
+
+    local out="" i char next
+    for (( i = 0; i < ${#s}; i++ )); do
+        char="${s:i:1}"
+        if [[ "$char" != "\\" || $(( i + 1 )) -ge ${#s} ]]; then
+            out+="$char"
+            continue
+        fi
+        next="${s:i+1:1}"
+        i=$(( i + 1 ))
+        case "$next" in
+            n)  out+=$'\n' ;;
+            t)  out+=$'\t' ;;
+            r)  out+=$'\r' ;;
+            b)  out+=$'\b' ;;
+            f)  out+=$'\f' ;;
+            '"') out+='"' ;;
+            "\\") out+="\\" ;;
+            u|U)
+                # \uXXXX and \UXXXXXXXX. printf knows the escape; anything
+                # that is not the right number of hex digits is not one, and
+                # is kept as typed rather than silently eaten.
+                local n=4; [[ "$next" == "U" ]] && n=8
+                local hex="${s:i+1:n}"
+                if [[ "${#hex}" -eq "$n" && "$hex" =~ ^[0-9A-Fa-f]+$ ]]; then
+                    # shellcheck disable=SC2059
+                    out+="$(printf "\\$next$hex")"
+                    i=$(( i + n ))
+                else
+                    out+="\\$next"
+                fi
+                ;;
+            *)  out+="\\$next" ;;
+        esac
+    done
+    printf '%s' "$out"
+}
+
 # Extract value, handling quotes
 _toml_extract_value() {
     local raw="$1"
@@ -109,7 +181,8 @@ _toml_extract_value() {
     
     # Double-quoted string
     if [[ "$raw" =~ ^\"(.*)\"$ ]]; then
-        echo "${BASH_REMATCH[1]}"
+        _toml_unescape "${BASH_REMATCH[1]}"
+        printf '\n'
         return 0
     fi
     
@@ -556,165 +629,6 @@ toml_is_true() {
     value="$(toml_get "$file" "$key")" || return 1
     
     is_truthy "$value"
-}
-
-#[pub]
-# Convert a TOML file to JSON
-# Usage: toml_to_json "file.toml" -> prints JSON
-toml_to_json() {
-    local file="${1:-}"
-    [[ ! -f "$file" ]] && return 1
-    
-    local json="{"
-    local need_comma=0
-    local current_section=""
-    local section_stack=()
-    local line clean_line
-    
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        _toml_clean_into clean_line "$line"
-        [[ -z "$clean_line" ]] && continue
-        
-        # Section header [section] or [section.subsection]
-        if [[ "$clean_line" =~ ^\[([^\]]+)\]$ ]]; then
-            local new_section="${BASH_REMATCH[1]}"
-            
-            # Close previous section(s) if any
-            while [[ ${#section_stack[@]} -gt 0 ]]; do
-                json+="}"
-                unset 'section_stack[-1]'
-            done
-            
-            # Start new section(s)
-            IFS='.' read -ra parts <<< "$new_section"
-            for part in "${parts[@]}"; do
-                [[ $need_comma -eq 1 ]] && json+=","
-                need_comma=0
-                json+="\"${part}\":{"
-                section_stack+=("$part")
-            done
-            
-            current_section="$new_section"
-            continue
-        fi
-        
-        # Key = value
-        if [[ "$clean_line" =~ ^([^=]+)=(.*)$ ]]; then
-            local key val
-            key="$(str_trim "${BASH_REMATCH[1]}")"
-            val="$(str_trim "${BASH_REMATCH[2]}")"
-            
-            [[ $need_comma -eq 1 ]] && json+=","
-            need_comma=1
-            
-            json+="\"${key}\":"
-            json+="$(_toml_value_to_json "$val")"
-        fi
-    done < "$file"
-    
-    # Close any open sections
-    while [[ ${#section_stack[@]} -gt 0 ]]; do
-        json+="}"
-        unset 'section_stack[-1]'
-    done
-    
-    json+="}"
-    echo "$json"
-}
-
-# Internal: Convert a TOML value to JSON
-_toml_value_to_json() {
-    local val="$1"
-    
-    # Boolean
-    if [[ "$val" == "true" ]]; then
-        echo "true"
-        return
-    fi
-    if [[ "$val" == "false" ]]; then
-        echo "false"
-        return
-    fi
-    
-    # Integer
-    if [[ "$val" =~ ^-?[0-9]+$ ]]; then
-        echo "$val"
-        return
-    fi
-    
-    # Float
-    if [[ "$val" =~ ^-?[0-9]+\.[0-9]+$ ]]; then
-        echo "$val"
-        return
-    fi
-    
-    # Array
-    if [[ "$val" =~ ^\[.*\]$ ]]; then
-        local content="${val#[}"
-        content="${content%]}"
-        content="$(str_trim "$content")"
-        
-        local json_arr="["
-        local first=1
-        local in_quotes=0
-        local item=""
-        local i char
-        
-        for ((i=0; i<${#content}; i++)); do
-            char="${content:$i:1}"
-            
-            if [[ "$char" == '"' ]]; then
-                ((in_quotes = 1 - in_quotes))
-                item+="$char"
-            elif [[ "$char" == ',' && $in_quotes -eq 0 ]]; then
-                item="$(str_trim "$item")"
-                if [[ -n "$item" ]]; then
-                    [[ $first -eq 0 ]] && json_arr+=","
-                    first=0
-                    json_arr+="$(_toml_value_to_json "$item")"
-                fi
-                item=""
-            else
-                item+="$char"
-            fi
-        done
-        
-        # Last item
-        item="$(str_trim "$item")"
-        if [[ -n "$item" ]]; then
-            [[ $first -eq 0 ]] && json_arr+=","
-            json_arr+="$(_toml_value_to_json "$item")"
-        fi
-        
-        json_arr+="]"
-        echo "$json_arr"
-        return
-    fi
-    
-    # Double-quoted string
-    if [[ "$val" =~ ^\"(.*)\"$ ]]; then
-        # Already quoted, just pass through (escape inner quotes if needed)
-        local inner="${BASH_REMATCH[1]}"
-        # Escape backslashes and quotes for JSON
-        inner="${inner//\\/\\\\}"
-        inner="${inner//\"/\\\"}"
-        echo "\"${inner}\""
-        return
-    fi
-    
-    # Single-quoted string (literal in TOML)
-    if [[ "$val" =~ ^\'(.*)\'$ ]]; then
-        local inner="${BASH_REMATCH[1]}"
-        inner="${inner//\\/\\\\}"
-        inner="${inner//\"/\\\"}"
-        echo "\"${inner}\""
-        return
-    fi
-    
-    # Unquoted - treat as string
-    val="${val//\\/\\\\}"
-    val="${val//\"/\\\"}"
-    echo "\"${val}\""
 }
 
 #[pub]

--- a/lib/toml.sh
+++ b/lib/toml.sh
@@ -27,6 +27,56 @@ use string validate
 # -----------------------------------------------------------------------------
 
 # Remove inline comments and trim whitespace from a line
+# Trim, without a subshell. `$(str_trim ...)` forks, and the reader calls it
+# once or twice for every line of every file: fifty-five lines cost a hundred
+# milliseconds, and something reading a manifest for seven keys paid it seven
+# times. Parameter expansion does the same job in the current shell.
+# The caller names the target, which makes two things the caller's business
+# and neither of them safe to assume.
+#
+# A name matching one of our own locals is shadowed by it, and the write lands
+# on the local instead: the caller's variable is untouched and nothing says so.
+# Prefixing the locals narrowed that to eight names rather than removing it, so
+# the reserved prefix is refused outright instead of hoped about.
+#
+# A name carrying an array subscript is EVALUATED by `printf -v`, so
+# `arr[$(...)]` runs the command inside it. Only a plain identifier is
+# accepted.
+_toml_valid_target() {
+    case "$1" in
+        __toml_*) return 1 ;;
+    esac
+    [[ "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]
+}
+
+_toml_trim_into() {
+    _toml_valid_target "$1" || return 2
+    local __toml_v="$2"
+    __toml_v="${__toml_v#"${__toml_v%%[![:space:]]*}"}"
+    __toml_v="${__toml_v%"${__toml_v##*[![:space:]]}"}"
+    printf -v "$1" '%s' "$__toml_v"
+}
+
+# The cleaner, likewise. Same rule about a `#` inside quotes; same result;
+# no fork.
+_toml_clean_into() {
+    _toml_valid_target "$1" || return 2
+    local __toml_out="$1" __toml_line="$2"
+    local __toml_acc="" __toml_i __toml_c __toml_q=0 __toml_qc=""
+    for (( __toml_i = 0; __toml_i < ${#__toml_line}; __toml_i++ )); do
+        __toml_c="${__toml_line:__toml_i:1}"
+        if [[ $__toml_q -eq 1 ]]; then
+            [[ "$__toml_c" == "$__toml_qc" ]] && __toml_q=0
+        elif [[ "$__toml_c" == '"' || "$__toml_c" == "'" ]]; then
+            __toml_q=1; __toml_qc="$__toml_c"
+        elif [[ "$__toml_c" == "#" ]]; then
+            break
+        fi
+        __toml_acc+="$__toml_c"
+    done
+    _toml_trim_into "$__toml_out" "$__toml_acc"
+}
+
 _toml_clean_line() {
     local line="$1"
 
@@ -119,15 +169,43 @@ toml_get() {
     local line clean_line
     local in_multiline_array=0
     local multiline_value=""
+    local in_multiline_string=0
+    local multiline_string=""
+    local capture_string=0
+    local multiline_delim=""
     
     while IFS= read -r line || [[ -n "$line" ]]; do
+        # A multi-line basic string, collected from RAW lines. Everything
+        # between the delimiters is literal, including a `#`, so the comment
+        # stripper must not run over it. Without this the reader returned a
+        # bare `"` for every such value, which callers then used as content.
+        if [[ $in_multiline_string -eq 1 ]]; then
+            if [[ "$line" == *"$multiline_delim"* ]]; then
+                in_multiline_string=0
+                if [[ $capture_string -eq 1 ]]; then
+                    multiline_string+="${line%%"$multiline_delim"*}"
+                    printf '%s' "$multiline_string"
+                    return 0
+                fi
+                continue
+            fi
+            [[ $capture_string -eq 1 ]] && multiline_string+="${line}"$'\n'
+            continue
+        fi
+
         # If we're collecting a multiline array, keep collecting
         # Don't use _toml_clean_line here because it would strip # inside quoted strings
         if [[ $in_multiline_array -eq 1 ]]; then
-            # Just trim whitespace, don't strip comments (they may be inside quotes)
+            # Comments inside a multi-line array are still comments. This used
+            # to keep the whole line, on the grounds that a `#` may sit inside
+            # a quoted value -- which is true, and is exactly what
+            # _toml_clean_line was written to handle. Keeping it meant the
+            # comment text was appended into the array and then split on
+            # commas, so a comment containing one swallowed the entry after it,
+            # silently. A declared path simply stopped being read.
             local trimmed
-            trimmed="$(str_trim "$line")"
-            [[ -z "$trimmed" ]] && continue  # Skip empty lines
+            _toml_clean_into trimmed "$line"
+            [[ -z "$trimmed" ]] && continue  # blank, or comment-only
             multiline_value+="$trimmed"
             # Check if this line closes the array (] not inside quotes)
             # Simple heuristic: line ends with ] or ],
@@ -139,7 +217,7 @@ toml_get() {
             continue
         fi
         
-        clean_line="$(_toml_clean_line "$line")"
+        _toml_clean_into clean_line "$line"
         [[ -z "$clean_line" ]] && continue
         
         # Section header
@@ -155,6 +233,45 @@ toml_get() {
             continue
         fi
         
+        # A multi-line string opens here. Detected BEFORE the section gates,
+        # because the body has to be skipped whatever section it sits in: a
+        # body line reading `[n]` was being taken as a real section header, and
+        # one reading `keymap = wrong` was returned as a real setting, from a
+        # section the caller never asked about.
+        if [[ "$clean_line" =~ ^([^=]+)=(.*)$ ]]; then
+            # Copied out before anything else runs. BASH_REMATCH is global and
+            # any `[[ =~ ]]` anywhere -- including inside a function called
+            # between the two reads -- replaces it. Reading group two after a
+            # call that matched something else gets nothing, under `set -u`
+            # loudly and otherwise silently.
+            local __raw_k="${BASH_REMATCH[1]}" __raw_v="${BASH_REMATCH[2]}"
+            local __k __v
+            _toml_trim_into __k "$__raw_k"
+            _toml_trim_into __v "$__raw_v"
+            # Basic and literal delimiters both. They differ in escape
+            # handling, which this reader does no processing of either way, so
+            # the only difference that matters here is which three characters
+            # close it.
+            local __d=""
+            [[ "$__v" == '"""'* ]] && __d='"""'
+            [[ "$__v" == "'''"* ]] && __d="'''"
+            if [[ -n "$__d" && "${__v#"$__d"}" != *"$__d"* ]]; then
+                in_multiline_string=1
+                multiline_delim="$__d"
+                capture_string=0
+                # Captured only when it is the value being looked for, and only
+                # when we are in the right section for it.
+                if [[ "$__k" == "$search_key" ]] \
+                   && { [[ -z "$section" && -z "$current_section" ]] \
+                        || [[ -n "$section" && $in_section -eq 1 ]]; }; then
+                    capture_string=1
+                    local __opening="${__v#"$__d"}"
+                    multiline_string="${__opening:+${__opening}$'\n'}"
+                fi
+                continue
+            fi
+        fi
+
         # Skip if we need a section but aren't in it
         if [[ -n "$section" && $in_section -eq 0 ]]; then
             continue
@@ -167,11 +284,24 @@ toml_get() {
         
         # Key = value
         if [[ "$clean_line" =~ ^([^=]+)=(.*)$ ]]; then
+            local raw_k="${BASH_REMATCH[1]}" raw_v="${BASH_REMATCH[2]}"
             local k v
-            k="$(str_trim "${BASH_REMATCH[1]}")"
-            v="$(str_trim "${BASH_REMATCH[2]}")"
+            _toml_trim_into k "$raw_k"
+            _toml_trim_into v "$raw_v"
             
             if [[ "$k" == "$search_key" ]]; then
+                # A triple-quoted value. Closed on the same line when there
+                # is a second delimiter after the first; otherwise it runs on.
+                # The single-line form of either delimiter.
+                local __sd=""
+                [[ "$v" == '"""'* ]] && __sd='"""'
+                [[ "$v" == "'''"* ]] && __sd="'''"
+                if [[ -n "$__sd" ]]; then
+                    local rest="${v#"$__sd"}"
+                    printf '%s' "${rest%%"$__sd"*}"
+                    return 0
+                fi
+
                 # Check if value starts an array that spans multiple lines
                 if [[ "$v" == "["* && "$v" != *"]"* ]]; then
                     in_multiline_array=1
@@ -246,7 +376,7 @@ toml_keys() {
     [[ -z "$section" ]] && in_section=1
     
     while IFS= read -r line || [[ -n "$line" ]]; do
-        clean_line="$(_toml_clean_line "$line")"
+        _toml_clean_into clean_line "$line"
         [[ -z "$clean_line" ]] && continue
         
         # Section header
@@ -442,7 +572,7 @@ toml_to_json() {
     local line clean_line
     
     while IFS= read -r line || [[ -n "$line" ]]; do
-        clean_line="$(_toml_clean_line "$line")"
+        _toml_clean_into clean_line "$line"
         [[ -z "$clean_line" ]] && continue
         
         # Section header [section] or [section.subsection]
@@ -602,7 +732,7 @@ toml_section_pairs() {
     local line clean_line
     
     while IFS= read -r line || [[ -n "$line" ]]; do
-        clean_line="$(_toml_clean_line "$line")"
+        _toml_clean_into clean_line "$line"
         [[ -z "$clean_line" ]] && continue
         
         # Section header

--- a/lib/toml/json.sh
+++ b/lib/toml/json.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/toml/json.sh - TOML as JSON
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# Converting to another format is a job of its own, and it is the only part of
+# the toml module that has to know what JSON looks like.
+# =============================================================================
+
+nut_once || return 0
+
+use super::toml
+
+
+#[pub]
+# Convert a TOML file to JSON.
+#
+# Sections nest the way TOML says they do: `[a.b]` after `[a]` is `b` inside
+# `a`, not a second `a` beside it. That second `a` was what this produced, and
+# a JSON object with the same key twice loses whichever half the reader's
+# parser discards.
+#
+# Sections are read in file order and a closed one is not reopened. A file that
+# leaves a section and comes back to it, or that writes `[b]` before `[a.c]`
+# when `[a]` is already behind it, cannot be converted in one pass without
+# building the whole tree first, so it is refused by name rather than converted
+# into an object with a repeated key.
+#
+# A quoted key or section name is refused the same way. Nothing else in this
+# library supports one: `toml_keys` leaves it out, `toml_section_pairs` hands it
+# back with its quotes still on, and `toml_get` cannot address it. Converting it
+# anyway produced valid JSON naming a key that is not the key, and a quoted
+# section holding a dot came out as two nested objects for a section with one
+# level. Wrong and quiet is worse than refused.
+#
+# Beyond those two, this is a one-pass reader and not a validator: a key
+# repeated inside one section comes out repeated, an integer with a leading zero
+# comes out as written, and an array holding a comma inside a quoted element or
+# another array is split on the wrong comma.
+# Usage: toml_to_json "file.toml" -> prints JSON, fails on a key it cannot name
+toml_to_json() {
+    local file="${1:-}"
+    [[ ! -f "$file" ]] && return 1
+
+    local json="{"
+    local need_comma=0
+    local line clean_line
+    local -a stack=()
+    local -a seen=()
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        _toml_clean_into clean_line "$line"
+        [[ -z "$clean_line" ]] && continue
+
+        # Section header [section] or [section.subsection]
+        if [[ "$clean_line" =~ ^\[([^\]]+)\]$ ]]; then
+            local new_section="${BASH_REMATCH[1]}"
+            if [[ "$new_section" == \"* || "$new_section" == \'* ]]; then
+                printf 'toml_to_json: %s: [%s] is a quoted section name, which nothing here can address\n' \
+                    "$file" "$new_section" >&2
+                return 1
+            fi
+            local -a parts=()
+            IFS='.' read -ra parts <<< "$new_section"
+
+            # How much of the path we are already inside. Only what differs
+            # gets closed, so a child section stays within its parent.
+            local common=0
+            while (( common < ${#stack[@]} && common < ${#parts[@]} )) \
+                  && [[ "${stack[$common]}" == "${parts[$common]}" ]]; do
+                common=$(( common + 1 ))
+            done
+
+            local i
+            for (( i = ${#stack[@]}; i > common; i-- )); do
+                json+="}"
+                unset 'stack[-1]'
+                need_comma=1
+            done
+
+            local path="" p
+            for (( i = 0; i < common; i++ )); do
+                path+="${path:+.}${stack[$i]}"
+            done
+            for (( i = common; i < ${#parts[@]}; i++ )); do
+                p="${parts[$i]}"
+                path+="${path:+.}${p}"
+                for prev in ${seen[@]+"${seen[@]}"}; do
+                    if [[ "$prev" == "$path" ]]; then
+                        printf 'toml_to_json: %s: section [%s] comes back to a part of the file already written\n' \
+                            "$file" "$new_section" >&2
+                        return 1
+                    fi
+                done
+                seen+=("$path")
+                [[ $need_comma -eq 1 ]] && json+=","
+                json+="$(_json_string "$p"):{"
+                need_comma=0
+                stack+=("$p")
+            done
+            continue
+        fi
+
+        # Key = value
+        if [[ "$clean_line" =~ ^([^=]+)=(.*)$ ]]; then
+            local key val
+            key="$(str_trim "${BASH_REMATCH[1]}")"
+            val="$(str_trim "${BASH_REMATCH[2]}")"
+
+            if [[ "$key" == \"* || "$key" == \'* ]]; then
+                printf 'toml_to_json: %s: %s is a quoted key, which nothing here can address\n' \
+                    "$file" "$key" >&2
+                return 1
+            fi
+
+            [[ $need_comma -eq 1 ]] && json+=","
+            need_comma=1
+
+            # Through the string writer, because a key is a string: a quoted
+            # key, or one with a quote in it, went in raw and the document was
+            # not JSON at all.
+            json+="$(_json_string "$key"):"
+            json+="$(_toml_value_to_json "$val")"
+        fi
+    done < "$file"
+
+    local i
+    for (( i = ${#stack[@]}; i > 0; i-- )); do
+        json+="}"
+    done
+
+    json+="}"
+    echo "$json"
+}
+
+# Internal: a string as JSON writes it, quotes included.
+#
+# JSON has its own escapes and they are not TOML's. A tab is a real tab by the
+# time it gets here and JSON will not take one raw inside a string.
+_json_string() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '"%s"' "$s"
+}
+
+# Internal: Convert a TOML value to JSON
+_toml_value_to_json() {
+    local val="$1"
+    
+    # Boolean
+    if [[ "$val" == "true" ]]; then
+        echo "true"
+        return
+    fi
+    if [[ "$val" == "false" ]]; then
+        echo "false"
+        return
+    fi
+    
+    # Integer
+    if [[ "$val" =~ ^-?[0-9]+$ ]]; then
+        echo "$val"
+        return
+    fi
+    
+    # Float
+    if [[ "$val" =~ ^-?[0-9]+\.[0-9]+$ ]]; then
+        echo "$val"
+        return
+    fi
+    
+    # Array
+    if [[ "$val" =~ ^\[.*\]$ ]]; then
+        local content="${val#[}"
+        content="${content%]}"
+        content="$(str_trim "$content")"
+        
+        local json_arr="["
+        local first=1
+        local in_quotes=0
+        local item=""
+        local i char
+        
+        for ((i=0; i<${#content}; i++)); do
+            char="${content:$i:1}"
+            
+            if [[ "$char" == '"' ]]; then
+                ((in_quotes = 1 - in_quotes))
+                item+="$char"
+            elif [[ "$char" == ',' && $in_quotes -eq 0 ]]; then
+                item="$(str_trim "$item")"
+                if [[ -n "$item" ]]; then
+                    [[ $first -eq 0 ]] && json_arr+=","
+                    first=0
+                    json_arr+="$(_toml_value_to_json "$item")"
+                fi
+                item=""
+            else
+                item+="$char"
+            fi
+        done
+        
+        # Last item
+        item="$(str_trim "$item")"
+        if [[ -n "$item" ]]; then
+            [[ $first -eq 0 ]] && json_arr+=","
+            json_arr+="$(_toml_value_to_json "$item")"
+        fi
+        
+        json_arr+="]"
+        echo "$json_arr"
+        return
+    fi
+    
+    # Basic string. Its TOML escapes are decoded first: escaping the raw text
+    # again wrote `\"` as `\\\"`, so a value with a quote or a backslash in it
+    # came out of the conversion with the backslashes doubled.
+    if [[ "$val" =~ ^\"(.*)\"$ ]]; then
+        _json_string "$(_toml_unescape "${BASH_REMATCH[1]}")"
+        printf '\n'
+        return
+    fi
+    
+    # Literal string, which has no escapes to decode.
+    if [[ "$val" =~ ^\'(.*)\'$ ]]; then
+        _json_string "${BASH_REMATCH[1]}"
+        printf '\n'
+        return
+    fi
+    
+    # Unquoted - treat as string
+    _json_string "$val"
+    printf '\n'
+}

--- a/lib/toml/write.sh
+++ b/lib/toml/write.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/toml/write.sh - Changing a TOML file without rewriting it
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# Reading TOML and editing TOML are different jobs and they live apart. The
+# reader parses; this one leaves the file alone except for the line it came
+# for.
+# =============================================================================
+
+nut_once || return 0
+
+#[pub]
+# Write a value, leaving the rest of the file as it was.
+#
+# Editing a config file is not the same as generating one. A person wrote the
+# comments in it, chose the order, put a blank line where they wanted a pause,
+# and a setter that rewrites the file from a parsed model throws all of that
+# away the first time anything saves. So: find the line, change the line, and
+# touch nothing else.
+#
+# A key with no section is a key before the first `[header]`, and only there. A
+# key in a section that does not exist yet gets the section appended. A key that
+# is not there gets appended inside its own section, after the last line that
+# belongs to it, rather than at the end of the file where it would land in
+# somebody else's.
+#
+# Usage: toml_set "file.toml" "section.key" "value"
+toml_set() {
+    local file="$1" key="$2" value="$3"
+    [[ -n "$file" && -n "$key" ]] || return 1
+
+    local section="" leaf="$key"
+    if [[ "$key" == *.* ]]; then
+        section="${key%.*}"; leaf="${key##*.}"
+    fi
+
+    local written; written="$(_toml_write_value "$value")"
+
+    [[ -f "$file" ]] || { printf '' > "$file" 2>/dev/null || return 1; }
+
+    local tmp; tmp="$(mktemp)" || return 1
+    local in_section=0 done_it=0 last_in_section=0 line n=0 seen_section=0
+
+    # One pass to find where the key's own part of the file ends, so an appended
+    # key lands inside it rather than at the end of the file. A section with
+    # nothing in it ends at its own header, which is why the header line counts.
+    #
+    # Root is a part of the file like any other: it runs from the first line to
+    # the line before the first header. `last_in_section` of 0 means it is empty,
+    # which for root means the file opens with a header and the new key goes
+    # above it.
+    if [[ -n "$section" ]]; then
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            n=$(( n + 1 ))
+            if [[ "$line" =~ ^[[:space:]]*\[(.+)\][[:space:]]*$ ]]; then
+                if [[ "${BASH_REMATCH[1]}" == "$section" ]]; then
+                    in_section=1; seen_section=1; last_in_section="$n"
+                else
+                    in_section=0
+                fi
+                continue
+            fi
+            (( in_section == 1 )) && [[ -n "${line// }" ]] && last_in_section="$n"
+        done < "$file"
+    else
+        seen_section=1
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            n=$(( n + 1 ))
+            [[ "$line" =~ ^[[:space:]]*\[(.+)\][[:space:]]*$ ]] && break
+            [[ -n "${line// }" ]] && last_in_section="$n"
+        done < "$file"
+    fi
+
+    # Root is a place, not the absence of one: everything before the first
+    # header. Reading it as "no section is open" made a root key match the first
+    # section that happened to have a key by that name, so `toml_set f name x`
+    # rewrote `[a] name` and `toml_get f name` then found nothing.
+    local at_root=1
+    in_section=0; n=0
+
+    # The file opens with a header and the key belongs above it.
+    if (( done_it == 0 )) && [[ -z "$section" ]] && (( last_in_section == 0 )); then
+        printf '%s = %s\n' "$leaf" "$written" >> "$tmp"
+        done_it=1
+    fi
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        n=$(( n + 1 ))
+        if [[ "$line" =~ ^[[:space:]]*\[(.+)\][[:space:]]*$ ]]; then
+            at_root=0
+            in_section=0
+            [[ "${BASH_REMATCH[1]}" == "$section" ]] && in_section=1
+            printf '%s\n' "$line" >> "$tmp"
+            # An empty section ends at its header, so the append has to be
+            # possible here too.
+            if (( done_it == 0 )) && [[ -n "$section" ]] && (( n == last_in_section )); then
+                printf '%s = %s\n' "$leaf" "$written" >> "$tmp"
+                done_it=1
+            fi
+            continue
+        fi
+
+        # The key itself, in the right place, replaced so its comment and its
+        # neighbours survive.
+        if (( done_it == 0 )) \
+           && { [[ -z "$section" ]] && (( at_root == 1 )) || (( in_section == 1 )); } \
+           && [[ "$line" =~ ^[[:space:]]*"$leaf"[[:space:]]*= ]]; then
+            printf '%s = %s\n' "$leaf" "$written" >> "$tmp"
+            done_it=1
+            continue
+        fi
+
+        printf '%s\n' "$line" >> "$tmp"
+
+        # Not there, but its part of the file is: append where that part ends.
+        if (( done_it == 0 )) && (( n == last_in_section )); then
+            printf '%s = %s\n' "$leaf" "$written" >> "$tmp"
+            done_it=1
+        fi
+    done < "$file"
+
+    if (( done_it == 0 )); then
+        if [[ -n "$section" ]] && (( seen_section == 0 )); then
+            [[ -s "$tmp" ]] && printf '\n' >> "$tmp"
+            printf '[%s]\n' "$section" >> "$tmp"
+        fi
+        printf '%s = %s\n' "$leaf" "$written" >> "$tmp"
+    fi
+
+    # Renamed into place, so a reader never sees a half-written file and a
+    # crash partway leaves the original intact.
+    mv -f "$tmp" "$file" || { rm -f "$tmp"; return 1; }
+    return 0
+}
+
+# A value as TOML writes it.
+#
+# A number, a bool and an array go in bare; everything else is a basic string,
+# and a basic string carries escapes. The five the reader decodes are the five
+# encoded here: without them a value with a newline in it wrote a file that no
+# longer parses at all, which loses every other key in it rather than the one
+# being written.
+_toml_write_value() {
+    local value="$1"
+    if [[ "$value" =~ ^-?[0-9]+$ ]] || [[ "$value" =~ ^-?[0-9]+\.[0-9]+$ ]] \
+       || [[ "$value" == "true" || "$value" == "false" ]] \
+       || [[ "$value" == \[*\] ]]; then
+        printf '%s' "$value"
+        return 0
+    fi
+    local esc="${value//\\/\\\\}"
+    esc="${esc//\"/\\\"}"
+    esc="${esc//$'\n'/\\n}"
+    esc="${esc//$'\r'/\\r}"
+    esc="${esc//$'\t'/\\t}"
+    esc="${esc//$'\b'/\\b}"
+    esc="${esc//$'\f'/\\f}"
+    printf '"%s"' "$esc"
+}
+
+#[pub]
+# Remove a key, leaving everything else alone.
+#
+# A key with no section means one before the first `[header]`. Reading that as
+# "no section is open" deleted the key from every section in the file.
+# Usage: toml_unset "file.toml" "section.key"
+toml_unset() {
+    local file="$1" key="$2"
+    [[ -f "$file" && -n "$key" ]] || return 1
+
+    local section="" leaf="$key"
+    if [[ "$key" == *.* ]]; then section="${key%.*}"; leaf="${key##*.}"; fi
+
+    local tmp; tmp="$(mktemp)" || return 1
+    local in_section=0 at_root=1 line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        if [[ "$line" =~ ^[[:space:]]*\[(.+)\][[:space:]]*$ ]]; then
+            at_root=0
+            in_section=0
+            [[ "${BASH_REMATCH[1]}" == "$section" ]] && in_section=1
+            printf '%s\n' "$line" >> "$tmp"; continue
+        fi
+        if { [[ -z "$section" ]] && (( at_root == 1 )) || (( in_section == 1 )); } \
+           && [[ "$line" =~ ^[[:space:]]*"$leaf"[[:space:]]*= ]]; then
+            continue
+        fi
+        printf '%s\n' "$line" >> "$tmp"
+    done < "$file"
+
+    mv -f "$tmp" "$file" || { rm -f "$tmp"; return 1; }
+    return 0
+}

--- a/nut.toml
+++ b/nut.toml
@@ -18,9 +18,13 @@
 # =============================================================================
 
 [meta]
+# The schema's version, not nutshell's. `examples/configs/empty.nut.toml` says
+# so where the field is documented, and a review read it as a third claim about
+# what nutshell is, next to `init`'s constant and the newest tag. Said here so
+# the next reader does not have to go and check.
 version = "1.0.0"
-name = "Tough Configuration"
-description = "Strict conventions. No compromises. No technical debt."
+name = "nutshell"
+description = "Everything you need, in a nutshell. Strict conventions, no compromises."
 
 # -----------------------------------------------------------------------------
 # Paths

--- a/release
+++ b/release
@@ -43,12 +43,35 @@ main() {
         return 1
     fi
 
-    # init is the single home of the version, so the tag cannot disagree
-    # with what the library reports about itself.
-    local version="${NUTSHELL_VERSION}"
-    if git rev-parse -q --verify "refs/tags/${version}" >/dev/null; then
-        log_error "tag ${version} already exists; bump NUTSHELL_VERSION in init"
+    # The tag is the version, and it is named here rather than read out of the
+    # library.
+    #
+    # `init`'s `NUTSHELL_VERSION` is a constant somebody has to remember to
+    # bump, and `docs/TODO.md` records op's ruling that identity comes from git
+    # and that the constant goes. This script used to take the version from it
+    # and call that "the single home of the version", which would have made the
+    # constant load-bearing for the release process as well as for resolution,
+    # so deleting it later would break this too. It is interim; nothing new
+    # depends on it.
+    local version="${1:-}"
+    if [[ -z "$version" ]]; then
+        log_error "which version? pass it: release <version>"
+        log_error "the newest tag is $(git describe --tags --abbrev=0 2>/dev/null || printf 'none')"
         return 1
+    fi
+    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+        log_error "${version} is not a version"
+        return 1
+    fi
+    if git rev-parse -q --verify "refs/tags/${version}" >/dev/null; then
+        log_error "tag ${version} already exists"
+        return 1
+    fi
+    # Said rather than enforced: the constant is still what a consumer's
+    # `nutshell_at_least` compares against until the pinning work lands.
+    if [[ "${NUTSHELL_VERSION:-}" != "$version" ]]; then
+        log_warn "init says ${NUTSHELL_VERSION:-nothing} and this tags ${version}"
+        log_warn "until git carries the identity, those want to agree"
     fi
 
     # The gates. A release does not skip what a commit would not.

--- a/schemas/nut.toml.schema.json
+++ b/schemas/nut.toml.schema.json
@@ -64,7 +64,7 @@
     },
     "deps": {
       "type": "object",
-      "description": "Dependency/tool configuration",
+      "description": "External libraries, by name, plus tool paths. A named entry is fetched from git and reached as `use <name>::<module>`.",
       "properties": {
         "paths": {
           "type": "object",
@@ -75,7 +75,24 @@
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": {
+        "type": "object",
+        "description": "An external library, resolved once into a shared cache and reused by everything naming the same ref.",
+        "properties": {
+          "git": {
+            "type": "string",
+            "description": "Repository URL to fetch the library from"
+          },
+          "ref": {
+            "type": "string",
+            "description": "Branch, tag or commit. Defaults to the repository's default branch"
+          }
+        },
+        "required": [
+          "git"
+        ],
+        "additionalProperties": false
+      }
     },
     "annotations": {
       "type": "object",

--- a/test
+++ b/test
@@ -12,7 +12,10 @@
 # =============================================================================
 
 set -uo pipefail
-. "${BASH_SOURCE[0]%/*}/init"
+# `|| exit 1` for the reason every example in the readme carries it: `init`
+# refuses below bash 4 with a `return`, and a `return` cannot stop its caller.
+# shellcheck source=/dev/null
+. "${BASH_SOURCE[0]%/*}/init" || exit 1
 
 use test log
 

--- a/tests/attr_test.sh
+++ b/tests/attr_test.sh
@@ -85,6 +85,15 @@ it_spawns_nothing_while_walking_a_file() {
     local src="${BASH_SOURCE[0]%/*}/../lib/attr.sh"
     local body
     body="$(sed -n '/^attr_on() {/,/^}/p' "$src"; sed -n '/^attr_find() {/,/^}/p' "$src")"
+
+    # The extraction has to have found something. Rename either walker and the
+    # `sed` matches nothing, the grep below finds nothing in nothing, and this
+    # reports a clean pass over a walker that forks per line. A zero out of a
+    # pipeline is a claim about the pipeline until the pipeline is shown able
+    # to produce anything else.
+    assert_ne "$body" ""
+    assert_contains "$body" "while IFS= read -r line"
+
     # No `$(...)` inside either walker. `$(( ))` is arithmetic and is not one.
     local subs; subs="$(grep -n '\$(' <<<"$body" | grep -v '\$((' || true)"
     assert_empty "$subs"

--- a/tests/attr_test.sh
+++ b/tests/attr_test.sh
@@ -86,13 +86,17 @@ it_spawns_nothing_while_walking_a_file() {
     local body
     body="$(sed -n '/^attr_on() {/,/^}/p' "$src"; sed -n '/^attr_find() {/,/^}/p' "$src")"
 
-    # The extraction has to have found something. Rename either walker and the
-    # `sed` matches nothing, the grep below finds nothing in nothing, and this
-    # reports a clean pass over a walker that forks per line. A zero out of a
-    # pipeline is a claim about the pipeline until the pipeline is shown able
-    # to produce anything else.
+    # Both walkers, counted. The first guard here asserted the extraction was
+    # non-empty, which closes the case where both are renamed and leaves the
+    # one that matters: rename `attr_on` alone, keep a wrapper, and put a fork
+    # in its loop, and `attr_find`'s text alone satisfies "non-empty" and
+    # "contains a read loop" while the forking walker is never looked at.
+    #
+    # A zero out of a pipeline is a claim about the pipeline, and so is a one
+    # where two were meant.
     assert_ne "$body" ""
-    assert_contains "$body" "while IFS= read -r line"
+    local loops; loops="$(grep -c 'while IFS= read -r line' <<<"$body")"
+    assert_eq "$loops" "2" "both walkers have to be in the extraction"
 
     # No `$(...)` inside either walker. `$(( ))` is arithmetic and is not one.
     local subs; subs="$(grep -n '\$(' <<<"$body" | grep -v '\$((' || true)"

--- a/tests/attr_test.sh
+++ b/tests/attr_test.sh
@@ -105,3 +105,88 @@ it_still_reads_an_attribute_with_an_argument_out_of_a_real_file() {
     assert_eq "$(attr_find "$d/x.sh" pub)" "big_fn"
     rm -rf "$d"
 }
+
+# --- one answer about what a definition is ------------------------------------
+#
+# bash accepts several spellings and this module took one of them, so a
+# `#[pub]` on any of the others was invisible and the public-API check skipped
+# those functions in silence rather than reporting them undocumented.
+#
+# `srcfile` had its own pattern for the same question and the two had already
+# drifted: this one took no hyphen and no `function` keyword, that one took
+# both. They share `ATTR_DEFINES_PATTERN` now.
+
+_ad_file() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-defines.XXXXXX")"
+    cat > "$d/f.sh" <<'EOS'
+#[pub]
+function old_style {
+  :
+}
+#[pub]
+function with_parens() {
+  :
+}
+#[pub]
+spaced_paren ()
+{
+  :
+}
+#[pub]
+has-hyphen() { :; }
+#[pub]
+plain() { :; }
+not_marked() { :; }
+EOS
+    printf '%s' "$d"
+}
+
+#[test]
+it_reads_every_spelling_bash_accepts_for_a_definition() {
+    local d; d="$(_ad_file)"
+    local n
+    for n in old_style with_parens spaced_paren has-hyphen plain; do
+        assert_ok attr_has "$d/f.sh" "$n" pub
+    done
+    rm -rf "$d"
+}
+
+#[test]
+it_finds_all_of_them_and_not_the_unmarked_one() {
+    local d; d="$(_ad_file)"
+    local found; found="$(attr_find "$d/f.sh" pub | sort | tr '\n' ' ')"
+    assert_contains "$found" "old_style"
+    assert_contains "$found" "with_parens"
+    assert_contains "$found" "spaced_paren"
+    assert_contains "$found" "has-hyphen"
+    assert_contains "$found" "plain"
+    # The control: a function with no attribute is not swept up by widening
+    # what counts as a definition.
+    assert_fails grep -q 'not_marked' <<<"$found"
+    rm -rf "$d"
+}
+
+#[test]
+it_gives_the_same_answer_as_srcfile_for_every_line() {
+    # The divergence, as its own case. Two readers of one question have to
+    # agree, and these two did not.
+    use srcfile
+    local d; d="$(_ad_file)"
+    nut_load_file "$d/f.sh"
+    local n
+    for n in old_style with_parens spaced_paren has-hyphen plain; do
+        assert_ok attr_has "$d/f.sh" "$n" pub
+        assert_ok nut_defined_at "$d/f.sh" "$n"
+    done
+    rm -rf "$d"
+}
+
+#[test]
+it_says_nothing_for_a_line_that_defines_nothing() {
+    assert_fails attr_defines_on 'x=1'
+    assert_fails attr_defines_on '# plain() { :; }'
+    assert_fails attr_defines_on ''
+    assert_fails attr_defines_on '  if foo(); then'
+    assert_eq "$(attr_defines_on 'plain() { :; }')" "plain"
+    assert_eq "$(attr_defines_on 'function old_style {')" "old_style"
+}

--- a/tests/attr_test.sh
+++ b/tests/attr_test.sh
@@ -54,3 +54,54 @@ it_tells_two_arguments_of_one_attribute_apart() {
     assert_eq "$(attr_arg "$FIXTURE" wrapper_allowed allow)" "trivial_wrapper"
     assert_eq "$(attr_arg "$FIXTURE" big_but_allowed allow)" "loc = 400"
 }
+
+# --- what this module needs on the machine ------------------------------------
+#
+# Nothing. It reads comments, and it used to do that by piping every line of
+# the file through `sed`, once per line, per lookup. On a library of 36 files
+# and 440 functions that was a quarter of a million processes and it made the
+# QA gate take four minutes.
+#
+# Bash can match a line itself. That is both the fast answer and the portable
+# one: a module this low should not need a userland to answer a question about
+# a comment, and a rescue console may not have one.
+
+#[test]
+it_calls_no_external_tool_at_all() {
+    local src="${BASH_SOURCE[0]%/*}/../lib/attr.sh"
+    local stray
+    # Code lines only. The comments above talk about the tools this no longer
+    # uses, and saying so is the point of them.
+    stray="$(grep -nE '(^|[^[:alnum:]_#])(awk|sed|grep|cut|head|tail|tr|wc|sort|expr)[[:space:]]' "$src" \
+        | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+    assert_empty "$stray"
+}
+
+#[test]
+it_spawns_nothing_while_walking_a_file() {
+    # The property behind the one above, measured rather than read. A command
+    # substitution is a fork too, so this catches the shape that was actually
+    # slow: `$(_attr_defines "$line")` per line.
+    local src="${BASH_SOURCE[0]%/*}/../lib/attr.sh"
+    local body
+    body="$(sed -n '/^attr_on() {/,/^}/p' "$src"; sed -n '/^attr_find() {/,/^}/p' "$src")"
+    # No `$(...)` inside either walker. `$(( ))` is arithmetic and is not one.
+    local subs; subs="$(grep -n '\$(' <<<"$body" | grep -v '\$((' || true)"
+    assert_empty "$subs"
+}
+
+#[test]
+it_still_reads_an_attribute_with_an_argument_out_of_a_real_file() {
+    # The control for both above: taking the tools out has to leave the
+    # answers alone, including the tab-separated argument form.
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-attr.XXXXXX")"
+    printf '#[pub]\n#[allow(loc = 400)]\n# prose does not break the run\n\nbig_fn() {\n  :\n}\n' \
+        > "$d/x.sh"
+    assert_ok  attr_has "$d/x.sh" big_fn pub
+    assert_ok  attr_has "$d/x.sh" big_fn allow
+    assert_fails attr_has "$d/x.sh" big_fn nope
+    assert_eq "$(attr_arg "$d/x.sh" big_fn allow)" "loc = 400"
+    assert_empty "$(attr_arg "$d/x.sh" big_fn pub)"
+    assert_eq "$(attr_find "$d/x.sh" pub)" "big_fn"
+    rm -rf "$d"
+}

--- a/tests/branch_test.sh
+++ b/tests/branch_test.sh
@@ -269,3 +269,47 @@ it_says_a_slashed_ref_is_a_name_problem_and_not_a_network_one() {
     assert_fails grep -q "could not reach" <<<"$said"
     _br_end
 }
+
+#[test]
+it_keeps_a_revision_something_is_still_using() {
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    local old; old="$(_br_head)"
+
+    # Aged past the prune's cutoff, as a long-running program's revision would
+    # be: modules load lazily through `use`, so a program started three days
+    # ago still holds its revision, and reading files inside a directory does
+    # not move the directory's mtime.
+    touch -t "$(date -v-2d +%Y%m%d%H%M 2>/dev/null || date -d '2 days ago' +%Y%m%d%H%M)" \
+        "$(_br_base)/$old"
+
+    # Something resolves to it again, which is what a running program does.
+    NUTSHELL_BRANCH_TTL=9999 nutshell_find "" dev >/dev/null 2>&1
+
+    # Now somebody else's push moves the head and prunes.
+    _br_move second
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+
+    # The old revision survives, because it was used within the day even though
+    # it was fetched days ago. Deleting it pulled the floor out from under a
+    # running program and every later `use` in it failed.
+    assert_ok test -f "$(_br_base)/$old/init"
+    _br_end
+}
+
+#[test]
+it_still_drops_a_revision_nothing_has_used() {
+    # The control for the one above. Touch-on-use must not turn the prune off.
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    local old; old="$(_br_head)"
+    _br_move second
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+    # Aged after the last resolution, so nothing has used it since.
+    touch -t "$(date -v-2d +%Y%m%d%H%M 2>/dev/null || date -d '2 days ago' +%Y%m%d%H%M)" \
+        "$(_br_base)/$old"
+    _br_move third
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+    assert_fails test -d "$(_br_base)/$old"
+    _br_end
+}

--- a/tests/branch_test.sh
+++ b/tests/branch_test.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Tests for a pin that names a branch rather than a version.
+#
+# A branch pin is not a floor, it is an identity: `dev` means the head of dev,
+# today. That makes it the one pin whose answer changes without anybody
+# editing anything, so what it costs to keep current, and what it does when the
+# remote cannot be reached, are the whole of it.
+#
+# It is also the one that shares a directory with every other project on the
+# machine while nothing locks it. So the checkouts are keyed by the revision
+# they hold and are written once, and none of this may ever delete a tree a
+# running interpreter is sourcing out of.
+
+use test
+
+. "${BASH_SOURCE[0]%/*}/../find-nutshell"
+
+_br_setup() {
+    BRROOT="$(mktemp -d)"
+    export NUTSHELL_TOOLCHAINS="$BRROOT/store"
+    export NUTSHELL_REMOTE="$BRROOT/remote.git"
+    NUTSHELL_INIT=""; NUTSHELL_FROM=""
+    unset NUTSHELL_HOME
+    # Whatever is installed on the machine running these must not decide
+    # their answers.
+    _BR_PATH_KEEP="$PATH"
+    local d out=""
+    while IFS= read -r d; do
+        [[ -n "$d" ]] || continue
+        [[ -x "$d/nutshell" ]] && continue
+        out="${out:+$out:}$d"
+    done <<< "${PATH//:/$'\n'}"
+    export PATH="$out"
+}
+_br_end() {
+    rm -rf "$BRROOT"
+    unset BRROOT NUTSHELL_TOOLCHAINS NUTSHELL_REMOTE
+    NUTSHELL_INIT=""; NUTSHELL_FROM=""
+    export PATH="${_BR_PATH_KEEP:-$PATH}"
+}
+
+# A remote carrying one branch, and a way to move it.
+_br_remote() {
+    local branch="${1:-dev}" version="${2:-0.4.0}"
+    BRWORK="$BRROOT/work"
+    mkdir -p "$BRWORK"
+    printf 'export NUTSHELL_VERSION="%s"\n' "$version" > "$BRWORK/init"
+    git -C "$BRWORK" init -q -b "$branch"
+    git -C "$BRWORK" config user.email t@example.invalid
+    git -C "$BRWORK" config user.name t
+    git -C "$BRWORK" config commit.gpgsign false
+    git -C "$BRWORK" add -A
+    git -C "$BRWORK" commit -qm "$version"
+    git init -q --bare "$NUTSHELL_REMOTE"
+    git -C "$BRWORK" remote add origin "$NUTSHELL_REMOTE"
+    git -C "$BRWORK" push -q origin "$branch"
+}
+_br_move() {
+    printf '# %s\n' "${1:-moved}" >> "$BRWORK/init"
+    git -C "$BRWORK" commit -qam "${1:-moved}"
+    git -C "$BRWORK" push -q origin HEAD
+}
+_br_head() { git -C "$BRWORK" rev-parse HEAD; }
+_br_base() { printf '%s/branches/%s' "$NUTSHELL_TOOLCHAINS" "${1:-dev}"; }
+
+# --- what a branch pin resolves to -------------------------------------------
+
+#[test]
+it_resolves_a_branch_pin_to_the_head_of_that_branch() {
+    _br_setup; _br_remote dev 0.4.0
+    assert_ok nutshell_find "" dev
+    assert_eq "$NUTSHELL_FROM" "branch:dev"
+    assert_contains "$NUTSHELL_INIT" "$(_br_head)"
+    _br_end
+}
+
+#[test]
+it_keys_the_checkout_by_the_revision_rather_than_by_the_branch_name() {
+    _br_setup; _br_remote dev 0.4.0
+    nutshell_find "" dev
+    # The directory name is what makes the store safe to share: a checkout
+    # named for a branch has to be replaced when the branch moves, and
+    # replacing it is deleting a tree somebody may be sourcing out of.
+    assert_ok test -f "$(_br_base)/$(_br_head)/init"
+    assert_fails test -f "$(_br_base)/init"
+    _br_end
+}
+
+#[test]
+it_records_the_revision_the_branch_last_resolved_to() {
+    _br_setup; _br_remote dev 0.4.0
+    nutshell_find "" dev
+    assert_eq "$(_nutshell_branch_head "$(_br_base)")" "$(_br_head)"
+    _br_end
+}
+
+# --- what it costs to keep current -------------------------------------------
+
+#[test]
+it_does_not_ask_the_remote_again_inside_the_window() {
+    _br_setup; _br_remote dev 0.4.0
+    nutshell_find "" dev
+    local first="$NUTSHELL_INIT"
+    # The remote is taken away entirely, and the answer has to come back with
+    # nothing said. Checking only that the path is unchanged would pass either
+    # way: the offline fallback returns that same path, having gone to the
+    # network to find out it could not. Silence is what distinguishes them.
+    export NUTSHELL_REMOTE="$BRROOT/gone.git"
+    local said; said="$(nutshell_find "" dev 2>&1 >/dev/null)"
+    assert_eq "$NUTSHELL_INIT" "$first"
+    assert_empty "$said"
+    _br_end
+}
+
+#[test]
+it_asks_again_once_the_window_is_out_and_follows_the_branch() {
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    local before="$NUTSHELL_INIT"
+    _br_move second
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+    assert_ne "$NUTSHELL_INIT" "$before"
+    assert_contains "$NUTSHELL_INIT" "$(_br_head)"
+    _br_end
+}
+
+#[test]
+it_leaves_the_old_revision_in_place_when_the_branch_moves() {
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    local old; old="$NUTSHELL_INIT"
+    _br_move second
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+    # Somebody else's push must not pull the floor out from under a run that
+    # already started. The old checkout is still there and still sourceable;
+    # it goes when it is a day old, not when it stops being the head.
+    assert_ok test -f "$old"
+    _br_end
+}
+
+#[test]
+it_does_not_refetch_a_revision_the_store_already_holds() {
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    printf 'in use\n' > "$(_br_base)/$(_br_head)/marker"
+    # The window is out and the head has not moved. That is a stamp refresh,
+    # not a clone, and certainly not a replacement of the directory.
+    local said; said="$(NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>&1 >/dev/null)"
+    assert_fails grep -q 'moved, fetching' <<<"$said"
+    assert_ok test -f "$(_br_base)/$(_br_head)/marker"
+    _br_end
+}
+
+# --- when the remote cannot be reached ---------------------------------------
+
+#[test]
+it_runs_from_the_last_known_revision_when_the_remote_is_unreachable() {
+    _br_setup; _br_remote dev 0.4.0
+    nutshell_find "" dev
+    local known="$NUTSHELL_INIT"
+    export NUTSHELL_REMOTE="$BRROOT/gone.git"
+    local said
+    said="$(NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>&1 >/dev/null)"
+    assert_eq "$NUTSHELL_INIT" "$known"
+    # Named rather than pretended about. A stale head that runs beats a
+    # refusal, and a reader has to be able to tell which one they got.
+    assert_contains "$said" "could not reach"
+    _br_end
+}
+
+#[test]
+it_names_the_revision_it_fell_back_to() {
+    _br_setup; _br_remote dev 0.4.0
+    nutshell_find "" dev
+    local head; head="$(_br_head)"
+    export NUTSHELL_REMOTE="$BRROOT/gone.git"
+    local said; said="$(NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>&1 >/dev/null)"
+    assert_contains "$said" "${head:0:12}"
+    _br_end
+}
+
+#[test]
+it_falls_through_to_a_vendored_copy_when_the_branch_was_never_fetched() {
+    _br_setup
+    export NUTSHELL_REMOTE="$BRROOT/gone.git"
+    local root="$BRROOT/project"
+    mkdir -p "$root/lib/nutshell"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$root/lib/nutshell/init"
+    assert_ok nutshell_find "$root" dev 2>/dev/null
+    assert_eq "$NUTSHELL_FROM" "vendored"
+    _br_end
+}
+
+#[test]
+it_takes_what_the_caller_named_before_asking_the_remote_anything() {
+    _br_setup
+    export NUTSHELL_REMOTE="$BRROOT/gone.git"
+    local d="$BRROOT/named"
+    mkdir -p "$d"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$d/init"
+    # A suite that exports this must not send every child process it starts to
+    # the network.
+    NUTSHELL_HOME="$d" assert_ok nutshell_find "" dev
+    assert_eq "$NUTSHELL_FROM" "NUTSHELL_HOME"
+    _br_end
+}
+
+# --- names that are not branch names -----------------------------------------
+
+#[test]
+it_refuses_a_ref_that_would_escape_the_store() {
+    _br_setup; _br_remote dev 0.4.0
+    local outside="$BRROOT/outside"
+    mkdir -p "$outside"; printf 'here\n' > "$outside/keep"
+    assert_fails _nutshell_branch "../outside" 2>/dev/null
+    assert_ok test -f "$outside/keep"
+    _br_end
+}
+
+#[test]
+it_refuses_a_ref_carrying_a_slash() {
+    _br_setup
+    # `feat/thing` is a legal branch name and is not a legal directory name
+    # here. Refusing it is a limit, and it is a stated one rather than a path
+    # built out of it.
+    assert_fails _nutshell_branch "feat/thing" 2>/dev/null
+    _br_end
+}
+
+# --- pruning ------------------------------------------------------------------
+
+#[test]
+it_keeps_a_revision_that_is_not_a_day_old_yet() {
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    local old; old="$(_br_head)"
+    _br_move second
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+    assert_ok test -d "$(_br_base)/$old"
+    _br_end
+}
+
+#[test]
+it_drops_a_revision_nothing_has_touched_for_a_day() {
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    local old; old="$(_br_head)"
+    # Aged deliberately. Two days back, so a machine on either side of a
+    # daylight-saving boundary still reads it as older than a day.
+    touch -t "$(date -v-2d +%Y%m%d%H%M 2>/dev/null || date -d '2 days ago' +%Y%m%d%H%M)" \
+        "$(_br_base)/$old"
+    _br_move second
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+    assert_fails test -d "$(_br_base)/$old"
+    # And the one it just resolved to is still there, which is the half that
+    # makes the pruning safe rather than merely tidy.
+    assert_ok test -f "$(_br_base)/$(_br_head)/init"
+    _br_end
+}
+
+#[test]
+it_says_a_slashed_ref_is_a_name_problem_and_not_a_network_one() {
+    _br_setup; _br_remote dev 0.4.0
+    # `feat/toolchains` is a legal branch name and is not a directory name in
+    # the store. The limit is real; reporting it as "could not reach" sends the
+    # reader to check their connection.
+    local said; said="$(nutshell_find "" "feat/toolchains" 2>&1 >/dev/null)"
+    assert_contains "$said" "cannot name a toolchain directory"
+    assert_fails grep -q "could not reach" <<<"$said"
+    _br_end
+}

--- a/tests/check_docblock_owner_test.sh
+++ b/tests/check_docblock_owner_test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Tests for whether a docblock belongs to the function it landed on.
+#
+# Attributes attach downward, to the next definition. So a `#[pub]` block and
+# its `Usage:` line, with a second function inserted underneath them, document
+# that second function instead. Two things break at once and neither shows:
+# the function the block was written for goes undocumented, and a private
+# helper gets marked public.
+#
+# It was in every repository this gate runs on, four times, and the existing
+# docs check reported the helper as documented because it was, by the block
+# meant for somebody else.
+
+use test
+
+NUT_CHECK_LOAD_ONLY=1 . "${BASH_SOURCE[0]%/*}/../examples/checks/check_public_api_docs.sh"
+
+# A file on disk, since the readers work over one, plus the docblock the check
+# would have extracted for a given definition.
+_dbo_file() {
+    local f; f="$(mktemp "${TMPDIR:-/tmp}/nutshell-dbo.XXXXXX")"
+    printf '%s' "$1" > "$f"
+    printf '%s' "$f"
+}
+
+# Whether the block above <func> in <file> is orphaned, and from whom.
+_orphan_of() {
+    local file="$1" func="$2" block
+    _pad_load "$file" || return 1
+    get_function_docblock "$file" "$func" >/dev/null
+    block="$PAD_DOCBLOCK"
+    docblock_orphaned_from "$file" "$func" "$block"
+}
+
+#[test]
+it_catches_a_block_the_next_definition_stole() {
+    # The case that was actually shipped, four times, reduced.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+#[pub]
+# What the public one does.
+# Usage: the_public_one -> prints a thing
+# A private helper that got inserted underneath.
+_the_helper() {
+    printf helper
+}
+
+the_public_one() {
+    _the_helper
+}
+')"
+    assert_eq "$(_orphan_of "$f" "_the_helper")" "the_public_one"
+    rm -f "$f"
+}
+
+#[test]
+it_leaves_a_block_that_names_its_own_function_alone() {
+    # The control. A detector that answered yes always would pass the test
+    # above and fail every real file in the tree.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+#[pub]
+# What it does.
+# Usage: the_public_one -> prints a thing
+the_public_one() {
+    printf thing
+}
+
+_the_helper() {
+    printf helper
+}
+')"
+    assert_fails _orphan_of "$f" "the_public_one"
+    rm -f "$f"
+}
+
+#[test]
+it_does_not_mistake_an_invocation_example_for_a_name() {
+    # `Usage: exit "$(doctor_exit)"` names `exit`, which defines nothing here.
+    # A detector matching the first token without checking it is defined
+    # reports every such block, and this shape is all over the tree.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+#[pub]
+# An exit status for the whole run.
+# Usage: exit "$(doctor_exit)"
+doctor_exit() {
+    printf 0
+}
+')"
+    assert_fails _orphan_of "$f" "doctor_exit"
+    rm -f "$f"
+}
+
+#[test]
+it_does_not_flag_a_block_referring_back_to_something_above_it() {
+    # Naming a function defined *earlier* is prose about a relationship, not a
+    # block that slid down past its own definition. Only later counts.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+first_one() {
+    printf first
+}
+
+#[pub]
+# Does the same as first_one, for the other shape.
+# Usage: first_one
+second_one() {
+    printf second
+}
+')"
+    assert_fails _orphan_of "$f" "second_one"
+    rm -f "$f"
+}
+
+#[test]
+it_does_not_flag_a_name_that_is_defined_nowhere() {
+    # A `Usage:` naming something from another module is a cross reference. It
+    # cannot be an orphan here, because there is nothing here to be orphaned
+    # from.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+#[pub]
+# Wraps the thing from the other module.
+# Usage: some_other_modules_function
+the_wrapper() {
+    printf wrapped
+}
+')"
+    assert_fails _orphan_of "$f" "the_wrapper"
+    rm -f "$f"
+}
+
+#[test]
+it_reads_a_hyphenated_and_a_function_keyword_definition() {
+    # Both spellings bash accepts. A detector that only knew `name()` would
+    # report the block below as an orphan of a function it could not see was
+    # defined.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+#[pub]
+# Usage: the_public_one -> prints a thing
+_the_helper() {
+    printf helper
+}
+
+function the_public_one {
+    _the_helper
+}
+')"
+    assert_eq "$(_orphan_of "$f" "_the_helper")" "the_public_one"
+    rm -f "$f"
+}
+
+#[test]
+it_finds_the_orphan_when_a_later_usage_line_is_the_right_one() {
+    # A block can carry more than one `Usage:`. One matching the definition it
+    # sits above means the block belongs here, whatever else it mentions.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+#[pub]
+# Usage: the_public_one -> the other form
+# Usage: _the_helper -> this form
+_the_helper() {
+    printf helper
+}
+
+the_public_one() {
+    _the_helper
+}
+')"
+    assert_fails _orphan_of "$f" "_the_helper"
+    rm -f "$f"
+}

--- a/tests/check_duplication_test.sh
+++ b/tests/check_duplication_test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Tests for the cross-file duplicate-name comparison.
+#
+# The check compares function names across files, so a module split into two
+# files trips it on the shared prefix alone: `toml_get` and `toml_set` score
+# 0.875 while naming opposite operations. What is asserted here is that the
+# prefix no longer carries a match on its own, and, more importantly, that the
+# check can still catch the copy it exists for.
+
+use test
+
+NUT_CHECK_LOAD_ONLY=1 . "${BASH_SOURCE[0]%/*}/../examples/checks/check_function_duplication.sh"
+
+# The comparison takes "name|file" lines and prints a MATCH line per pair.
+_pairs() { compare_full_names "$1" "0.85"; }
+
+#[test]
+it_catches_the_same_function_copied_into_another_file() {
+    # The positive control. Without it every result below is a claim about a
+    # comparison that might match nothing at all.
+    local out; out="$(_pairs "$(printf 'parse_the_line|a.sh\nparse_the_lines|b.sh\n')")"
+    assert_contains "$out" "MATCH"
+    assert_contains "$out" "parse_the_line"
+}
+
+#[test]
+it_does_not_call_a_getter_and_a_setter_a_duplicate() {
+    local out; out="$(_pairs "$(printf 'toml_get|lib/toml.sh\ntoml_set|lib/toml/write.sh\n')")"
+    assert_empty "$out"
+}
+
+#[test]
+it_does_not_call_two_more_operations_of_one_module_duplicates() {
+    local out; out="$(_pairs "$(printf 'huli_run|a.sh\nhuli_add|b.sh\n')")"
+    assert_empty "$out"
+}
+
+#[test]
+it_still_catches_a_copy_that_shares_the_module_prefix() {
+    # The guard is about the prefix carrying a match on its own. Two names in
+    # one family whose own halves also look alike are still a copy.
+    local out; out="$(_pairs "$(printf 'toml_read_value|a.sh\ntoml_read_values|b.sh\n')")"
+    assert_contains "$out" "MATCH"
+}
+
+#[test]
+it_ignores_a_pair_that_lives_in_one_file() {
+    # A getter and a setter side by side are the ordinary way to write a
+    # module, and the check has never been about that.
+    local out; out="$(_pairs "$(printf 'json_get|lib/json.sh\njson_set|lib/json.sh\n')")"
+    assert_empty "$out"
+}
+
+#[test]
+it_ignores_names_that_do_not_look_alike() {
+    local out; out="$(_pairs "$(printf 'toml_get|a.sh\nfs_mkdir|b.sh\n')")"
+    assert_empty "$out"
+}
+
+#[test]
+it_matches_the_identical_name_in_two_files() {
+    local out; out="$(_pairs "$(printf 'do_the_thing|a.sh\ndo_the_thing|b.sh\n')")"
+    assert_contains "$out" "MATCH"
+    assert_contains "$out" "1.000"
+}
+
+#[test]
+it_does_not_compare_a_name_with_no_prefix_by_a_prefix_rule() {
+    # Nothing to strip, so the guard must not fire and swallow the match.
+    local out; out="$(_pairs "$(printf 'render|a.sh\nrenders|b.sh\n')")"
+    assert_contains "$out" "MATCH"
+}

--- a/tests/check_file_cache_test.sh
+++ b/tests/check_file_cache_test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Tests for reading a file once and answering from it.
+#
+# Every check reads the same twenty-odd files, and used to do it with a
+# pipeline per question per function: `grep | head | cut` for a definition,
+# `tail | grep | head | cut` for its end, a seven-stage `grep -v` chain for its
+# body, and five more processes to count what was in it. Thousands of processes
+# per check, and each check starting again from nothing.
+#
+# The answers have to be the same ones. A faster checker that reports different
+# functions is not a faster checker.
+
+use test
+
+. "${BASH_SOURCE[0]%/*}/../lib/check-runner.sh"
+
+_cfc_tmp() { printf '%s' "$(mktemp -d "${TMPDIR:-/tmp}/nutshell-filecache.XXXXXX")"; }
+
+# A file with one of each shape the body reader has to judge.
+_cfc_file() {
+    local d="$1"
+    mkdir -p "$d"
+    cat > "$d/a.sh" <<'EOS'
+#!/usr/bin/env bash
+
+thin() { other "$1"; }
+
+#[pub]
+documented() {
+    local a="$1"
+    printf '%s' "$a"
+}
+
+does_work() {
+    local a="$1" b="$2"
+    # a comment, which is not a line of body
+
+    readonly c=3
+    if [[ -n "$a" ]]; then
+        printf '%s-%s' "$a" "$b"
+    fi
+    return
+}
+EOS
+    printf '%s' "$d/a.sh"
+}
+
+#[test]
+it_finds_where_a_function_is_defined() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    assert_ok nut_load_file "$f"
+    assert_eq "$(nut_defined_at "$f" documented)" "6"
+    assert_eq "$(nut_defined_at "$f" does_work)" "11"
+    assert_fails nut_defined_at "$f" no_such_function
+    rm -rf "$d"
+}
+
+#[test]
+it_finds_where_a_function_ends() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    assert_eq "$(nut_ends_at "$f" documented)" "9"
+    assert_eq "$(nut_ends_at "$f" does_work)" "20"
+    rm -rf "$d"
+}
+
+#[test]
+it_drops_the_lines_that_are_not_body() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    local -a body=()
+    assert_ok nut_body_of "$f" does_work body
+    # `local`, `readonly`, the comment, the blank and the bare `return` all go.
+    # What is left is the `if`, the `printf` and the `fi`.
+    assert_eq "${#body[@]}" "3"
+    assert_contains "${body[*]}" "printf"
+    assert_fails grep -q 'readonly' <<<"${body[*]}"
+    assert_fails grep -q 'local' <<<"${body[*]}"
+    rm -rf "$d"
+}
+
+#[test]
+it_refuses_an_array_name_that_is_not_one() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    # The name reaches `eval`. Anything but a plain identifier is refused
+    # before it gets there.
+    local -a body=()
+    assert_fails nut_body_of "$f" does_work 'x[$(touch /tmp/nut-should-not-exist)]'
+    assert_fails test -e /tmp/nut-should-not-exist
+    rm -rf "$d"
+}
+
+#[test]
+it_reads_a_file_once_however_often_it_is_asked() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    # The file is edited underneath, and the cache is what answers. A loader
+    # that re-read on every call would see the new content, which is the shape
+    # that was costing thousands of processes.
+    printf 'changed() { :; }\n' > "$f"
+    nut_load_file "$f"
+    assert_ok nut_defined_at "$f" does_work
+    assert_fails nut_defined_at "$f" changed
+    rm -rf "$d"
+}
+
+#[test]
+it_says_how_many_lines_a_file_has() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    assert_eq "$(nut_file_lines "$f")" "$(wc -l < "$f" | tr -d ' ')"
+    assert_eq "$(nut_file_line "$f" 3)" 'thin() { other "$1"; }'
+    rm -rf "$d"
+}
+
+#[test]
+it_refuses_a_file_that_is_not_there() {
+    assert_fails nut_load_file "/no/such/file/at/all.sh"
+    assert_fails nut_load_file ""
+}
+
+# --- the answers have to be the ones the pipelines gave ------------------------
+
+#[test]
+it_counts_the_same_variables_the_five_stage_pipeline_did() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    local -a body=()
+    nut_body_of "$f" does_work body
+
+    # The old shape, kept here as the oracle rather than as the implementation:
+    # grep the names out, drop the punctuation, unique them, count. Five
+    # processes, and the only reason it is acceptable in a test is that a test
+    # runs once and a checker runs per function.
+    local want
+    want="$(printf '%s\n' "${body[@]}" \
+        | grep -oE '\$\{?[a-zA-Z_][a-zA-Z0-9_]*' | sed 's/[${}]//g' \
+        | sort -u | wc -l | tr -d ' ')"
+
+    local -A seen=(); local line rest name
+    for line in "${body[@]}"; do
+        rest="$line"
+        while [[ "$rest" =~ \$\{?([a-zA-Z_][a-zA-Z0-9_]*) ]]; do
+            name="${BASH_REMATCH[1]}"; seen["$name"]=1
+            rest="${rest#*"${BASH_REMATCH[0]}"}"
+        done
+    done
+    assert_eq "${#seen[@]}" "$want"
+    # And not vacuously zero, which is what a broken reader would give.
+    assert_ne "${#seen[@]}" "0"
+    rm -rf "$d"
+}
+
+#[test]
+it_counts_the_same_tokens_the_pipeline_did() {
+    local d; d="$(_cfc_tmp)"; local f; f="$(_cfc_file "$d")"
+    nut_load_file "$f"
+    local -a body=()
+    nut_body_of "$f" does_work body
+
+    local want
+    want="$(printf '%s\n' "${body[@]}" | tr -s '[:space:]' '\n' | grep -v '^$' \
+        | wc -l | tr -d ' ')"
+
+    local line n=0; local -a words=()
+    for line in "${body[@]}"; do
+        # shellcheck disable=SC2206
+        words=($line); n=$(( n + ${#words[@]} ))
+    done
+    assert_eq "$n" "$want"
+    assert_ne "$n" "0"
+    rm -rf "$d"
+}

--- a/tests/check_reporting_test.sh
+++ b/tests/check_reporting_test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Tests for a failing check saying what it found.
+#
+# The runner sets `NUTSHELL_CHECK_QUIET=1` so eight checks do not each print a
+# summary block. A check that fails then prints nothing at all, and the runner
+# showed a bare red cross with no thread to pull. Observed on a consumer whose
+# gate went from green to failing the moment it started reading the right
+# repository, with nothing on screen to say why.
+
+use test
+
+_CRP_TMP="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-checkrep.XXXXXX")"
+trap '[[ -n "${_CRP_TMP:-}" ]] && rm -rf "$_CRP_TMP"' EXIT
+_CRP_NUT="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+
+# A project whose only check is one we wrote, so what the runner does with a
+# child's output is the only thing under test.
+_crp_project() {
+    local name="$1" body="$2"
+    local d="$_CRP_TMP/$name"
+    mkdir -p "$d/checks"
+    printf '[qa]\ncustom_checks = ["checks/probe.sh"]\nrun_builtins = false\n' > "$d/nut.toml"
+    printf '#!/usr/bin/env bash\n%s\n' "$body" > "$d/checks/probe.sh"
+    chmod +x "$d/checks/probe.sh"
+    printf '%s' "$d"
+}
+
+_crp_run() { (cd "$1" && "$_CRP_NUT/check" 2>&1); }
+
+#[test]
+it_shows_what_a_check_found_when_the_check_prints_it() {
+    local d; d="$(_crp_project talks '
+printf "✗ the thing is wrong\n"
+exit 1')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "the thing is wrong"
+}
+
+#[test]
+it_asks_a_silent_failing_check_again_with_its_report_turned_on() {
+    # The case. Quiet on the first run, and the reader is left with a cross.
+    local d; d="$(_crp_project quiet '
+if [[ "${NUTSHELL_CHECK_QUIET:-0}" == "1" ]]; then exit 1; fi
+printf "✗ four wrappers are trivial\n"
+exit 1')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "four wrappers are trivial"
+}
+
+#[test]
+it_says_so_when_a_check_fails_and_will_not_explain_itself_either_way() {
+    # A check that says nothing however it is asked. The runner cannot invent
+    # a reason, and printing nothing at all is what it used to do.
+    local d; d="$(_crp_project mute 'exit 1')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "failed and printed nothing"
+}
+
+#[test]
+it_does_not_ask_again_when_the_check_passed() {
+    # The second run costs a whole check. It happens on failure only, and a
+    # check that ran twice would say so here.
+    local d; d="$(_crp_project counted '
+printf "%s\n" "ran" >> "$PWD/ran.log"
+exit 0')"
+    _crp_run "$d" >/dev/null
+    assert_eq "$(grep -c . "$d/ran.log" 2>/dev/null || printf 0)" "1"
+}
+
+# --- the verdict is an exit code, not a glyph in the output --------------------
+#
+# `exit_with_status` promised "2 on warnings only" in its own usage line and
+# had two branches that never returned 2. So the only way the runner could tell
+# a warning from a clean pass was to grep tens of kilobytes of the child's
+# stdout for the character it prints, which needs quiet mode to have left the
+# line in and needs whichever `grep` is installed to read the pattern the same
+# way. A check reporting 23 warnings came out as a clean pass.
+
+#[test]
+it_reports_warnings_through_the_exit_code() {
+    local d; d="$(_crp_project warned '
+. "'"$_CRP_NUT"'/init"
+use check-runner
+log_warn_test() { :; }
+TESTS_WARNED=1
+exit_with_status')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "⚠"
+    assert_fails grep -q '✓ probe' <<<"$out"
+}
+
+#[test]
+it_reports_a_clean_run_as_clean() {
+    local d; d="$(_crp_project clean '
+. "'"$_CRP_NUT"'/init"
+use check-runner
+exit_with_status')"
+    local out; out="$(_crp_run "$d")"
+    assert_fails grep -q '⚠' <<<"$out"
+}
+
+#[test]
+it_still_reads_the_glyph_from_a_check_that_cannot_say_two() {
+    # A custom check that does not use the framework has no `exit_with_status`
+    # to call, so the fallback stays.
+    local d; d="$(_crp_project glyphonly '
+printf "  ⚠ something wants a look\n"
+exit 0')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "⚠"
+}
+
+#[test]
+it_does_not_ask_a_warning_to_explain_itself() {
+    # Re-running is for a failure that said nothing. A warning is not a
+    # failure, and asking cost a whole second run of the check.
+    local d; d="$(_crp_project quietwarn '
+. "'"$_CRP_NUT"'/init"
+use check-runner
+printf "%s\n" "ran" >> "$PWD/ran.log"
+TESTS_WARNED=1
+exit_with_status')"
+    _crp_run "$d" >/dev/null
+    assert_eq "$(grep -c . "$d/ran.log" 2>/dev/null || printf 0)" "1"
+}

--- a/tests/check_reporting_test.sh
+++ b/tests/check_reporting_test.sh
@@ -179,3 +179,92 @@ exit_with_status')"
     local out; out="$(_crp_run "$d")"
     assert_contains "$out" "⚠"
 }
+
+# --- a gate that examined nothing has not passed -----------------------------
+#
+# `./check` sourced `init` unchecked. `init` refuses below bash 4 with a
+# `return`, and a `return` returns to whoever sourced it: it cannot stop them.
+# So on macOS under `/bin/bash` the gate printed the refusal, ran its whole
+# body with no modules loaded, found nothing to run, and reported
+# `PASSED - All 0 checks passed` with exit 0. `release` gates on that command.
+#
+# Two independent guards, because either alone leaves a hole. The source line
+# stops this particular cause; the zero-check refusal stops every other way a
+# run can end up examining nothing.
+
+# A nutshell whose `init` refuses, and this repo's `check` beside it.
+_crp_refusing_nutshell() {
+    local d="$_CRP_TMP/refusing"
+    rm -rf "$d"; mkdir -p "$d"
+    cp -R "$_CRP_NUT/lib" "$_CRP_NUT/examples" "$d/" 2>/dev/null
+    cp "$_CRP_NUT/check" "$d/check"
+    # `init` that says no, the way it does on bash 3.
+    {
+        printf 'printf "nutshell needs bash 4.0 or newer.\\n" >&2\n'
+        printf 'return 1 2>/dev/null || exit 1\n'
+    } > "$d/init"
+    chmod +x "$d/check"
+    printf '%s' "$d"
+}
+
+#[test]
+it_refuses_rather_than_passing_when_nutshell_will_not_load() {
+    local d; d="$(_crp_refusing_nutshell)"
+    local out rc=0
+    out="$( (cd "$d" && ./check) 2>&1 )" || rc=$?
+
+    assert_ne "$rc" "0"
+    # And it must not have said the word that made this dangerous.
+    assert_eq "${out#*All 0 checks passed}" "$out"
+}
+
+#[test]
+it_fails_with_the_reason_rather_than_shell_noise() {
+    # The source guard on its own, and what it is actually worth.
+    #
+    # The zero-check refusal below turns this scenario into a failure too, and
+    # `set -u` often kills the unguarded run on an unbound variable before it
+    # gets anywhere, so "did it fail" cannot separate them. What separates them
+    # is *what the reader is told*.
+    #
+    # Guarded, the source line is the last thing that runs and the refusal is
+    # the whole output. Unguarded, the body runs on with no modules loaded and
+    # the reader gets `use: command not found` and `NUTSHELL_ROOT: unbound
+    # variable` on top of it, or, where nothing happens to be unbound, a
+    # summary saying everything passed.
+    local d; d="$(_crp_refusing_nutshell)"
+    local out
+    out="$( (cd "$d" && ./check) 2>&1 )" || true
+
+    assert_contains "$out" "bash 4.0 or newer"
+    assert_eq "${out#*unbound variable}" "$out" "it kept going with nothing loaded"
+    assert_eq "${out#*command not found}" "$out" "it kept going with nothing loaded"
+    assert_eq "${out#*checks passed}" "$out" "it reached a verdict with nothing loaded"
+}
+
+#[test]
+it_says_no_checks_ran_rather_than_all_of_them_passing() {
+    # The second guard on its own. A project that names no checks and runs no
+    # builtins reaches the summary with a working nutshell and nothing done.
+    local d="$_CRP_TMP/nothing-to-run"
+    mkdir -p "$d"
+    printf '[qa]\ncustom_checks = []\nrun_builtins = false\n' > "$d/nut.toml"
+
+    local out rc=0
+    out="$(_crp_run "$d")" || rc=$?
+
+    assert_ne "$rc" "0"
+    assert_contains "$out" "no checks ran"
+}
+
+#[test]
+it_still_passes_a_project_that_has_a_check_and_it_succeeds() {
+    # The control for both. A refusal that fired on every run would satisfy the
+    # two above and make the gate useless.
+    local d; d="$(_crp_project ok-run 'exit 0')"
+    local out rc=0
+    out="$(_crp_run "$d")" || rc=$?
+
+    assert_eq "$rc" "0"
+    assert_contains "$out" "PASSED"
+}

--- a/tests/check_reporting_test.sh
+++ b/tests/check_reporting_test.sh
@@ -123,3 +123,59 @@ exit_with_status')"
     _crp_run "$d" >/dev/null
     assert_eq "$(grep -c . "$d/ran.log" 2>/dev/null || printf 0)" "1"
 }
+
+
+# --- a check sourced into this process must not inherit it ---------------------
+#
+# The runner sources a check with the nutshell shebang into a subshell rather
+# than starting eight interpreters. All eight built-in checks take that branch
+# and every fixture in this file used `#!/usr/bin/env bash`, so the branch that
+# runs in production had no coverage at all.
+
+# A project whose check carries the nutshell shebang, which is the branch the
+# built-in checks take.
+_crp_nut_project() {
+    local name="$1" body="$2"
+    local d="$_CRP_TMP/$name"
+    mkdir -p "$d/checks"
+    printf '[qa]\ncustom_checks = ["checks/probe.sh"]\nrun_builtins = false\n' > "$d/nut.toml"
+    printf '#!/usr/bin/env nutshell\n%s\n' "$body" > "$d/checks/probe.sh"
+    chmod +x "$d/checks/probe.sh"
+    printf '%s' "$d"
+}
+
+#[test]
+it_gives_a_sourced_check_no_arguments_of_its_own() {
+    local d; d="$(_crp_nut_project args '
+if [[ $# -ne 0 ]]; then
+    printf "  ✗ inherited %s argument(s): %s\n" "$#" "$*"
+    exit 1
+fi
+exit 0')"
+    local out; out="$(_crp_run "$d")"
+    # It used to get the runner's `$1` and `$2`: the check path and its display
+    # name. Any check reading `$1` or `$@` was operating on itself.
+    assert_fails grep -q 'inherited' <<<"$out"
+    assert_contains "$out" "✓"
+}
+
+#[test]
+it_runs_a_sourced_check_at_all() {
+    # The control for the one above: the nutshell-shebang branch is genuinely
+    # taken and its exit code is genuinely read.
+    local d; d="$(_crp_nut_project taken '
+printf "  ✗ this check ran and failed on purpose\n"
+exit 1')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "ran and failed on purpose"
+}
+
+#[test]
+it_reports_a_sourced_checks_warnings_through_its_exit_code() {
+    local d; d="$(_crp_nut_project warned '
+use check-runner
+TESTS_WARNED=1
+exit_with_status')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "⚠"
+}

--- a/tests/check_root_test.sh
+++ b/tests/check_root_test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Tests for which repository the QA gate reads.
+#
+# The gate reported PASSED WITH WARNINGS in two consumers and none of it was
+# about them. `_find_repo_root` walked up from this file, which lands on
+# whichever nutshell is running the check, so the thresholds were the
+# consumer's and the files they were applied to were nutshell's. Nothing in
+# either consumer's source had ever been read, and `paths.exclude` naming the
+# vendored directory could not help, because the walk began inside it.
+#
+# It is not only a vendoring problem: a consumer resolving nutshell out of the
+# store gets the same answer, because a store checkout carries a `.git` too.
+
+use test
+
+. "${BASH_SOURCE[0]%/*}/../lib/check-runner.sh"
+
+_CR_TMP="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-checkroot.XXXXXX")"
+trap '[[ -n "${_CR_TMP:-}" ]] && rm -rf "$_CR_TMP"' EXIT
+
+# A consumer, and a nutshell sitting inside it the way a vendored or
+# store-resolved one does.
+_cr_consumer() {
+    local d="$_CR_TMP/$1"
+    mkdir -p "$d/lib/nutshell/lib" "$d/libs"
+    printf '[meta]\nname = "%s"\n' "$1" > "$d/nut.toml"
+    mkdir -p "$d/.git"
+    printf '[meta]\nname = "nutshell"\n' > "$d/lib/nutshell/nut.toml"
+    mkdir -p "$d/lib/nutshell/.git"
+    printf '%s' "$d"
+}
+
+#[test]
+it_reads_the_repository_the_check_was_run_from() {
+    local d; d="$(_cr_consumer one)"
+    local got; got="$(cd "$d" && _CHECK_RUNNER_DIR="$d/lib/nutshell/lib" NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_eq "$got" "$(cd "$d" && pwd)"
+}
+
+#[test]
+it_does_not_read_the_nutshell_that_is_running_the_check() {
+    # The defect, stated as its own case. The runner sits inside the consumer,
+    # in a directory that is itself a repository, which is exactly what the
+    # old walk stopped at.
+    local d; d="$(_cr_consumer two)"
+    local got; got="$(cd "$d" && _CHECK_RUNNER_DIR="$d/lib/nutshell/lib" NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_ne "$got" "$(cd "$d/lib/nutshell" && pwd)"
+}
+
+#[test]
+it_reads_the_repository_from_a_directory_inside_it() {
+    # `./check` is run from the root, but a person in a subdirectory reaching
+    # for an installed one means the same project.
+    local d; d="$(_cr_consumer three)"
+    mkdir -p "$d/libs/tui"
+    local got; got="$(cd "$d/libs/tui" && _CHECK_RUNNER_DIR="$d/lib/nutshell/lib" NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_eq "$got" "$(cd "$d" && pwd)"
+}
+
+#[test]
+it_takes_the_directory_of_a_config_that_was_named() {
+    # A config file states which repository it is the config for, and that
+    # outranks where the command happened to be typed.
+    local d e
+    d="$(_cr_consumer four)"; e="$(_cr_consumer five)"
+    local got; got="$(cd "$e" && NUTSHELL_CONFIG="$d/nut.toml" _find_repo_root)"
+    assert_eq "$got" "$(cd "$d" && pwd)"
+}
+
+#[test]
+it_reads_nutshell_itself_when_it_is_checking_itself() {
+    # The case that always worked and has to keep working: nutshell's own
+    # `./check`, run at nutshell's own root.
+    local root; root="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+    local got; got="$(cd "$root" && NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_eq "$got" "$root"
+}
+
+#[test]
+it_falls_back_to_the_interpreter_when_nothing_above_says_repository() {
+    # Run from somewhere that is not a project at all. There is nothing to
+    # check but the interpreter, and saying so beats reporting on a directory
+    # nobody asked about.
+    local bare="$_CR_TMP/bare"; mkdir -p "$bare"
+    local fake="$_CR_TMP/fakenut/lib"; mkdir -p "$fake"
+    mkdir -p "$_CR_TMP/fakenut/.git"
+    local got; got="$(cd "$bare" && _CHECK_RUNNER_DIR="$fake" NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_eq "$got" "$(cd "$_CR_TMP/fakenut" && pwd)"
+}
+
+#[test]
+it_refuses_to_walk_from_a_directory_that_is_not_there() {
+    assert_fails _walk_to_marker "$_CR_TMP/no-such-directory"
+    assert_fails _walk_to_marker ""
+}
+
+#[test]
+it_does_not_walk_past_a_few_levels_to_find_some_ancestor() {
+    # There is usually a repository somewhere above any directory. A `$HOME`
+    # that is a dotfiles checkout, or a workspace clone holding member clones,
+    # both make an unbounded walk grade something nobody asked about.
+    local top="$_CR_TMP/deep"
+    mkdir -p "$top/.git" "$top/a/b/c/d/e/f"
+    local fake="$_CR_TMP/deepnut/lib"; mkdir -p "$fake" "$_CR_TMP/deepnut/.git"
+    local got; got="$(cd "$top/a/b/c/d/e/f" && _CHECK_RUNNER_DIR="$fake" NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_ne "$got" "$(cd "$top" && pwd)"
+    assert_eq "$got" "$(cd "$_CR_TMP/deepnut" && pwd)"
+}
+
+#[test]
+it_still_reaches_a_project_root_from_a_source_directory_inside_it() {
+    # The depth has to clear the ordinary case it exists beside:
+    # `crates/foo/src/bar` is four levels down and must still answer.
+    local top="$_CR_TMP/proj"
+    mkdir -p "$top/crates/foo/src/bar"
+    printf '[meta]\nname = "proj"\n' > "$top/nut.toml"
+    local fake="$_CR_TMP/projnut/lib"; mkdir -p "$fake" "$_CR_TMP/projnut/.git"
+    local got; got="$(cd "$top/crates/foo/src/bar" && _CHECK_RUNNER_DIR="$fake" NUTSHELL_CONFIG="" _find_repo_root)"
+    assert_eq "$got" "$(cd "$top" && pwd)"
+}
+
+#[test]
+it_lets_the_depth_be_named_when_a_tree_is_deeper_than_that() {
+    local top="$_CR_TMP/verydeep"
+    mkdir -p "$top/a/b/c/d/e/f"
+    printf '[meta]\nname = "verydeep"\n' > "$top/nut.toml"
+    local fake="$_CR_TMP/vdnut/lib"; mkdir -p "$fake" "$_CR_TMP/vdnut/.git"
+    local got; got="$(cd "$top/a/b/c/d/e/f" && _CHECK_RUNNER_DIR="$fake" NUTSHELL_CONFIG="" NUTSHELL_CHECK_DEPTH=9 _find_repo_root)"
+    assert_eq "$got" "$(cd "$top" && pwd)"
+}

--- a/tests/checkcache_test.sh
+++ b/tests/checkcache_test.sh
@@ -132,11 +132,102 @@ it_can_be_thrown_away() {
 }
 
 #[test]
-it_does_not_let_a_path_escape_the_cache_directory() {
+it_keeps_every_computed_entry_inside_the_cache_directory() {
     _cc_setup
-    local outside="$CCROOT/outside"; mkdir -p "$outside"; printf 'keep\n' > "$outside/f"
-    nut_cache_write '../../outside' '../../outside/f' 'nope'
-    assert_ok test -f "$outside/f"
-    assert_eq "$(cat "$outside/f")" "keep"
+    local root; root="$(_nut_cache_root)"
+    local name entry
+    # The old version of this asserted a file outside was not overwritten,
+    # which held for every possible argument because the substitution had
+    # already removed every `/`. It read as a security test and restated a
+    # substitution. This asserts the computed path instead, over names chosen
+    # to escape if anything could.
+    for name in '../../etc/passwd' '/etc/passwd' '..' '.' '-rf' \
+                'a/b/../../../c' "$(printf 'new\nline')" '$(touch /tmp/nut-pwn)' \
+                '~/x' 'a b' "*"; do
+        entry="$(_nut_cache_path probe "$name")" || continue
+        assert_contains "$entry" "$root"
+        assert_fails grep -q '/\.\./' <<<"$entry"
+    done
+    assert_fails test -e /tmp/nut-pwn
+    _cc_end
+}
+
+#[test]
+it_does_not_give_one_file_the_answer_meant_for_another() {
+    _cc_setup
+    # Flattening every separator to `_` mapped `lib/toml/json.sh` and
+    # `lib/toml_json.sh` onto one entry, so the answer for one was served for
+    # the other. Both exist in this repository.
+    printf 'one\n' > "$CCROOT/a.sh"; printf 'two\n' > "$CCROOT/b.sh"
+    sleep 1
+    nut_cache_write probe "$CCROOT/a.sh" "answer for a"
+    assert_ne "$(_nut_cache_path probe 'lib/toml/json.sh')" \
+              "$(_nut_cache_path probe 'lib/toml_json.sh')"
+    assert_fails nut_cache_hit probe "$CCROOT/b.sh"
+    _cc_end
+}
+
+#[test]
+it_forgets_when_a_file_changes_without_its_time_moving_forward() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'FINDING: none'
+    # `tar -x`, `rsync -a`, `cp -p` and `touch -t` all move mtime backwards,
+    # and `-nt` only sees it move forward. Reproduced before this was fixed:
+    # the cache served "no findings" for a file whose contents had been
+    # replaced wholesale, which is the one direction a cache must not be wrong.
+    printf 'COMPLETELY DIFFERENT AND LONGER\n' > "$CCROOT/src.sh"
+    touch -t 200001010000 "$CCROOT/src.sh"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_forgets_when_the_file_changes_size_but_not_its_time() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    local when; when="$(stat -f '%Sm' -t '%Y%m%d%H%M.%S' "$CCROOT/src.sh" 2>/dev/null                         || stat -c '%y' "$CCROOT/src.sh")"
+    printf 'a much longer line than before\n' > "$CCROOT/src.sh"
+    touch -t 200001010000 "$CCROOT/src.sh"
+    # Size alone is enough to know it moved.
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_forgets_when_a_module_the_check_uses_changes() {
+    _cc_setup
+    # A check is not one file. `check_trivial_wrappers` gets its behaviour from
+    # `lib/srcfile.sh`, so editing that changes what it reports while touching
+    # neither the check nor the config. op's ruling is that a check gaining a
+    # step reads everything again.
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    assert_ok nut_cache_hit probe "$CCROOT/src.sh"
+    # The interpreter's own stamp is part of the key, so moving it is a miss.
+    _NUT_CACHE_BASE="f2:something-else"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_refuses_a_hit_when_the_config_is_not_named_at_all() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    unset CONFIG_FILE
+    # The config test used to sit inside `if [[ -n "$CONFIG_FILE" ]]`, so an
+    # unset one skipped it and the entry hit anyway, while the header said
+    # freshness meant newer than the config.
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_refuses_an_entry_written_in_an_older_format() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    local entry; entry="$(_nut_cache_path probe "$CCROOT/src.sh")"
+    # The store is shared by every nutshell on the machine. An entry from a
+    # version that meant something else by its stamp is a miss, not a lie.
+    { printf 'f1:whatever|0 0|0 0|0 0\n'; printf 'stale answer'; } > "$entry"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
     _cc_end
 }

--- a/tests/checkcache_test.sh
+++ b/tests/checkcache_test.sh
@@ -286,8 +286,10 @@ _stat_stub() {
     mkdir -p "$dir"
     case "$kind" in
         gnu)
-            # `-c` works. `-f` exits 0 and prints filesystem noise, which is
-            # the whole hazard.
+            # `-c` works and expands directives the way GNU does. `-f` exits 0
+            # and prints filesystem noise, which is the whole hazard: written
+            # against exit status, the chooser picks `-f` here and every stamp
+            # on Linux is garbage that compares equal to itself.
             cat > "$dir/stat" <<'STUB'
 #!/bin/sh
 if [ "$1" = "-c" ]; then
@@ -295,11 +297,9 @@ if [ "$1" = "-c" ]; then
     for f do
         m=$(/usr/bin/stat -f '%m' "$f" 2>/dev/null) || exit 1
         z=$(/usr/bin/stat -f '%z' "$f" 2>/dev/null) || exit 1
-        case "$fmt" in
-            '%Y %s %n') printf '%s %s %s\n' "$m" "$z" "$f" ;;
-            '%Y')       printf '%s\n' "$m" ;;
-            *)          printf '?\n' ;;
-        esac
+        out=$fmt
+        out=$(printf '%s' "$out" | sed -e "s|%Y|$m|g" -e "s|%s|$z|g" -e "s|%n|$f|g")
+        printf '%s\n' "$out"
     done
     exit 0
 fi
@@ -319,6 +319,32 @@ shift; fmt="$1"; shift
 exec /usr/bin/stat -f "$fmt" "$@"
 STUB
             ;;
+        gnu-numeric)
+            # The premise the digit test rested on, denied. A `stat` whose
+            # wrong-flag output *starts with a number* passes any "first field
+            # looks numeric" probe, and the chooser then picks `-f` on a
+            # machine where `-f` is not a format flag at all. Nothing here can
+            # rule such a `stat` out, so the detection stops depending on it.
+            cat > "$dir/stat" <<'STUB'
+#!/bin/sh
+if [ "$1" = "-c" ]; then
+    shift; fmt="$1"; shift
+    for f do
+        m=$(/usr/bin/stat -f '%m' "$f" 2>/dev/null) || exit 1
+        z=$(/usr/bin/stat -f '%z' "$f" 2>/dev/null) || exit 1
+        out=$(printf '%s' "$fmt" | sed -e "s|%Y|$m|g" -e "s|%s|$z|g" -e "s|%n|$f|g")
+        printf '%s\n' "$out"
+    done
+    exit 0
+fi
+if [ "$1" = "-f" ]; then
+    shift; shift
+    for f do printf '4096 1000000 500000\n'; done
+    exit 0
+fi
+exit 1
+STUB
+            ;;
         none)
             printf '#!/bin/sh\nexit 127\n' > "$dir/stat"
             ;;
@@ -328,7 +354,7 @@ STUB
     # The stub owns the whole PATH. Prepending leaves the real one reachable
     # by anything that resolves a second time, and then the test is about the
     # machine rather than about the stub.
-    for t in find sort head printf mktemp rm cat chmod sh; do
+    for t in find sort head printf mktemp rm cat chmod sh sed grep; do
         [[ -e "$dir/$t" ]] && continue
         local real; real="$(command -v "$t" 2>/dev/null)" || continue
         ln -sf "$real" "$dir/$t"
@@ -395,5 +421,20 @@ it_reads_a_real_mtime_and_size_through_whichever_stat_it_picked() {
     assert_ne "$got" ""
     assert_eq "${got#* }" "10"
     [[ "${got%% *}" =~ ^[0-9]+$ ]] || _test_failed "mtime is not a number: [${got%% *}]"
+    rm -rf "$d"
+}
+
+#[test]
+it_is_not_fooled_by_a_stat_whose_wrong_flag_prints_numbers() {
+    # The control for the two picks above, and the reason the detection writes
+    # a file of known size rather than looking for a leading digit.
+    #
+    # This `stat` is GNU: `-c` is the format flag and `-f` asks about the file
+    # system. Its `-f` output happens to begin with a block size. A probe that
+    # accepted "the first field is a number" picks `-f` here and is wrong about
+    # every stamp afterwards, on the platform where it matters.
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")"
+    _stat_stub "$d" gnu-numeric
+    assert_eq "$(_stat_flag_under "$d")" "-c"
     rm -rf "$d"
 }

--- a/tests/checkcache_test.sh
+++ b/tests/checkcache_test.sh
@@ -182,29 +182,63 @@ it_forgets_when_a_file_changes_without_its_time_moving_forward() {
 }
 
 #[test]
-it_forgets_when_the_file_changes_size_but_not_its_time() {
+it_forgets_when_the_content_changes_and_the_time_does_not() {
     _cc_setup
+    # A reference whose mtime the file is restored to, so the only thing that
+    # moves is the content and its size. Two `git checkout`s inside one second
+    # do this, and so does `touch -r` and any build step that restores times.
+    #
+    # The previous version of this test moved the mtime *backward*, which is
+    # what the test above it already covers, so it passed on a key the size was
+    # not actually in. The size was stat'd and then discarded by a `${v##* }`
+    # that took the path.
+    local ref="$CCROOT/ref"; printf 'r\n' > "$ref"
+    touch -r "$ref" "$CCROOT/src.sh"
     nut_cache_write probe "$CCROOT/src.sh" 'answer'
-    local when; when="$(stat -f '%Sm' -t '%Y%m%d%H%M.%S' "$CCROOT/src.sh" 2>/dev/null                         || stat -c '%y' "$CCROOT/src.sh")"
+    assert_ok nut_cache_hit probe "$CCROOT/src.sh"
+
     printf 'a much longer line than before\n' > "$CCROOT/src.sh"
-    touch -t 200001010000 "$CCROOT/src.sh"
-    # Size alone is enough to know it moved.
+    touch -r "$ref" "$CCROOT/src.sh"
+
+    # Same mtime, different size.
     assert_fails nut_cache_hit probe "$CCROOT/src.sh"
     _cc_end
 }
 
 #[test]
-it_forgets_when_a_module_the_check_uses_changes() {
+it_forgets_when_a_module_the_check_uses_is_edited_in_place() {
     _cc_setup
     # A check is not one file. `check_trivial_wrappers` gets its behaviour from
     # `lib/srcfile.sh`, so editing that changes what it reports while touching
-    # neither the check nor the config. op's ruling is that a check gaining a
-    # step reads everything again.
+    # neither the check nor the config, and op's ruling is that a check gaining
+    # a step reads everything again.
+    #
+    # A real edit, under a scratch interpreter root. The previous version of
+    # this test hand-set `_NUT_CACHE_BASE` and asserted a miss, which restated
+    # the string comparison in `nut_cache_hit` and never entered the function
+    # that computes it. The defect it was named for survived that test: the
+    # computation stat'd the `lib` directory, whose mtime moves when an entry
+    # is added or removed and not when a file inside it is edited.
+    local fake="$CCROOT/fakenut"
+    mkdir -p "$fake/lib"
+    printf 'a module\n' > "$fake/lib/srcfile.sh"
+    printf 'an init\n' > "$fake/init"
+
+    local keep="${NUTSHELL_ROOT:-}"
+    export NUTSHELL_ROOT="$fake"
+    _NUT_CACHE_BASE=""
+
     nut_cache_write probe "$CCROOT/src.sh" 'answer'
     assert_ok nut_cache_hit probe "$CCROOT/src.sh"
-    # The interpreter's own stamp is part of the key, so moving it is a miss.
-    _NUT_CACHE_BASE="f2:something-else"
+
+    sleep 1
+    printf 'a module, with another step\n' > "$fake/lib/srcfile.sh"
+    _NUT_CACHE_BASE=""
+
     assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+
+    export NUTSHELL_ROOT="$keep"
+    _NUT_CACHE_BASE=""
     _cc_end
 }
 

--- a/tests/checkcache_test.sh
+++ b/tests/checkcache_test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Tests for keeping a check's answer until it can change.
+#
+# A cache that is wrong is worse than a check that is slow, so most of this is
+# about what has to invalidate it. Three things can: the file, the check that
+# read it, and the config the thresholds came from. op's point, and the one an
+# obvious implementation misses: the checker counts. A cache over the file
+# alone keeps answering with the old check's opinion after the check changes,
+# and nothing says so.
+
+use test
+use checkcache
+
+_cc_setup() {
+    CCROOT="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-cc.XXXXXX")"
+    export NUT_CACHE_DIR="$CCROOT/cache"
+    export NUT_CACHE_ENABLED=1
+    export NUT_CACHE_CHECKER="$CCROOT/checker.sh"
+    printf 'a checker\n' > "$NUT_CACHE_CHECKER"
+    printf 'some source\n' > "$CCROOT/src.sh"
+    CONFIG_FILE="$CCROOT/nut.toml"; printf 'threshold = 1\n' > "$CONFIG_FILE"
+    # Everything below wants the entry to be newer than its inputs, and a
+    # filesystem with one-second stamps cannot tell two writes apart.
+    sleep 1
+}
+_cc_end() {
+    rm -rf "$CCROOT"
+    unset CCROOT NUT_CACHE_DIR NUT_CACHE_ENABLED NUT_CACHE_CHECKER CONFIG_FILE
+}
+
+#[test]
+it_has_nothing_before_anything_is_written() {
+    _cc_setup
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_gives_back_what_was_kept() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'two findings here'
+    assert_ok nut_cache_hit probe "$CCROOT/src.sh"
+    assert_eq "$(nut_cache_read probe "$CCROOT/src.sh")" "two findings here"
+    _cc_end
+}
+
+#[test]
+it_forgets_when_the_file_changes() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'old answer'
+    sleep 1
+    printf 'edited\n' > "$CCROOT/src.sh"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_forgets_when_the_check_itself_changes() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'old answer'
+    sleep 1
+    # The one an obvious cache misses. The file is untouched and the answer is
+    # still wrong, because a different check is asking.
+    printf 'a checker, with another step\n' > "$NUT_CACHE_CHECKER"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_forgets_when_the_thresholds_change() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'old answer'
+    sleep 1
+    printf 'threshold = 2\n' > "$CONFIG_FILE"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_keeps_one_answer_per_check_for_the_same_file() {
+    _cc_setup
+    nut_cache_write one "$CCROOT/src.sh" 'what one thinks'
+    nut_cache_write two "$CCROOT/src.sh" 'what two thinks'
+    assert_eq "$(nut_cache_read one "$CCROOT/src.sh")" "what one thinks"
+    assert_eq "$(nut_cache_read two "$CCROOT/src.sh")" "what two thinks"
+    _cc_end
+}
+
+#[test]
+it_answers_nothing_when_the_checker_is_not_named() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    unset NUT_CACHE_CHECKER
+    # A check that will not say which file it is cannot be cached, because
+    # there is no way to notice it changing.
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_stays_out_of_the_way_until_it_is_turned_on() {
+    _cc_setup
+    NUT_CACHE_ENABLED=0
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    # And nothing was written, so turning it on later does not find a stale one.
+    NUT_CACHE_ENABLED=1
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_forgets_a_file_that_is_no_longer_there() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    rm -f "$CCROOT/src.sh"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_can_be_thrown_away() {
+    _cc_setup
+    nut_cache_write one "$CCROOT/src.sh" 'a'
+    nut_cache_write two "$CCROOT/src.sh" 'b'
+    nut_cache_clear one
+    assert_fails nut_cache_hit one "$CCROOT/src.sh"
+    assert_ok    nut_cache_hit two "$CCROOT/src.sh"
+    nut_cache_clear
+    assert_fails nut_cache_hit two "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_does_not_let_a_path_escape_the_cache_directory() {
+    _cc_setup
+    local outside="$CCROOT/outside"; mkdir -p "$outside"; printf 'keep\n' > "$outside/f"
+    nut_cache_write '../../outside' '../../outside/f' 'nope'
+    assert_ok test -f "$outside/f"
+    assert_eq "$(cat "$outside/f")" "keep"
+    _cc_end
+}

--- a/tests/checkcache_test.sh
+++ b/tests/checkcache_test.sh
@@ -265,3 +265,135 @@ it_refuses_an_entry_written_in_an_older_format() {
     assert_fails nut_cache_hit probe "$CCROOT/src.sh"
     _cc_end
 }
+
+# --- which stat this machine has ---------------------------------------------
+#
+# The flavour is decided by what `stat` prints, not by what it returns, and
+# the difference only shows on the platform this was not developed on.
+#
+# BSD spells the format `-f`. GNU spells it `-c`, and its own `-f` asks for
+# file-system status and does not know `%m`. A chooser written as
+# `stat -f … || stat -c …` therefore reads the wrong thing on Linux while
+# exiting 0, so the fallback never fires and every stamp is garbage that
+# compares equal to itself. Invalidation stops with nothing to show for it.
+#
+# GNU is unavailable here, so it is planted: a `stat` that owns the whole PATH
+# and behaves the way GNU's does. Prepending would let the machine's real one
+# answer, which is how a stub test comes to prove nothing.
+
+_stat_stub() {
+    local dir="$1" kind="$2"
+    mkdir -p "$dir"
+    case "$kind" in
+        gnu)
+            # `-c` works. `-f` exits 0 and prints filesystem noise, which is
+            # the whole hazard.
+            cat > "$dir/stat" <<'STUB'
+#!/bin/sh
+if [ "$1" = "-c" ]; then
+    shift; fmt="$1"; shift
+    for f do
+        m=$(/usr/bin/stat -f '%m' "$f" 2>/dev/null) || exit 1
+        z=$(/usr/bin/stat -f '%z' "$f" 2>/dev/null) || exit 1
+        case "$fmt" in
+            '%Y %s %n') printf '%s %s %s\n' "$m" "$z" "$f" ;;
+            '%Y')       printf '%s\n' "$m" ;;
+            *)          printf '?\n' ;;
+        esac
+    done
+    exit 0
+fi
+if [ "$1" = "-f" ]; then
+    shift; shift
+    for f do printf 'Blocks: Total: 1000 Free: 500\n'; done
+    exit 0
+fi
+exit 1
+STUB
+            ;;
+        bsd)
+            cat > "$dir/stat" <<'STUB'
+#!/bin/sh
+[ "$1" = "-f" ] || exit 1
+shift; fmt="$1"; shift
+exec /usr/bin/stat -f "$fmt" "$@"
+STUB
+            ;;
+        none)
+            printf '#!/bin/sh\nexit 127\n' > "$dir/stat"
+            ;;
+    esac
+    chmod +x "$dir/stat"
+
+    # The stub owns the whole PATH. Prepending leaves the real one reachable
+    # by anything that resolves a second time, and then the test is about the
+    # machine rather than about the stub.
+    for t in find sort head printf mktemp rm cat chmod sh; do
+        [[ -e "$dir/$t" ]] && continue
+        local real; real="$(command -v "$t" 2>/dev/null)" || continue
+        ln -sf "$real" "$dir/$t"
+    done
+}
+
+_stat_flag_under() {
+    local dir="$1"
+    bash -c '
+        PATH="$1"; export PATH
+        . "$2"/init || exit 1
+        use checkcache
+        _nut_cache_stat_flag || printf "NONE"
+    ' _ "$dir" "$NUTSHELL_ROOT" 2>/dev/null
+}
+
+#[test]
+it_picks_the_format_a_gnu_stat_understands() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")"
+    _stat_stub "$d" gnu
+    assert_eq "$(_stat_flag_under "$d")" "-c"
+    rm -rf "$d"
+}
+
+#[test]
+it_picks_the_format_a_bsd_stat_understands() {
+    # The control. A probe that always answered `-c` would pass the one above
+    # and be just as wrong, in the other direction.
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")"
+    _stat_stub "$d" bsd
+    assert_eq "$(_stat_flag_under "$d")" "-f"
+    rm -rf "$d"
+}
+
+#[test]
+it_says_so_rather_than_guessing_when_there_is_no_stat() {
+    # A machine with neither has no stamps, and no stamps has to mean every
+    # entry misses. Answering with a flag that does not work would mean every
+    # entry hits on a stamp that never changes.
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")"
+    _stat_stub "$d" none
+    assert_eq "$(_stat_flag_under "$d")" "NONE"
+    rm -rf "$d"
+}
+
+#[test]
+it_reads_a_real_mtime_and_size_through_whichever_stat_it_picked() {
+    # The flag being right is not the claim. The claim is that the numbers
+    # coming back are this file's mtime and size, and a probe that accepted a
+    # format printing `?` would satisfy the three above and fail this.
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")"
+    _stat_stub "$d" gnu
+    printf '0123456789' > "$d/probe.txt"
+
+    local got
+    got="$(bash -c '
+        PATH="$1"; export PATH
+        . "$2"/init || exit 1
+        use checkcache
+        _nut_cache_stat_into "$3"
+        printf "%s" "${_NUT_CACHE_STAMP[$3]:-}"
+    ' _ "$d" "$NUTSHELL_ROOT" "$d/probe.txt" 2>/dev/null)"
+
+    assert_ne "$got" ""
+    assert_eq "${got#* }" "10"
+    [[ "${got%% *}" =~ ^[0-9]+$ ]] || _test_failed "mtime is not a number: [${got%% *}]"
+    rm -rf "$d"
+}

--- a/tests/cli_args_test.sh
+++ b/tests/cli_args_test.sh
@@ -66,3 +66,34 @@ it_still_runs_an_ordinary_script_path() {
 it_still_says_so_when_a_script_path_is_wrong() {
     assert_contains "$(nut /no/such/script.sh)" "script not found"
 }
+
+#[test]
+it_runs_the_script_in_the_working_directory_not_the_one_on_path() {
+    # `source name` searches PATH before the working directory, and a lot of
+    # short script names collide with something in /bin.
+    local d; d="$(mktemp -d)"
+    printf 'echo mine\n' > "$d/test"
+    local out; out="$(cd "$d" && "$NUT_BIN" test 2>&1)"
+    rm -rf "$d"
+    assert_eq "$out" "mine"
+}
+
+#[test]
+it_runs_a_script_named_by_a_relative_path() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/sub"
+    printf 'echo nested\n' > "$d/sub/s.sh"
+    local out; out="$(cd "$d" && "$NUT_BIN" sub/s.sh 2>&1)"
+    rm -rf "$d"
+    assert_eq "$out" "nested"
+}
+
+#[test]
+it_says_so_when_the_script_is_not_there() {
+    local d; d="$(mktemp -d)"
+    local out; out="$(cd "$d" && "$NUT_BIN" nosuchscript 2>&1)"
+    local code=$?
+    rm -rf "$d"
+    assert_contains "$out" "not found"
+    assert_ne "$code" "0"
+}

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -393,3 +393,47 @@ it_still_resolves_from_the_working_directory_when_nothing_names_a_script() {
     unset NUTSHELL_SCRIPT_DIR
     assert_eq "$(_extern_manifest)" "${root}/project/nut.toml"
 }
+
+# --- resolving once per process -----------------------------------------------
+
+#[test]
+it_remembers_a_resolved_path() {
+    # Every `use <dep>::<module>` resolved the dependency again: manifest
+    # re-read, lockfile re-read, git asked twice. None of it can change while a
+    # script runs, and five modules out of one library cost it five times.
+    _EXTERN_RESOLVED=()
+    _EXTERN_RESOLVED[fixture]="/tmp"
+    _extern_is_repo() { return 0; }
+    assert_eq "$(extern_path fixture)" "/tmp"
+}
+
+#[test]
+it_forgets_one_name_when_asked() {
+    _EXTERN_RESOLVED=()
+    _EXTERN_RESOLVED[a]="/tmp/a"
+    _EXTERN_RESOLVED[b]="/tmp/b"
+    extern_forget a
+    assert_empty "${_EXTERN_RESOLVED[a]:-}"
+    assert_eq "${_EXTERN_RESOLVED[b]:-}" "/tmp/b"
+}
+
+#[test]
+it_forgets_everything_when_given_no_name() {
+    _EXTERN_RESOLVED=()
+    _EXTERN_RESOLVED[a]="/tmp/a"
+    _EXTERN_RESOLVED[b]="/tmp/b"
+    extern_forget
+    assert_eq "${#_EXTERN_RESOLVED[@]}" "0"
+}
+
+#[test]
+it_does_not_hand_back_a_checkout_that_has_gone() {
+    # A cached path whose checkout was removed is worse than no cache: the
+    # caller gets a directory git will not answer for, and no explanation.
+    # It must fall through and resolve again rather than returning it.
+    _EXTERN_RESOLVED=()
+    _EXTERN_RESOLVED[fixture]="/tmp/definitely-not-a-checkout"
+    _extern_is_repo() { return 1; }
+    extern_path fixture >/dev/null 2>&1 || true
+    assert_empty "${_EXTERN_RESOLVED[fixture]:-}"
+}

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -553,3 +553,29 @@ it_does_not_record_a_module_that_failed_to_load() {
     # was never sourced.
     assert_eq "$out" "not recorded"
 }
+
+#[test]
+it_finds_a_units_manifest_when_run_from_somewhere_else() {
+    # A tool installed on PATH and run from any other directory could not
+    # resolve a single dependency: the manifest search had only PWD, which is a
+    # fact about where the shell was started rather than about which unit is
+    # asking.
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/unit/lib" "$d/dep/libs"
+    printf '[meta]\nname="unit"\n\n[deps.dep]\ngit = "x"\n' > "$d/unit/nut.toml"
+    printf 'MARKER=reached\n' > "$d/dep/libs/thing.sh"
+    printf 'thing libs/thing.sh\n' > "$d/dep/lib.nut"
+    printf 'use extern\nextern_path() { printf "%%s" "%s/dep"; }\nuse dep::thing\n' "$d" \
+        > "$d/unit/lib/main.sh"
+
+    # Run from a directory that is not the unit and has no manifest above it.
+    # The init path is captured before the cd: `$PWD` inside would be the
+    # directory just moved to, which is the mistake this test is about.
+    local nut; nut="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+    out="$(cd "$d" && bash -c "
+        . '$nut/init' 2>/dev/null
+        . '$d/unit/lib/main.sh'
+        printf '%s' \"\${MARKER:-unset}\"" 2>&1)"
+    assert_ok grep -q 'reached' <<<"$out"
+    rm -rf "$d"
+}

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -13,7 +13,7 @@ use extern test fs
 # commits, so a test can pin to the older one and see whether it is obeyed.
 _extern_fixture() {
     local work dep first second
-    work="$(fs_temp_dir nutshell-extern)"
+    work="$(_ex_tmp work)"
     dep="${work}/dep"
 
     mkdir -p "${dep}/lib"
@@ -40,9 +40,35 @@ TOML
 }
 
 # Each test gets its own cache root, so one test's checkout is not another's.
+# A store of its own for each test.
+#
+# `NUTSHELL_STORE` rather than an XDG variable, because the store root is the
+# thing being isolated and pointing at whichever XDG directory it currently
+# derives from is isolation that stops working the moment it moves. It did:
+# the store went from the cache directory to the data directory and the tests
+# kept setting the cache one, so they were writing into the real store and
+# nothing said so.
+# One root for the whole file, taken down at the end of it.
+#
+# Every scratch directory here is a child of this one. `fs_temp_dir` and a bare
+# `mktemp -d` both make one under the system temporary directory and neither
+# removes it, and this file was leaving twenty-seven per run.
+#
+# The three that still call `mktemp -d` run in a fresh `bash -c` which has none
+# of this file's helpers, and each removes its own directory on the way out.
+# They say `self-cleaned` on the line, which is what the guard below allows.
+_EX_TMP="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-extern.XXXXXX")"
+trap '[[ -n "${_EX_TMP:-}" ]] && rm -rf "$_EX_TMP"' EXIT
+
+# A scratch directory under this file's own root.
+_ex_tmp() {
+    local d; d="$(mktemp -d "${_EX_TMP}/${1:-d}.XXXXXX")"
+    printf '%s' "$d"
+}
+
 _isolate() {
-    XDG_CACHE_HOME="$(fs_temp_dir nutshell-extern-cache)"
-    export XDG_CACHE_HOME
+    NUTSHELL_STORE="$(_ex_tmp store)"
+    export NUTSHELL_STORE
 }
 
 #[test]
@@ -397,7 +423,7 @@ _manifest_fixture() {
     # fs_temp_dir passes it through, while a path that has been cd'd into comes
     # back single-slashed. Comparing one against the other fails on the slash
     # rather than on the behaviour.
-    root="$(cd "$(fs_temp_dir nutshell-manifest)" && pwd)"
+    root="$(cd "$(_ex_tmp manifest)" && pwd)"
     mkdir -p "${root}/unit" "${root}/elsewhere" "${root}/project/sub" "${root}/loose"
     printf '[deps.a]\ngit = "x"\n' > "${root}/unit/nut.toml"
     printf '[deps.b]\ngit = "y"\n' > "${root}/project/nut.toml"
@@ -510,7 +536,7 @@ it_does_not_hand_back_a_checkout_that_has_gone() {
 
 #[test]
 it_takes_a_nested_module_separated_all_the_way_down() {
-    local d; d="$(mktemp -d)"
+    local d; d="$(_ex_tmp)"
     mkdir -p "$d/dep/libs/tui"
     printf 'MARKER=reached\n' > "$d/dep/libs/tui/key.sh"
     printf '[meta]\nname="dep"\n' > "$d/dep/nut.toml"
@@ -523,7 +549,7 @@ it_takes_a_nested_module_separated_all_the_way_down() {
 
 #[test]
 it_refuses_a_module_path_that_uses_a_slash() {
-    local d; d="$(mktemp -d)"
+    local d; d="$(_ex_tmp)"
     mkdir -p "$d/dep/libs/tui"
     printf 'MARKER=reached\n' > "$d/dep/libs/tui/key.sh"
     extern_path() { printf '%s/dep' "$d"; }
@@ -536,7 +562,7 @@ it_refuses_a_module_path_that_uses_a_slash() {
 
 #[test]
 it_says_the_spelling_that_would_have_worked() {
-    local d out; d="$(mktemp -d)"
+    local d out; d="$(_ex_tmp)"
     mkdir -p "$d/dep/libs/tui"
     : > "$d/dep/libs/tui/key.sh"
     extern_path() { printf '%s/dep' "$d"; }
@@ -548,7 +574,7 @@ it_says_the_spelling_that_would_have_worked() {
 
 #[test]
 it_still_takes_a_flat_module() {
-    local d; d="$(mktemp -d)"
+    local d; d="$(_ex_tmp)"
     mkdir -p "$d/dep/lib"
     : > "$d/dep/lib/plain.sh"
     extern_path() { printf '%s/dep' "$d"; }
@@ -570,7 +596,7 @@ it_loads_a_module_once_however_it_was_named() {
     out="$(bash -c '
         cd '"$PWD"'
         . ./init
-        d=$(mktemp -d); mkdir -p "$d/libs/tui"
+        d=$(mktemp -d); mkdir -p "$d/libs/tui"  # self-cleaned, fresh shell
         printf "COUNT=\$(( \${COUNT:-0} + 1 ))\n" > "$d/libs/tui/key.sh"
         use extern
         extern_path() { printf "%s" "$d"; }
@@ -587,7 +613,7 @@ it_answers_that_a_module_is_loaded_by_either_name() {
     out="$(bash -c '
         cd '"$PWD"'
         . ./init
-        d=$(mktemp -d); mkdir -p "$d/libs/tui"
+        d=$(mktemp -d); mkdir -p "$d/libs/tui"  # self-cleaned, fresh shell
         : > "$d/libs/tui/key.sh"
         use extern
         extern_path() { printf "%s" "$d"; }
@@ -605,7 +631,7 @@ it_does_not_record_a_module_that_failed_to_load() {
     out="$(bash -c '
         cd '"$PWD"'
         . ./init
-        d=$(mktemp -d); mkdir -p "$d/libs"
+        d=$(mktemp -d); mkdir -p "$d/libs"  # self-cleaned, fresh shell
         printf "return 1\n" > "$d/libs/bad.sh"
         use extern
         extern_path() { printf "%s" "$d"; }
@@ -623,7 +649,7 @@ it_finds_a_units_manifest_when_run_from_somewhere_else() {
     # resolve a single dependency: the manifest search had only PWD, which is a
     # fact about where the shell was started rather than about which unit is
     # asking.
-    local d out; d="$(mktemp -d)"
+    local d out; d="$(_ex_tmp)"
     mkdir -p "$d/unit/lib" "$d/dep/libs"
     printf '[meta]\nname="unit"\n\n[deps.dep]\ngit = "x"\n' > "$d/unit/nut.toml"
     printf 'MARKER=reached\n' > "$d/dep/libs/thing.sh"
@@ -652,7 +678,7 @@ it_finds_a_units_manifest_when_run_from_somewhere_else() {
 # and months of work in it had never reached the consumer.
 
 _ex_origin() {
-    local d; d="$(mktemp -d)"
+    local d; d="$(_ex_tmp)"
     git -C "$d" init --quiet -b dev
     git -C "$d" config user.email t@t; git -C "$d" config user.name t
     mkdir -p "$d/libs"
@@ -671,7 +697,7 @@ _ex_advance() {
 #[test]
 it_takes_the_newest_commit_when_the_lock_says_nothing() {
     local origin; origin="$(_ex_origin)"
-    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    local mirror; mirror="$(_ex_tmp)"; rm -rf "$mirror"
     git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
     local before; before="$(_extern_ref_commit "$mirror" dev)"
 
@@ -693,7 +719,7 @@ it_answers_with_the_commit_it_already_has_when_the_ref_cannot_be_fetched() {
     # A machine with no network still has whatever it cloned. A stale answer
     # beats no answer for a tool whose job is a machine that is broken.
     local origin; origin="$(_ex_origin)"
-    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    local mirror; mirror="$(_ex_tmp)"; rm -rf "$mirror"
     git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
     local before; before="$(_extern_ref_commit "$mirror" dev)"
     rm -rf "$origin"
@@ -707,7 +733,7 @@ it_answers_with_the_commit_it_already_has_when_the_ref_cannot_be_fetched() {
 #[test]
 it_refuses_a_ref_the_mirror_has_never_heard_of() {
     local origin; origin="$(_ex_origin)"
-    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    local mirror; mirror="$(_ex_tmp)"; rm -rf "$mirror"
     git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
     local rc=0
     _extern_ref_commit "$mirror" "no-such-ref" >/dev/null 2>&1 || rc=$?
@@ -723,7 +749,7 @@ it_takes_a_commit_that_carries_a_file_the_old_one_did_not() {
     # commit of a library resolved every module that existed then and none of
     # the ones added since, and the error named the module rather than the pin.
     local origin; origin="$(_ex_origin)"
-    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    local mirror; mirror="$(_ex_tmp)"; rm -rf "$mirror"
     git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
     _ex_advance "$origin"
     _extern_refresh "$mirror" dev
@@ -767,4 +793,104 @@ it_resolves_the_tag_again_when_the_lock_entry_is_gone() {
 
     dir="$(extern_path fixture)"
     assert_eq "$(git -C "$dir" rev-parse HEAD)" "$first"
+}
+
+# --- the isolation itself ----------------------------------------------------
+
+#[test]
+it_puts_the_store_where_it_is_told_to() {
+    # The negative control for every test above. Each of them believes it is
+    # working in a store of its own, and none of them would notice being wrong.
+    _isolate
+    assert_contains "$(_extern_cache_root)" "$NUTSHELL_STORE"
+}
+
+#[test]
+it_puts_the_store_under_the_data_directory_when_nothing_overrides_it() {
+    local root
+    root="$(unset NUTSHELL_STORE; XDG_DATA_HOME=/tmp/xdg-probe _extern_cache_root)"
+    assert_contains "$root" "/tmp/xdg-probe"
+    assert_contains "$root" "externs"
+    _isolate
+}
+
+#[test]
+it_does_not_put_the_store_under_the_cache_directory() {
+    # With nothing overriding it, so the branch that derives the path is the
+    # one under test. Asserting this with `NUTSHELL_STORE` pointing at a
+    # scratch directory, as this used to, is a claim about `mktemp` that no
+    # change to the derivation could ever falsify.
+    #
+    # Not merely somewhere else: specifically not in the directory a cleaner is
+    # entitled to empty, which is where every project's dependencies used to
+    # live.
+    local root cache
+    root="$(unset NUTSHELL_STORE XDG_DATA_HOME; _extern_cache_root)"
+    cache="$(unset XDG_CACHE_HOME; xdg_set_app_name nutshell; xdg_app_cache)"
+    assert_ne "$root" ""
+    assert_ne "$cache" ""
+    # Against what this platform actually calls its cache, not against the
+    # spelling one platform happens to use. Matching `/.cache/` passes on macOS
+    # whatever the derivation does, because the cache there is
+    # `~/Library/Caches`, so that assertion could not fail on half the machines
+    # it runs on.
+    assert_ne "${root%/externs}" "$cache"
+    _isolate
+}
+
+# --- one root, spelled twice -------------------------------------------------
+#
+# `find-nutshell` runs before nutshell exists and cannot use `lib/xdg.sh`, so
+# the platform branch is written out in both places. Nothing but this test
+# holds them together, and without it they were already apart: the toolchains
+# went to `~/.local/share` on macOS while the externs went to
+# `~/Library/Application Support`, and the README said they shared a root.
+
+#[test]
+it_puts_the_externs_and_the_toolchains_under_one_root() {
+    unset NUTSHELL_STORE NUTSHELL_TOOLCHAINS
+    # shellcheck source=/dev/null
+    . "${BASH_SOURCE[0]%/*}/../find-nutshell"
+    local externs toolchains
+    externs="$(_extern_cache_root)"
+    toolchains="$(nutshell_toolchain_dir)"
+    assert_eq "${externs%/externs}" "${toolchains%/toolchains}"
+    assert_eq "${externs%/externs}" "$(nutshell_store_root)"
+    _isolate
+}
+
+#[test]
+it_keeps_them_together_when_the_root_is_named() {
+    export NUTSHELL_STORE="/tmp/one-root-probe"
+    # shellcheck source=/dev/null
+    . "${BASH_SOURCE[0]%/*}/../find-nutshell"
+    assert_eq "$(_extern_cache_root)" "/tmp/one-root-probe/externs"
+    assert_eq "$(nutshell_toolchain_dir)" "/tmp/one-root-probe/toolchains"
+    _isolate
+}
+
+#[test]
+it_keeps_them_together_when_xdg_names_the_data_directory() {
+    unset NUTSHELL_STORE NUTSHELL_TOOLCHAINS
+    export XDG_DATA_HOME="/tmp/xdg-one-root"
+    # shellcheck source=/dev/null
+    . "${BASH_SOURCE[0]%/*}/../find-nutshell"
+    # The branch both sides take when the variable is set, which is the one
+    # place they already agreed. The two above are where they did not.
+    assert_eq "$(_extern_cache_root)" "/tmp/xdg-one-root/nutshell/externs"
+    assert_eq "$(nutshell_toolchain_dir)" "/tmp/xdg-one-root/nutshell/toolchains"
+    unset XDG_DATA_HOME
+    _isolate
+}
+
+#[test]
+it_makes_no_scratch_directory_outside_its_own_root() {
+    # The leak was twenty-seven per run and nothing failed while it happened.
+    # The three that stay are in a fresh `bash -c` which cannot see `_ex_tmp`,
+    # and each removes its own directory; they are named so, and the check
+    # allows exactly those.
+    local stray
+    stray="$(grep -nE 'mktemp -d[)" ]|fs_temp_dir[ )"]' "${BASH_SOURCE[0]}" \
+        | grep -v '_EX_TMP' | grep -v 'self-cleaned' | grep -vE '^[0-9]+: *#' || true)"
+    assert_empty "$stray"
 }

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -77,32 +77,90 @@ it_writes_the_resolved_commit_to_the_lockfile() {
 }
 
 #[test]
-it_holds_a_checkout_at_the_locked_commit() {
-    # The point of the file. `ref = "main"` moves, so without this two checkouts
-    # of one project can be running different code and neither can say so.
+it_follows_the_branch_rather_than_the_lock() {
+    # A branch pin means that branch's head. A lockfile entry naming an older
+    # commit is a note about the past, not a pin: holding the checkout there
+    # would make `ref = "main"` a pin on whatever main happened to be the first
+    # time anybody asked, which is how a consumer ended up on its dependency's
+    # first commit while months of work went past it.
     _isolate
-    local fix work first dir
+    local fix work first second dir
     fix="$(_extern_fixture)"; work="${fix%% *}"
     first="$(printf '%s' "$fix" | cut -d' ' -f2)"
+    second="${fix##* }"
     cd "${work}/project" || return 1
 
     extern_lock_write fixture "$first"
     dir="$(extern_path fixture)"
 
+    assert_eq "$(git -C "$dir" rev-parse HEAD)" "$second"
+    assert_contains "$(cat "${dir}/lib/greet.sh")" "goodbye"
+}
+
+#[test]
+it_rewrites_the_lock_when_the_branch_has_moved() {
+    # The lockfile's other job. On a branch it records what the head resolved
+    # to and is rewritten every time that moves, so it reports rather than pins.
+    _isolate
+    local fix work first second
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    first="$(printf '%s' "$fix" | cut -d' ' -f2)"
+    second="${fix##* }"
+    cd "${work}/project" || return 1
+
+    extern_lock_write fixture "$first"
+    extern_path fixture >/dev/null
+    assert_eq "$(extern_locked fixture)" "$second"
+}
+
+#[test]
+it_holds_a_checkout_at_a_pinned_commit() {
+    # The lockfile's first job, on the pin that has one. A revision names one
+    # commit forever, and two checkouts of a project pinned to it are running
+    # the same code.
+    _isolate
+    local fix work first dir
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    first="$(printf '%s' "$fix" | cut -d' ' -f2)"
+    cd "${work}/project" || return 1
+    sed -i.bak "s|^ref = .*|ref = \"${first}\"|" nut.toml && rm -f nut.toml.bak
+
+    dir="$(extern_path fixture)"
+    assert_eq "$(git -C "$dir" rev-parse HEAD)" "$first"
+    assert_contains "$(cat "${dir}/lib/greet.sh")" "hello"
+}
+
+#[test]
+it_holds_a_checkout_at_a_pinned_tag() {
+    # A tag is the other fixed kind, and the one somebody writes when they mean
+    # a release rather than a revision.
+    _isolate
+    local fix work first dir
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    first="$(printf '%s' "$fix" | cut -d' ' -f2)"
+    # Annotated, which is what a release tag usually is, and the shape whose
+    # `^{}` peeling the resolution has to follow: the tag object's own sha is
+    # not a commit and nothing can be checked out at it.
+    git -C "${work}/dep" tag -a v1 -m 'v1' "$first"
+    cd "${work}/project" || return 1
+    sed -i.bak 's|^ref = .*|ref = "v1"|' nut.toml && rm -f nut.toml.bak
+
+    dir="$(extern_path fixture)"
     assert_eq "$(git -C "$dir" rev-parse HEAD)" "$first"
     assert_contains "$(cat "${dir}/lib/greet.sh")" "hello"
 }
 
 #[test]
 it_refuses_a_commit_the_remote_does_not_have() {
-    # Silently taking the tip instead would defeat the lock at the one moment
-    # it matters.
+    # Silently taking the tip instead would defeat the pin at the one moment it
+    # matters.
     _isolate
     local fix work
     fix="$(_extern_fixture)"; work="${fix%% *}"
     cd "${work}/project" || return 1
+    sed -i.bak 's|^ref = .*|ref = "0000000000000000000000000000000000000000"|' nut.toml
+    rm -f nut.toml.bak
 
-    extern_lock_write fixture "0000000000000000000000000000000000000000"
     assert_fails extern_path fixture
 }
 
@@ -141,13 +199,18 @@ it_gives_two_projects_locked_apart_their_own_checkouts() {
     mkdir -p "${work}/other"
     cp "${work}/project/nut.toml" "${work}/other/nut.toml"
 
+    # Pinned apart by their manifests, since that is what a pin is now: a lock
+    # entry on a branch is rewritten to the head and cannot hold two projects
+    # apart.
+    sed -i.bak "s|^ref = .*|ref = \"${first}\"|"  "${work}/project/nut.toml"
+    sed -i.bak "s|^ref = .*|ref = \"${second}\"|" "${work}/other/nut.toml"
+    rm -f "${work}/project/nut.toml.bak" "${work}/other/nut.toml.bak"
+
     local dir_a dir_b
     cd "${work}/project" || return 1
-    extern_lock_write fixture "$first"
     dir_a="$(extern_path fixture)"
 
     cd "${work}/other" || return 1
-    extern_lock_write fixture "$second"
     dir_b="$(extern_path fixture)"
 
     assert_ne "$dir_a" "$dir_b" "a checkout per commit, not per ref"
@@ -578,4 +641,130 @@ it_finds_a_units_manifest_when_run_from_somewhere_else() {
         printf '%s' \"\${MARKER:-unset}\"" 2>&1)"
     assert_ok grep -q 'reached' <<<"$out"
     rm -rf "$d"
+}
+
+# --- taking the newest commit on a ref ---------------------------------------
+#
+# `nut.lock` tells a reader that deleting an entry takes the newest commit on
+# its ref again. A mirror cloned once and never fetched cannot do that: it
+# answers with whatever the ref pointed at the first time anybody asked. In the
+# case that produced these tests the answer was the dependency's first commit,
+# and months of work in it had never reached the consumer.
+
+_ex_origin() {
+    local d; d="$(mktemp -d)"
+    git -C "$d" init --quiet -b dev
+    git -C "$d" config user.email t@t; git -C "$d" config user.name t
+    mkdir -p "$d/libs"
+    printf 'first\n' > "$d/libs/thing.sh"
+    printf 'x = 1\n' > "$d/nut.toml"
+    git -C "$d" add -A; git -C "$d" commit --quiet -m first
+    printf '%s' "$d"
+}
+
+_ex_advance() {
+    printf 'second\n' > "$1/libs/thing.sh"
+    printf 'second\n' > "$1/libs/later.sh"
+    git -C "$1" add -A; git -C "$1" commit --quiet -m second
+}
+
+#[test]
+it_takes_the_newest_commit_when_the_lock_says_nothing() {
+    local origin; origin="$(_ex_origin)"
+    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
+    local before; before="$(_extern_ref_commit "$mirror" dev)"
+
+    _ex_advance "$origin"
+    _extern_refresh "$mirror" dev
+    local after; after="$(_extern_ref_commit "$mirror" dev)"
+
+    local head_only; head_only="$(git -C "$mirror" rev-parse HEAD)"
+    rm -rf "$origin" "$mirror"
+
+    assert_ne "$after" "$before"
+    # The control for the whole thing: `rev-parse HEAD` on the mirror, which is
+    # what this replaced, still answers with the old commit after the refresh.
+    assert_eq "$head_only" "$before"
+}
+
+#[test]
+it_answers_with_the_commit_it_already_has_when_the_ref_cannot_be_fetched() {
+    # A machine with no network still has whatever it cloned. A stale answer
+    # beats no answer for a tool whose job is a machine that is broken.
+    local origin; origin="$(_ex_origin)"
+    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
+    local before; before="$(_extern_ref_commit "$mirror" dev)"
+    rm -rf "$origin"
+
+    assert_ok _extern_refresh "$mirror" dev
+    local after; after="$(_extern_ref_commit "$mirror" dev)"
+    rm -rf "$mirror"
+    assert_eq "$after" "$before"
+}
+
+#[test]
+it_refuses_a_ref_the_mirror_has_never_heard_of() {
+    local origin; origin="$(_ex_origin)"
+    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
+    local rc=0
+    _extern_ref_commit "$mirror" "no-such-ref" >/dev/null 2>&1 || rc=$?
+    rm -rf "$origin" "$mirror"
+    # HEAD is the last resort and it exists, so this answers rather than fails.
+    # What must not happen is inventing a commit for a ref that is not there.
+    assert_eq "$rc" "0"
+}
+
+#[test]
+it_takes_a_commit_that_carries_a_file_the_old_one_did_not() {
+    # The shape of the failure this fixes: a consumer pinned at the first
+    # commit of a library resolved every module that existed then and none of
+    # the ones added since, and the error named the module rather than the pin.
+    local origin; origin="$(_ex_origin)"
+    local mirror; mirror="$(mktemp -d)"; rm -rf "$mirror"
+    git clone --quiet --depth 1 --branch dev "$origin" "$mirror" 2>/dev/null
+    _ex_advance "$origin"
+    _extern_refresh "$mirror" dev
+    local c; c="$(_extern_ref_commit "$mirror" dev)"
+    local has; has="$(git -C "$mirror" ls-tree --name-only "$c" libs/ 2>/dev/null | tr '\n' ' ')"
+    rm -rf "$origin" "$mirror"
+    assert_contains "$has" "later.sh"
+}
+
+#[test]
+it_lets_the_lockfile_win_over_a_tag_that_disagrees() {
+    # Written down because it surprises: a tag names one commit and the lock
+    # names another, and the lock is what the checkout goes to. That is right
+    # when an upstream tag has moved under a project that already resolved it,
+    # and it means a hand-edited lock silently redirects a tag pin.
+    _isolate
+    local fix work first second dir
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    first="$(printf '%s' "$fix" | cut -d' ' -f2)"
+    second="${fix##* }"
+    git -C "${work}/dep" tag -a v1 -m 'v1' "$first"
+    cd "${work}/project" || return 1
+    sed -i.bak 's|^ref = .*|ref = "v1"|' nut.toml && rm -f nut.toml.bak
+
+    extern_lock_write fixture "$second"
+    dir="$(extern_path fixture)"
+    assert_eq "$(git -C "$dir" rev-parse HEAD)" "$second"
+}
+
+#[test]
+it_resolves_the_tag_again_when_the_lock_entry_is_gone() {
+    # The way back, and the reason the behaviour above is safe: deleting the
+    # entry is how you ask for the ref to decide.
+    _isolate
+    local fix work first dir
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    first="$(printf '%s' "$fix" | cut -d' ' -f2)"
+    git -C "${work}/dep" tag -a v1 -m 'v1' "$first"
+    cd "${work}/project" || return 1
+    sed -i.bak 's|^ref = .*|ref = "v1"|' nut.toml && rm -f nut.toml.bak
+
+    dir="$(extern_path fixture)"
+    assert_eq "$(git -C "$dir" rev-parse HEAD)" "$first"
 }

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -437,3 +437,119 @@ it_does_not_hand_back_a_checkout_that_has_gone() {
     extern_path fixture >/dev/null 2>&1 || true
     assert_empty "${_EXTERN_RESOLVED[fixture]:-}"
 }
+
+# --- how a module path is spelled ----------------------------------------------
+#
+# `::` separates modules the whole way down. A `/` used to work, because the
+# tail was handed to the filesystem unchanged, so `shebang::tui/key` found the
+# file and read as two different separators in one path. It is refused now, and
+# the refusal names the spelling that works.
+
+#[test]
+it_takes_a_nested_module_separated_all_the_way_down() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/dep/libs/tui"
+    printf 'MARKER=reached\n' > "$d/dep/libs/tui/key.sh"
+    printf '[meta]\nname="dep"\n' > "$d/dep/nut.toml"
+    extern_path() { printf '%s/dep' "$d"; }
+    local out; out="$(extern_resolve 'dep::tui::key')"
+    assert_eq "$out" "$d/dep/libs/tui/key.sh"
+    unset -f extern_path
+    rm -rf "$d"
+}
+
+#[test]
+it_refuses_a_module_path_that_uses_a_slash() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/dep/libs/tui"
+    printf 'MARKER=reached\n' > "$d/dep/libs/tui/key.sh"
+    extern_path() { printf '%s/dep' "$d"; }
+    # The file is right there. It is still refused, because a separator that
+    # works by accident ends up used in half the call sites and not the other.
+    assert_fails extern_resolve 'dep::tui/key'
+    unset -f extern_path
+    rm -rf "$d"
+}
+
+#[test]
+it_says_the_spelling_that_would_have_worked() {
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/dep/libs/tui"
+    : > "$d/dep/libs/tui/key.sh"
+    extern_path() { printf '%s/dep' "$d"; }
+    out="$(extern_resolve 'dep::tui/key' 2>&1 || true)"
+    assert_ok grep -q 'dep::tui::key' <<<"$out"
+    unset -f extern_path
+    rm -rf "$d"
+}
+
+#[test]
+it_still_takes_a_flat_module() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/dep/lib"
+    : > "$d/dep/lib/plain.sh"
+    extern_path() { printf '%s/dep' "$d"; }
+    assert_eq "$(extern_resolve 'dep::plain')" "$d/dep/lib/plain.sh"
+    unset -f extern_path
+    rm -rf "$d"
+}
+
+# --- one file, one load ----------------------------------------------------------
+#
+# A module is reachable by more than one name: its own unit calls it
+# `super::tui::key`, a consumer calls it `dep::tui::key`, and both are the same
+# file. Loaded-ness was keyed on the words rather than the file, so each name
+# sourced it again, and a module without a guard of its own ran twice.
+
+#[test]
+it_loads_a_module_once_however_it_was_named() {
+    local out
+    out="$(bash -c '
+        cd '"$PWD"'
+        . ./init
+        d=$(mktemp -d); mkdir -p "$d/libs/tui"
+        printf "COUNT=\$(( \${COUNT:-0} + 1 ))\n" > "$d/libs/tui/key.sh"
+        use extern
+        extern_path() { printf "%s" "$d"; }
+        use one::tui::key
+        use two::tui::key
+        printf "%s" "$COUNT"
+        rm -rf "$d"')"
+    assert_eq "$out" "1"
+}
+
+#[test]
+it_answers_that_a_module_is_loaded_by_either_name() {
+    local out
+    out="$(bash -c '
+        cd '"$PWD"'
+        . ./init
+        d=$(mktemp -d); mkdir -p "$d/libs/tui"
+        : > "$d/libs/tui/key.sh"
+        use extern
+        extern_path() { printf "%s" "$d"; }
+        use one::tui::key
+        nutshell_loaded one::tui::key && printf "first "
+        use two::tui::key
+        nutshell_loaded two::tui::key && printf "second"
+        rm -rf "$d"')"
+    assert_eq "$out" "first second"
+}
+
+#[test]
+it_does_not_record_a_module_that_failed_to_load() {
+    local out
+    out="$(bash -c '
+        cd '"$PWD"'
+        . ./init
+        d=$(mktemp -d); mkdir -p "$d/libs"
+        printf "return 1\n" > "$d/libs/bad.sh"
+        use extern
+        extern_path() { printf "%s" "$d"; }
+        use dep::bad 2>/dev/null
+        nutshell_loaded dep::bad && printf "recorded" || printf "not recorded"
+        rm -rf "$d"')"
+    # Leaving the mark would make a later retry succeed against a module that
+    # was never sourced.
+    assert_eq "$out" "not recorded"
+}

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -374,6 +374,57 @@ it_takes_over_a_lock_whose_holder_died() {
 }
 
 #[test]
+it_records_the_pid_of_the_process_that_actually_holds_the_lock() {
+    # The guard runs inside a command substitution: `init` calls
+    # `extern_resolve` in `$( )`, which reaches `extern_path` and then here.
+    # `$$` in a subshell is the *parent's* pid, so the lock recorded a process
+    # that outlives the one holding it. A subshell dying mid-clone then left a
+    # lock naming a pid `kill -0` says is alive, the takeover never fired, and
+    # the next run sat out the whole ten minute clock instead.
+    #
+    # So the property is that the pid in the lock belongs to whoever wrote it.
+    _isolate
+    local fix work dir lock
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    cd "${work}/project" || return 1
+
+    dir="$(_extern_cache_root)/pretend-pid"
+    lock="${dir}.lock"
+    # The store root need not exist yet, and the guard makes it. A missing
+    # parent used to fail `mkdir "$lock"` the same way contention does, so this
+    # waited eleven minutes for a lock nobody held.
+    assert_fails test -d "$lock"
+
+    # Held long enough to read the lock while it exists, from a subshell, which
+    # is how every real caller reaches this.
+    local seen
+    seen="$( _EXTERN_LOCK_WAIT_SECONDS=3 _extern_guard "$dir" bash -c 'cat "$0/pid"' "$lock" )"
+
+    assert_ne "$seen" "" "the guard writes a pid into the lock"
+    assert_ne "$seen" "$$" "and it is not the pid of the shell that will outlive it"
+}
+
+#[test]
+it_still_waits_for_a_lock_whose_holder_is_alive() {
+    # The control for the one above. A live holder is a lock that must not be
+    # taken over, however impatient the next process is, or two clones race
+    # into one directory.
+    _isolate
+    local fix work dir lock
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    cd "${work}/project" || return 1
+
+    dir="$(_extern_cache_root)/pretend-live"
+    lock="${dir}.lock"
+    fs_mkdir "$lock"
+    printf '%s' "$$" > "${lock}/pid"
+
+    local rc=0
+    _EXTERN_LOCK_WAIT_SECONDS=2 _extern_guard "$dir" true || rc=$?
+    assert_ne "$rc" "0" "a live holder is waited for, then reported"
+}
+
+#[test]
 it_resolves_a_namespaced_module_to_a_file() {
     # What a namespaced `use` turns into. Kept separate from loading so the
     # resolution can be asked about without sourcing anything.
@@ -893,4 +944,31 @@ it_makes_no_scratch_directory_outside_its_own_root() {
     stray="$(grep -nE 'mktemp -d[)" ]|fs_temp_dir[ )"]' "${BASH_SOURCE[0]}" \
         | grep -v '_EX_TMP' | grep -v 'self-cleaned' | grep -vE '^[0-9]+: *#' || true)"
     assert_empty "$stray"
+}
+
+#[test]
+it_does_not_wait_out_the_clock_for_a_parent_that_is_merely_absent() {
+    # `mkdir "$lock"` is the lock, and it failed for two different reasons that
+    # looked identical: somebody holds it, or the directory above it is not
+    # there yet. The second waited eleven minutes for a lock nobody held, which
+    # is the whole default wait, on a store that had simply never been used.
+    _isolate
+    local fix work dir
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    cd "${work}/project" || return 1
+
+    # Deliberately several levels below anything that exists.
+    dir="$(_extern_cache_root)/never/been/here/pretend"
+    assert_fails test -d "$(dirname "$dir")"
+
+    local start end rc=0
+    start="$(date +%s)"
+    _EXTERN_LOCK_WAIT_SECONDS=30 _extern_guard "$dir" git init --quiet "$dir" || rc=$?
+    end="$(date +%s)"
+
+    assert_eq "$rc" "0"
+    # Promptly, rather than after any part of the wait. The wait is set to 30
+    # here and is 660 in production, so the old behaviour blows this by a wide
+    # margin either way.
+    assert_ok test "$(( end - start ))" -lt 5
 }

--- a/tests/find_test.sh
+++ b/tests/find_test.sh
@@ -22,13 +22,36 @@ _fake_nutshell() {
     chmod +x "$d/bin/nutshell"
 }
 
-_reset() { NUTSHELL_INIT=""; NUTSHELL_FROM=""; unset NUTSHELL_HOME; }
+# Every test gets an empty store and a remote that cannot answer, so nothing
+# here reaches the network and nothing depends on what this machine happens to
+# have downloaded already. The tests that are about the store fill it in.
+# One root for the whole file, taken down at the end of it.
+#
+# Every scratch directory here is a child of this one. Making them with a bare
+# `mktemp -d` leaves them: removing the `store` child of one says nothing about
+# its parent, and this file was leaving twenty-six directories in the temporary
+# directory on every run.
+_FIND_TMP="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-find.XXXXXX")"
+trap '[[ -n "${_FIND_TMP:-}" ]] && rm -rf "$_FIND_TMP"' EXIT
+
+# A scratch directory under this file's own root.
+_tmp() {
+    local d; d="$(mktemp -d "${_FIND_TMP}/${1:-d}.XXXXXX")"
+    printf '%s' "$d"
+}
+
+_reset() {
+    NUTSHELL_INIT=""; NUTSHELL_FROM=""; unset NUTSHELL_HOME
+    [[ -n "${NUTSHELL_TOOLCHAINS:-}" ]] && rm -rf "$NUTSHELL_TOOLCHAINS"
+    export NUTSHELL_TOOLCHAINS="$(_tmp store)/store"
+    export NUTSHELL_REMOTE="/nonexistent/nutshell.git"
+}
 
 #[test]
 it_prefers_what_the_caller_named() {
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/named"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/named"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell"
     NUTSHELL_HOME="$d/named" nutshell_find "$root"
     local from="$NUTSHELL_FROM" init="$NUTSHELL_INIT"
     rm -rf "$d" "$root"; _reset
@@ -41,8 +64,8 @@ it_refuses_a_named_home_with_no_interpreter_in_it() {
     # Silently falling through to another one would make the override a
     # suggestion, and an override that is a suggestion is worse than none.
     _reset
-    local d; d="$(mktemp -d)"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    local d; d="$(_tmp)"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell"
     local rc=0
     NUTSHELL_HOME="$d/nothing" nutshell_find "$root" 2>/dev/null || rc=$?
     rm -rf "$d" "$root"; _reset
@@ -53,8 +76,8 @@ it_refuses_a_named_home_with_no_interpreter_in_it() {
 it_prefers_an_installed_one_over_a_vendored_one() {
     # The whole point. A per-project copy is the thing that goes stale.
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/installed"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell"
     PATH="$d/installed/bin:$PATH" nutshell_find "$root"
     local from="$NUTSHELL_FROM" init="$NUTSHELL_INIT"
     rm -rf "$d" "$root"; _reset
@@ -67,7 +90,7 @@ it_falls_back_to_the_vendored_one_when_nothing_is_installed() {
     # The machine this tool is usually rescuing has nothing installed, so the
     # vendored copy is a fallback rather than a mistake.
     _reset
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell"
     # A PATH with the ordinary tools on it and no nutshell, which is the
     # machine this is the fallback for.
     PATH="/usr/bin:/bin" nutshell_find "$root"
@@ -81,7 +104,7 @@ it_follows_a_launcher_that_is_a_link() {
     # The one on PATH is usually a link into a checkout, and the init sits
     # beside the binary rather than beside the link.
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/real"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/real"
     mkdir -p "$d/bin"; ln -s "$d/real/bin/nutshell" "$d/bin/nutshell"
     PATH="$d/bin:$PATH" nutshell_find ""
     local from="$NUTSHELL_FROM" init="$NUTSHELL_INIT"
@@ -95,7 +118,7 @@ it_does_not_take_a_file_called_init_that_is_not_one() {
     # A tool with its own `init` would be sourced and would fail somewhere
     # less obvious than here.
     _reset
-    local root; root="$(mktemp -d)"
+    local root; root="$(_tmp)"
     mkdir -p "$root/lib/nutshell"
     printf 'echo not nutshell\n' > "$root/lib/nutshell/init"
     local rc=0
@@ -164,7 +187,7 @@ it_finds_the_interpreter_with_nothing_on_the_path_at_all() {
     # ways that include its PATH. A resolver needing a tool to find the
     # interpreter fails exactly when it is needed.
     _reset
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell"
     PATH="" nutshell_find "$root"
     local from="$NUTSHELL_FROM"
     rm -rf "$root"; _reset
@@ -183,7 +206,7 @@ it_finds_the_interpreter_with_nothing_on_the_path_at_all() {
 it_reads_a_version_without_running_the_interpreter() {
     # Read rather than sourced: a candidate about to be rejected must not be
     # given the chance to run first.
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/n" "1.2.3"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/n" "1.2.3"
     local v; v="$(_nutshell_version_of "$d/n/init")"
     rm -rf "$d"
     assert_eq "$v" "1.2.3"
@@ -193,7 +216,7 @@ it_reads_a_version_without_running_the_interpreter() {
 it_takes_the_quotes_off_the_version() {
     # Trimming at the first character that is not a digit or a dot trims at the
     # opening quote and answers with nothing.
-    local d; d="$(mktemp -d)"
+    local d; d="$(_tmp)"
     mkdir -p "$d/n"
     printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$d/n/init"
     local v; v="$(_nutshell_version_of "$d/n/init")"
@@ -204,8 +227,8 @@ it_takes_the_quotes_off_the_version() {
 #[test]
 it_skips_an_installed_one_that_is_too_old() {
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.3.0"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/installed" "0.3.0"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
     PATH="$d/installed/bin:$PATH" nutshell_find "$root" "0.4.0" 2>/dev/null
     local from="$NUTSHELL_FROM"
     rm -rf "$d" "$root"; _reset
@@ -217,8 +240,8 @@ it_says_out_loud_when_it_skips_the_installed_one() {
     # Silently falling through would hide exactly the version skew this exists
     # to surface.
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.3.0"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/installed" "0.3.0"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
     local out
     out="$(PATH="$d/installed/bin:$PATH" nutshell_find "$root" "0.4.0" 2>&1)"
     rm -rf "$d" "$root"; _reset
@@ -230,8 +253,8 @@ it_says_out_loud_when_it_skips_the_installed_one() {
 it_still_prefers_an_installed_one_that_is_new_enough() {
     # The control. Skipping the too-old must not stop it preferring the rest.
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.5.0"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/installed" "0.5.0"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
     PATH="$d/installed/bin:$PATH" nutshell_find "$root" "0.4.0"
     local from="$NUTSHELL_FROM"
     rm -rf "$d" "$root"; _reset
@@ -241,8 +264,8 @@ it_still_prefers_an_installed_one_that_is_new_enough() {
 #[test]
 it_prefers_an_installed_one_when_no_minimum_is_named() {
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.1.0"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "9.9.9"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/installed" "0.1.0"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell" "9.9.9"
     PATH="$d/installed/bin:$PATH" nutshell_find "$root"
     local from="$NUTSHELL_FROM"
     rm -rf "$d" "$root"; _reset
@@ -254,8 +277,8 @@ it_honours_a_named_home_even_when_it_is_too_old() {
     # An override quietly ignored is worse than one that fails, and somebody
     # working on nutshell itself needs theirs honoured.
     _reset
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/named" "0.0.1"
-    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "9.9.9"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/named" "0.0.1"
+    local root; root="$(_tmp)"; _fake_nutshell "$root/lib/nutshell" "9.9.9"
     NUTSHELL_HOME="$d/named" nutshell_find "$root" "0.4.0"
     local from="$NUTSHELL_FROM"
     rm -rf "$d" "$root"; _reset
@@ -264,8 +287,42 @@ it_honours_a_named_home_even_when_it_is_too_old() {
 
 #[test]
 it_compares_the_pieces_as_numbers_when_choosing_too() {
-    local d; d="$(mktemp -d)"; _fake_nutshell "$d/n" "0.10.0"
+    local d; d="$(_tmp)"; _fake_nutshell "$d/n" "0.10.0"
     assert_ok    _nutshell_satisfies "$d/n/init" "0.9.0"
     assert_fails _nutshell_satisfies "$d/n/init" "0.11.0"
     rm -rf "$d"
+}
+
+# --- the scratch directories this file makes ----------------------------------
+#
+# Twenty-six of them per run were being left in the temporary directory, and
+# the leak was invisible: `_reset` removed the `store` child of a `mktemp -d`
+# and never the parent, and every test made one or two more that nothing
+# removed at all. Nothing failed, and the directory filled up.
+
+#[test]
+it_takes_its_scratch_directories_down_when_the_file_is_done_with_them() {
+    # A whole life of the file in one subshell: source it, take a directory,
+    # leave. The trap is what has to fire, so the assertion is made from
+    # outside the shell that armed it.
+    local d
+    d="$(bash -c '. "$0" >/dev/null 2>&1; _tmp probe' "${BASH_SOURCE[0]}")"
+    assert_ne "$d" ""
+    assert_fails test -d "$d"
+}
+
+#[test]
+it_puts_a_scratch_directory_under_its_own_root() {
+    local d; d="$(_tmp probe)"
+    assert_contains "$d" "$_FIND_TMP"
+}
+
+#[test]
+it_makes_no_scratch_directory_outside_that_root() {
+    # The one bare `mktemp -d` allowed is the root itself, and the helper that
+    # takes children of it names the root in the same line. Anything else is
+    # the leak coming back, and it comes back silently.
+    local stray
+    stray="$(grep -nE 'mktemp -d[)" ]' "${BASH_SOURCE[0]}" | grep -v '_FIND_TMP' || true)"
+    assert_empty "$stray"
 }

--- a/tests/find_test.sh
+++ b/tests/find_test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Tests for finding the interpreter.
+#
+# A copy of nutshell inside a project is a second version that drifts from the
+# installed one in silence. It happened twice in one day: a tool pinned at its
+# dependency's first commit resolved every module that existed then and none
+# added since, and the error named a missing module rather than a stale copy.
+#
+# So an installed one wins, and a version older than the tool needs is a
+# refusal at startup rather than a missing function halfway through a run.
+
+use test
+
+. "${BASH_SOURCE[0]%/*}/../find-nutshell"
+
+# A directory holding something that looks like an interpreter.
+_fake_nutshell() {
+    local d="$1" version="${2:-9.9.9}"
+    mkdir -p "$d/bin"
+    printf 'export NUTSHELL_VERSION="%s"\n' "$version" > "$d/init"
+    printf '#!/usr/bin/env bash\n' > "$d/bin/nutshell"
+    chmod +x "$d/bin/nutshell"
+}
+
+_reset() { NUTSHELL_INIT=""; NUTSHELL_FROM=""; unset NUTSHELL_HOME; }
+
+#[test]
+it_prefers_what_the_caller_named() {
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/named"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    NUTSHELL_HOME="$d/named" nutshell_find "$root"
+    local from="$NUTSHELL_FROM" init="$NUTSHELL_INIT"
+    rm -rf "$d" "$root"; _reset
+    assert_eq "$from" "NUTSHELL_HOME"
+    assert_contains "$init" "named"
+}
+
+#[test]
+it_refuses_a_named_home_with_no_interpreter_in_it() {
+    # Silently falling through to another one would make the override a
+    # suggestion, and an override that is a suggestion is worse than none.
+    _reset
+    local d; d="$(mktemp -d)"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    local rc=0
+    NUTSHELL_HOME="$d/nothing" nutshell_find "$root" 2>/dev/null || rc=$?
+    rm -rf "$d" "$root"; _reset
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_prefers_an_installed_one_over_a_vendored_one() {
+    # The whole point. A per-project copy is the thing that goes stale.
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    PATH="$d/installed/bin:$PATH" nutshell_find "$root"
+    local from="$NUTSHELL_FROM" init="$NUTSHELL_INIT"
+    rm -rf "$d" "$root"; _reset
+    assert_eq "$from" "installed"
+    assert_contains "$init" "installed"
+}
+
+#[test]
+it_falls_back_to_the_vendored_one_when_nothing_is_installed() {
+    # The machine this tool is usually rescuing has nothing installed, so the
+    # vendored copy is a fallback rather than a mistake.
+    _reset
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    # A PATH with the ordinary tools on it and no nutshell, which is the
+    # machine this is the fallback for.
+    PATH="/usr/bin:/bin" nutshell_find "$root"
+    local from="$NUTSHELL_FROM"
+    rm -rf "$root"; _reset
+    assert_eq "$from" "vendored"
+}
+
+#[test]
+it_follows_a_launcher_that_is_a_link() {
+    # The one on PATH is usually a link into a checkout, and the init sits
+    # beside the binary rather than beside the link.
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/real"
+    mkdir -p "$d/bin"; ln -s "$d/real/bin/nutshell" "$d/bin/nutshell"
+    PATH="$d/bin:$PATH" nutshell_find ""
+    local from="$NUTSHELL_FROM" init="$NUTSHELL_INIT"
+    rm -rf "$d"; _reset
+    assert_eq "$from" "installed"
+    assert_contains "$init" "real"
+}
+
+#[test]
+it_does_not_take_a_file_called_init_that_is_not_one() {
+    # A tool with its own `init` would be sourced and would fail somewhere
+    # less obvious than here.
+    _reset
+    local root; root="$(mktemp -d)"
+    mkdir -p "$root/lib/nutshell"
+    printf 'echo not nutshell\n' > "$root/lib/nutshell/init"
+    local rc=0
+    PATH="/usr/bin:/bin" nutshell_find "$root" 2>/dev/null || rc=$?
+    rm -rf "$root"; _reset
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_fails_when_there_is_nothing_anywhere() {
+    _reset
+    local rc=0
+    PATH="/usr/bin:/bin" nutshell_find "/no/such/root" 2>/dev/null || rc=$?
+    _reset
+    assert_ne "$rc" "0"
+}
+
+# --- refusing one that is too old --------------------------------------------
+
+#[test]
+it_accepts_a_version_that_is_new_enough() {
+    NUTSHELL_VERSION="0.3.0" assert_ok nutshell_at_least "0.3.0"
+    NUTSHELL_VERSION="0.4.0" assert_ok nutshell_at_least "0.3.0"
+    NUTSHELL_VERSION="1.0.0" assert_ok nutshell_at_least "0.9.9"
+}
+
+#[test]
+it_refuses_one_that_is_too_old() {
+    local rc=0
+    NUTSHELL_VERSION="0.2.9" nutshell_at_least "0.3.0" 2>/dev/null || rc=$?
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_compares_the_pieces_as_numbers() {
+    # `0.10.0` is newer than `0.9.0`. A text compare says the opposite, and the
+    # day that matters is the day the minor version reaches ten.
+    NUTSHELL_VERSION="0.10.0" assert_ok nutshell_at_least "0.9.0"
+    local rc=0
+    NUTSHELL_VERSION="0.9.0" nutshell_at_least "0.10.0" 2>/dev/null || rc=$?
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_says_which_interpreter_it_was_complaining_about() {
+    # The message has to name the copy, or somebody with two of them cannot
+    # tell which one answered.
+    NUTSHELL_INIT="/somewhere/init"; NUTSHELL_FROM="vendored"
+    local out
+    out="$(NUTSHELL_VERSION="0.1.0" nutshell_at_least "0.3.0" 2>&1 || true)"
+    NUTSHELL_INIT=""; NUTSHELL_FROM=""
+    assert_contains "$out" "0.1.0"
+    assert_contains "$out" "0.3.0"
+    assert_contains "$out" "/somewhere/init"
+    assert_contains "$out" "vendored"
+}
+
+#[test]
+it_asks_for_nothing_when_no_minimum_is_named() {
+    NUTSHELL_VERSION="0.0.1" assert_ok nutshell_at_least ""
+}
+
+#[test]
+it_finds_the_interpreter_with_nothing_on_the_path_at_all() {
+    # This runs before anything is set up, on a machine that may be broken in
+    # ways that include its PATH. A resolver needing a tool to find the
+    # interpreter fails exactly when it is needed.
+    _reset
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell"
+    PATH="" nutshell_find "$root"
+    local from="$NUTSHELL_FROM"
+    rm -rf "$root"; _reset
+    assert_eq "$from" "vendored"
+}

--- a/tests/find_test.sh
+++ b/tests/find_test.sh
@@ -170,3 +170,102 @@ it_finds_the_interpreter_with_nothing_on_the_path_at_all() {
     rm -rf "$root"; _reset
     assert_eq "$from" "vendored"
 }
+
+# --- resolving to something that can actually run the caller -------------------
+#
+# Both copies on the machine this was written on reported `0.3.0` while only one
+# had the feature the caller needed, so a floor of `0.3.0` passed against an
+# interpreter that could not run it. A version that does not move with the code
+# is not a version, and preferring an installed one that cannot run the caller
+# is not a preference worth having.
+
+#[test]
+it_reads_a_version_without_running_the_interpreter() {
+    # Read rather than sourced: a candidate about to be rejected must not be
+    # given the chance to run first.
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/n" "1.2.3"
+    local v; v="$(_nutshell_version_of "$d/n/init")"
+    rm -rf "$d"
+    assert_eq "$v" "1.2.3"
+}
+
+#[test]
+it_takes_the_quotes_off_the_version() {
+    # Trimming at the first character that is not a digit or a dot trims at the
+    # opening quote and answers with nothing.
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/n"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$d/n/init"
+    local v; v="$(_nutshell_version_of "$d/n/init")"
+    rm -rf "$d"
+    assert_eq "$v" "0.4.0"
+}
+
+#[test]
+it_skips_an_installed_one_that_is_too_old() {
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.3.0"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
+    PATH="$d/installed/bin:$PATH" nutshell_find "$root" "0.4.0" 2>/dev/null
+    local from="$NUTSHELL_FROM"
+    rm -rf "$d" "$root"; _reset
+    assert_eq "$from" "vendored"
+}
+
+#[test]
+it_says_out_loud_when_it_skips_the_installed_one() {
+    # Silently falling through would hide exactly the version skew this exists
+    # to surface.
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.3.0"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
+    local out
+    out="$(PATH="$d/installed/bin:$PATH" nutshell_find "$root" "0.4.0" 2>&1)"
+    rm -rf "$d" "$root"; _reset
+    assert_contains "$out" "0.3.0"
+    assert_contains "$out" "0.4.0"
+}
+
+#[test]
+it_still_prefers_an_installed_one_that_is_new_enough() {
+    # The control. Skipping the too-old must not stop it preferring the rest.
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.5.0"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "0.4.0"
+    PATH="$d/installed/bin:$PATH" nutshell_find "$root" "0.4.0"
+    local from="$NUTSHELL_FROM"
+    rm -rf "$d" "$root"; _reset
+    assert_eq "$from" "installed"
+}
+
+#[test]
+it_prefers_an_installed_one_when_no_minimum_is_named() {
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/installed" "0.1.0"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "9.9.9"
+    PATH="$d/installed/bin:$PATH" nutshell_find "$root"
+    local from="$NUTSHELL_FROM"
+    rm -rf "$d" "$root"; _reset
+    assert_eq "$from" "installed"
+}
+
+#[test]
+it_honours_a_named_home_even_when_it_is_too_old() {
+    # An override quietly ignored is worse than one that fails, and somebody
+    # working on nutshell itself needs theirs honoured.
+    _reset
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/named" "0.0.1"
+    local root; root="$(mktemp -d)"; _fake_nutshell "$root/lib/nutshell" "9.9.9"
+    NUTSHELL_HOME="$d/named" nutshell_find "$root" "0.4.0"
+    local from="$NUTSHELL_FROM"
+    rm -rf "$d" "$root"; _reset
+    assert_eq "$from" "NUTSHELL_HOME"
+}
+
+#[test]
+it_compares_the_pieces_as_numbers_when_choosing_too() {
+    local d; d="$(mktemp -d)"; _fake_nutshell "$d/n" "0.10.0"
+    assert_ok    _nutshell_satisfies "$d/n/init" "0.9.0"
+    assert_fails _nutshell_satisfies "$d/n/init" "0.11.0"
+    rm -rf "$d"
+}

--- a/tests/fixtures/no_tests_at_all_test.sh
+++ b/tests/fixtures/no_tests_at_all_test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# A test file with no #[test] in it, which the harness must refuse.
+#
+# The shape is not somebody forgetting to write tests. It is what every file
+# in the suite becomes when discovery itself breaks: `attr_find` is what finds
+# the tests, and `attr_find` is in the library under test.
+
+use test
+
+# Marked with something else, so the file is not empty and the attribute
+# reader is definitely running. It just finds nothing it was asked for.
+#[helper]
+it_looks_like_a_test_but_is_not_marked_as_one() {
+    assert_eq "1" "1"
+}

--- a/tests/harness_test.sh
+++ b/tests/harness_test.sh
@@ -88,3 +88,28 @@ it_does_not_charge_one_test_with_another_s_failure() {
     assert_contains "$out" "[PASS] it_forks_a_child_that_fails_late"
     assert_contains "$out" "[PASS] it_is_the_innocent_one_after_the_fork"
 }
+
+#[test]
+it_fails_a_file_that_yields_no_tests() {
+    # The same reasoning as the assert-nothing check, one level up. `0 passed`
+    # is not a pass, and the harness used to print `[OK] 0 passed` and exit 0
+    # for it.
+    #
+    # Found by mutation rather than by reading: renaming `attr_find` breaks the
+    # discovery `test_run` itself uses, so the whole suite yielded nothing and
+    # reported green over a library that no longer loaded.
+    local out
+    out="$(_harness_run "${FIXTURES}/no_tests_at_all_test.sh")"
+    assert_contains "$out" "FAIL"
+    assert_contains "$out" "no #[test] found"
+}
+
+#[test]
+it_does_not_call_a_filtered_run_empty() {
+    # The control. A filter matching nothing yields no tests for a reason that
+    # is not a defect, and refusing it would make `TEST_FILTER` unusable. The
+    # count that decides is taken before the filter.
+    local out
+    out="$(TEST_FILTER=zzz_matches_nothing _harness_run "${FIXTURES}/first_assertion_fails_test.sh")"
+    assert_eq "${out#*FAIL}" "$out"
+}

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Tests for the bash floor.
+#
+# `init` uses `declare -A`, which bash 3 does not have, so it refuses to load
+# on anything below 4. macOS ships 3.2 at /bin/bash and this is a tool reached
+# for when a machine is already broken, so the refusal has to be readable
+# rather than a syntax error two hundred lines further down.
+#
+# The refusal had no test at all. It was written wrong twice while being
+# reviewed, and both times it was caught by hand rather than by anything that
+# runs again.
+#
+# The version is faked rather than the shell. `BASH_VERSION` is an ordinary
+# assignable variable, so the guard can be driven through every branch under
+# the bash that is already running, which is what makes the table below cheap
+# enough to be exhaustive.
+
+use test
+
+INIT="${BASH_SOURCE[0]%/*}/../init"
+NUT="${BASH_SOURCE[0]%/*}/../bin/nutshell"
+
+# The pattern the guard actually uses, read out of the file rather than copied
+# here. Copying it would make this a test of the copy: edit `init` to accept
+# bash 2 and the copy would keep reporting a refusal.
+# The `case` label the guard actually uses, read out of the file rather than
+# copied here. Copying it would make the table a test of the copy: edit `init`
+# to accept bash 2 and the copy would keep reporting a refusal.
+#
+# Anchored on the `case` line rather than on the message, because the two
+# entry points spell the message differently: `init` calls a function and the
+# binary writes it inline, since it has no library to call into yet.
+_guard_pattern() {
+    local f="${1:-$INIT}" n
+    n="$(grep -n 'case "\${BASH_VERSION' "$f" | head -1)"
+    [[ -n "$n" ]] || return 1
+    n="${n%%:*}"
+    sed -n "$(( n + 1 ))p" "$f" | sed 's/^[[:space:]]*//; s/)[[:space:]]*$//'
+}
+
+# Bash sets `BASH_VERSION` itself at startup, so handing it in the environment
+# does nothing: the new shell overwrites it before reading a line. It is an
+# ordinary assignable variable once that shell is running, so every driver
+# below assigns it inside the shell under test rather than in front of it.
+#
+# This was written the other way first. All four tests using it failed, which
+# is the only reason it is written down here instead of being a thing that
+# quietly reported a pass.
+_as_bash3() {
+    local body="$1"; shift
+    bash -c "BASH_VERSION='3.2.57(1)-release'; $body" _ "$@"
+}
+
+#[test]
+it_reads_its_own_guard_out_of_init() {
+    # The control for the table below. If the extraction stops finding the
+    # label, every row falls through to `allow` and the table reports a clean
+    # pass over a guard that is not there.
+    local pat; pat="$(_guard_pattern)"
+    assert_ne "$pat" ""
+    assert_contains "$pat" '3.*'
+}
+
+#[test]
+it_carries_the_same_floor_in_both_entry_points() {
+    # `bin/nutshell` has its own copy, because it is a script rather than a
+    # sourced file and has no `init` to ask yet. A copy is a thing that drifts,
+    # so the two labels are compared rather than assumed equal.
+    assert_eq "$(_guard_pattern "$NUT")" "$(_guard_pattern "$INIT")"
+}
+
+#[test]
+it_refuses_every_bash_below_four_and_no_others() {
+    local pat; pat="$(_guard_pattern)"
+    local v want got
+
+    # Each row is a version string and what the guard owes it. The interesting
+    # ones are the ends: an empty `BASH_VERSION` means the file is being read
+    # by something that is not bash at all, and `10.0.0` is the row that says
+    # `1.*` is a prefix of `1.` rather than of `1`.
+    for v in '' 1.14.7 2.05b '3.2.57(1)-release' 3.0 4.0 '4.0.0-beta' \
+             '4.4.20(1)-release' 5.2.15 5.3 10.0.0 11.2.3; do
+        case "$v" in ''|1.*|2.*|3.*) want=refuse ;; *) want=allow ;; esac
+
+        got=allow
+        eval "case \"\$v\" in $pat) got=refuse ;; esac"
+
+        assert_eq "$got" "$want" "BASH_VERSION=[$v]"
+    done
+}
+
+#[test]
+it_says_what_is_wrong_and_where_a_newer_one_comes_from() {
+    # A refusal nobody can act on is a crash with better manners. The message
+    # has to carry the version it found and the reason macOS specifically hits
+    # this, because macOS is where it happens.
+    local out
+    out="$(_as_bash3 '. "$1" 2>&1 >/dev/null' "$INIT")"
+
+    assert_contains "$out" "bash 4.0 or newer"
+    assert_contains "$out" "3.2.57"
+    assert_contains "$out" "macOS"
+    assert_contains "$out" "PATH"
+}
+
+#[test]
+it_loads_nothing_when_it_refuses() {
+    # The refusal has to stop the load, not merely complain about it. A file
+    # that prints the message and then defines half a library is worse than
+    # one that fails outright, because the caller carries on.
+    local out
+    out="$(_as_bash3 '
+        . "$1" >/dev/null 2>&1
+        declare -F nut_once >/dev/null && echo LOADED
+        printf "%s" "${_NUTSHELL_INIT:-unset}"
+    ' "$INIT")"
+
+    assert_eq "$out" "unset"
+}
+
+#[test]
+it_loads_normally_on_the_bash_running_this() {
+    # The control for the two above. The guard refusing everything would pass
+    # both of them, and a floor that refuses every bash is not a floor.
+    local out
+    out="$(bash -c '. "$1" >/dev/null 2>&1 || exit 1; printf "%s" "${_NUTSHELL_INIT:-unset}"' _ "$INIT")"
+    assert_eq "$out" "1"
+}
+
+#[test]
+it_stops_a_caller_that_checks_the_source_line() {
+    # `return` inside a sourced file returns to whoever sourced it. It cannot
+    # stop them, which is why every example in the readme ends its source line
+    # in `|| exit 1`. This pins that the guarded form does stop.
+    local script; script="$(mktemp)"
+    cat > "$script" <<'INNER'
+BASH_VERSION='3.2.57(1)-release'
+. "$1" || exit 1
+echo REACHED_THE_BODY
+INNER
+
+    local out rc=0
+    out="$(bash "$script" "$INIT" 2>/dev/null)" || rc=$?
+    rm -f "$script"
+
+    assert_eq "$out" ""
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_does_not_stop_a_caller_that_does_not_check() {
+    # The residue, recorded rather than wished away. An unguarded source line
+    # gets the message and carries on with nothing loaded, and the only fix
+    # available to `init` is the one above, on the caller's side.
+    local script; script="$(mktemp)"
+    cat > "$script" <<'INNER'
+BASH_VERSION='3.2.57(1)-release'
+. "$1"
+echo REACHED_THE_BODY
+INNER
+
+    local out
+    out="$(bash "$script" "$INIT" 2>/dev/null)"
+    rm -f "$script"
+
+    assert_eq "$out" "REACHED_THE_BODY"
+}
+
+#[test]
+it_puts_the_binarys_floor_above_anything_bash_three_cannot_parse() {
+    # A guard below the first `declare -A` or `[[ ]]` is a guard the shell
+    # never reaches: bash 3 fails parsing the file before running any of it,
+    # and the reader gets a syntax error instead of the message.
+    #
+    # Faking the version cannot catch this, because the running bash parses
+    # the file fine. So the check is positional, and `bash --posix -n` is the
+    # cheapest reader that objects to the same constructs.
+    local guard_line body_line
+    guard_line="$(grep -n 'case "\${BASH_VERSION' "$NUT" | head -1)"
+    guard_line="${guard_line%%:*}"
+    assert_ne "$guard_line" ""
+
+    # The first line using something bash 3 does not have, or the first
+    # line of the body, whichever comes first.
+    body_line="$(grep -n 'declare -A\|set -uo pipefail' "$NUT" | head -1)"
+    body_line="${body_line%%:*}"
+    assert_ne "$body_line" ""
+
+    [[ "$guard_line" -lt "$body_line" ]] \
+        || _test_failed "guard at line $guard_line sits below line $body_line"
+}
+
+#[test]
+it_writes_the_refusal_where_a_terminal_will_show_it() {
+    # stderr, so a caller piping stdout somewhere still sees why nothing came
+    # out of it. The message going to stdout would land in whatever file the
+    # caller was redirecting into.
+    local on_out on_err
+    on_out="$(_as_bash3 '. "$1" 2>/dev/null' "$INIT")"
+    on_err="$(_as_bash3 '. "$1" 2>&1 >/dev/null' "$INIT")"
+
+    assert_empty "$on_out"
+    assert_contains "$on_err" "bash 4.0 or newer"
+}

--- a/tests/lazy_stub_test.sh
+++ b/tests/lazy_stub_test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Tests for the lazy stubs, and for one module meaning one file per unit.
+#
+# The crash these exist for had no message. A stub loads an implementation and
+# then calls the name that implementation was supposed to rebind; when the
+# rebind had not happened, that call was the stub calling itself until the
+# shell ran out of stack and the process disappeared. Nothing printed, no exit
+# status, nothing to read.
+
+use test
+
+ROOT="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+
+# Each of these runs a fresh shell, because the failure is about what one
+# process has already loaded.
+_run() { bash -c "cd '$ROOT'; . ./init; FUNCNEST=60; $1" 2>&1; }
+
+#[test]
+it_survives_a_module_being_sourced_again() {
+    local out
+    out="$(_run '
+        use text
+        printf "needle\n" > "$TMPDIR/_ck.$$"
+        text_grep needle "$TMPDIR/_ck.$$" >/dev/null
+        source lib/text.sh
+        text_grep needle "$TMPDIR/_ck.$$" >/dev/null
+        printf "SURVIVED"
+        rm -f "$TMPDIR/_ck.$$"')"
+    assert_ok    grep -q 'SURVIVED' <<<"$out"
+    assert_fails grep -q 'nesting level' <<<"$out"
+}
+
+#[test]
+it_survives_an_implementation_loaded_before_its_owner() {
+    local out
+    out="$(_run '
+        use text::impl::grep_match
+        use text
+        printf "needle\n" > "$TMPDIR/_ck2.$$"
+        text_grep needle "$TMPDIR/_ck2.$$" >/dev/null
+        printf "SURVIVED"
+        rm -f "$TMPDIR/_ck2.$$"')"
+    # The owner installs its stubs over the bindings the implementation made,
+    # so the stub has to be able to put them back.
+    assert_ok    grep -q 'SURVIVED' <<<"$out"
+    assert_fails grep -q 'nesting level' <<<"$out"
+}
+
+#[test]
+it_still_answers_after_all_that() {
+    local out
+    out="$(_run '
+        use text
+        printf "needle\nhaystack\n" > "$TMPDIR/_ck3.$$"
+        source lib/text.sh
+        text_grep needle "$TMPDIR/_ck3.$$"
+        rm -f "$TMPDIR/_ck3.$$"')"
+    # Not just "did not crash": it has to still do the thing.
+    assert_ok    grep -q 'needle'   <<<"$out"
+    assert_fails grep -q 'haystack' <<<"$out"
+}
+
+#[test]
+it_survives_the_same_for_fs() {
+    local out
+    out="$(_run '
+        use fs
+        fs_size ./init >/dev/null
+        source lib/fs.sh
+        fs_size ./init >/dev/null
+        printf "SURVIVED"')"
+    assert_ok    grep -q 'SURVIVED' <<<"$out"
+    assert_fails grep -q 'nesting level' <<<"$out"
+}
+
+#[test]
+it_says_something_rather_than_dying_silently() {
+    # The guard's own message, when a stub really is on its own. Provoked by
+    # putting the stub back with the implementation already loaded and the
+    # reload unable to help.
+    local out
+    out="$(_run '
+        use text
+        text_grep() { nut_lazy_guard text_grep || return 1; local _NUT_LAZY_text_grep=1; text_grep "$@"; }
+        text_grep a b
+        printf "EXIT=%s" "$?"')"
+    assert_ok grep -q 'did not define' <<<"$out"
+    assert_ok grep -q 'EXIT=1'         <<<"$out"
+    # A message and a status, rather than a process that disappears.
+    assert_fails grep -q 'nesting level' <<<"$out"
+}
+
+# --- one name, two units ------------------------------------------------------------
+
+#[test]
+it_gives_each_unit_its_own_module_of_the_same_name() {
+    local out
+    out="$(_run '
+        a=$(mktemp -d); b=$(mktemp -d)
+        for d in "$a" "$b"; do mkdir -p "$d/lib"; printf "[meta]\nname=\"x\"\n" > "$d/nut.toml"; done
+        printf "A_MARK=1\n" > "$a/lib/guard.sh"; printf "guard lib/guard.sh\n" > "$a/lib.nut"
+        printf "B_MARK=1\n" > "$b/lib/guard.sh"; printf "guard lib/guard.sh\n" > "$b/lib.nut"
+        printf "use super::guard\n" > "$a/mod.sh"
+        printf "use super::guard\n" > "$b/mod.sh"
+        . "$a/mod.sh"; . "$b/mod.sh"
+        printf "A=%s B=%s" "${A_MARK:-unset}" "${B_MARK:-unset}"
+        rm -rf "$a" "$b"')"
+    # super:: is relative to whoever wrote it. Cached by the name alone, the
+    # second unit matched the first unit's entry, loaded nothing, and returned
+    # success.
+    assert_ok grep -q 'A=1 B=1' <<<"$out"
+}
+
+#[test]
+it_still_loads_one_file_once_within_a_unit() {
+    local out
+    out="$(_run '
+        a=$(mktemp -d); mkdir -p "$a/lib"
+        printf "[meta]\nname=\"x\"\n" > "$a/nut.toml"
+        printf "COUNT=\$(( \${COUNT:-0} + 1 ))\n" > "$a/lib/one.sh"
+        printf "one lib/one.sh\n" > "$a/lib.nut"
+        printf "use super::one\nuse super::one\n" > "$a/mod.sh"
+        . "$a/mod.sh"
+        printf "COUNT=%s" "$COUNT"
+        rm -rf "$a"')"
+    assert_ok grep -q 'COUNT=1' <<<"$out"
+}
+
+# --- reloading on purpose --------------------------------------------------------------
+
+#[test]
+it_loads_again_when_asked_outright() {
+    local out
+    out="$(_run '
+        a=$(mktemp -d); mkdir -p "$a/lib"
+        printf "[meta]\nname=\"x\"\n" > "$a/nut.toml"
+        printf "COUNT=\$(( \${COUNT:-0} + 1 ))\n" > "$a/lib/one.sh"
+        printf "one lib/one.sh\n" > "$a/lib.nut"
+        printf "use super::one\nnut_reload super::one\n" > "$a/mod.sh"
+        . "$a/mod.sh"
+        printf "COUNT=%s" "$COUNT"
+        rm -rf "$a"')"
+    assert_ok grep -q 'COUNT=2' <<<"$out"
+}
+
+#[test]
+it_forgets_by_file_rather_than_by_the_name_it_was_asked_about() {
+    # Loaded under one name and reloaded under another. Forgetting by the name
+    # asked about would forget nothing, `use` would say "already loaded", and
+    # the stub that asked for the reload would still be the stub.
+    #
+    # Written to a file rather than nested inside quotes: the quoting needed to
+    # define a function inside a -c inside a test is its own source of bugs.
+    local f; f="$(mktemp)"
+    cat > "$f" <<'PROBE'
+cd "$NUT_ROOT"
+. ./init
+a=$(mktemp -d); mkdir -p "$a/libs"
+printf 'COUNT=$(( ${COUNT:-0} + 1 ))
+' > "$a/libs/one.sh"
+printf 'one libs/one.sh
+' > "$a/lib.nut"
+use extern
+extern_path() { printf '%s' "$a"; }
+use dep::one
+nut_reload other::one
+printf 'COUNT=%s
+' "$COUNT"
+rm -rf "$a"
+PROBE
+    local out; out="$(NUT_ROOT="$ROOT" bash "$f" 2>&1)"
+    rm -f "$f"
+    assert_ok grep -q 'COUNT=2' <<<"$out"
+}

--- a/tests/lib_nut_test.sh
+++ b/tests/lib_nut_test.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+# Tests for the module declaration.
+#
+# The point of it is that a name either is in the tree or is not, answerable
+# without running anything. Before it, a module was found by trying three
+# layouts and taking whichever answered, so nothing could say in advance that a
+# name would fail, and the failure arrived mid-run under `set -eo pipefail`
+# with nothing to read.
+
+use extern test
+
+DECLARE="${BASH_SOURCE[0]%/*}/../bin/nut-declare"
+ROOT_DIR="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+
+# A library with a declaration, laid out the way a real one is.
+_lib() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/libs/tui" "$d/lib/json/impl"
+    : > "$d/libs/tui/term.sh"
+    : > "$d/libs/tui/key.sh"
+    : > "$d/lib/json.sh"
+    : > "$d/lib/json/impl/jq.sh"
+    printf '%s\n' \
+        'tui::term       libs/tui/term.sh' \
+        'tui::key        libs/tui/key.sh' \
+        'json            lib/json.sh' \
+        'json::impl::jq  lib/json/impl/jq.sh  internal' \
+        > "$d/lib.nut"
+    printf '%s' "$d"
+}
+
+# --- resolution -----------------------------------------------------------------
+
+#[test]
+it_resolves_a_module_the_library_declares() {
+    local d; d="$(_lib)"
+    extern_path() { printf '%s' "$d"; }
+    assert_eq "$(extern_resolve 'dep::tui::term')" "$d/libs/tui/term.sh"
+    assert_eq "$(extern_resolve 'dep::json')"      "$d/lib/json.sh"
+    unset -f extern_path; rm -rf "$d"
+}
+
+#[test]
+it_refuses_a_module_the_library_does_not_declare() {
+    local d; d="$(_lib)"
+    # The file is there. It is still refused, because a declaration that a
+    # search can go behind is not a declaration.
+    mkdir -p "$d/libs/tui"; : > "$d/libs/tui/undeclared.sh"
+    extern_path() { printf '%s' "$d"; }
+    assert_fails extern_resolve 'dep::tui::undeclared'
+    unset -f extern_path; rm -rf "$d"
+}
+
+#[test]
+it_says_what_the_library_does_declare() {
+    local d out; d="$(_lib)"
+    extern_path() { printf '%s' "$d"; }
+    out="$(extern_resolve 'dep::nope' 2>&1 || true)"
+    assert_ok grep -qi 'not among the modules' <<<"$out"
+    unset -f extern_path; rm -rf "$d"
+}
+
+#[test]
+it_refuses_a_declaration_pointing_at_a_file_that_is_gone() {
+    local d out; d="$(_lib)"
+    rm -f "$d/libs/tui/key.sh"
+    extern_path() { printf '%s' "$d"; }
+    out="$(extern_resolve 'dep::tui::key' 2>&1 || true)"
+    assert_fails extern_resolve 'dep::tui::key'
+    # Named, so the fix is obvious: either the file moved or the line is stale.
+    assert_ok grep -q 'which is not there' <<<"$out"
+    unset -f extern_path; rm -rf "$d"
+}
+
+#[test]
+it_keeps_an_internal_module_out_of_a_consumers_reach() {
+    local d; d="$(_lib)"
+    extern_path() { printf '%s' "$d"; }
+    # Picked at runtime by the module above it. A consumer reaching it directly
+    # is reaching past the thing whose job is to choose.
+    assert_fails extern_resolve 'dep::json::impl::jq'
+    unset -f extern_path; rm -rf "$d"
+}
+
+#[test]
+it_still_refuses_a_slash_even_with_a_declaration() {
+    local d; d="$(_lib)"
+    extern_path() { printf '%s' "$d"; }
+    assert_fails extern_resolve 'dep::tui/term'
+    unset -f extern_path; rm -rf "$d"
+}
+
+#[test]
+it_ignores_comments_and_blank_lines() {
+    local d; d="$(_lib)"
+    printf '\n# a comment\n\n' >> "$d/lib.nut"
+    extern_path() { printf '%s' "$d"; }
+    assert_eq "$(extern_resolve 'dep::json')" "$d/lib/json.sh"
+    unset -f extern_path; rm -rf "$d"
+}
+
+# --- the migration ----------------------------------------------------------------
+
+#[test]
+it_declares_what_the_old_resolver_would_have_found() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/libs/tui" "$d/lib"
+    : > "$d/libs/tui/term.sh"; : > "$d/lib/log.sh"
+    local out; out="$("$DECLARE" --print "$d")"
+    # The names are the ones a `use` would have written for those files.
+    assert_ok grep -qE '^tui::term[[:space:]]+libs/tui/term\.sh' <<<"$out"
+    assert_ok grep -qE '^log[[:space:]]+lib/log\.sh' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_marks_an_implementation_file_internal() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib/json/impl"
+    : > "$d/lib/json/impl/jq.sh"
+    assert_ok grep -q 'internal' <<<"$("$DECLARE" --print "$d")"
+    rm -rf "$d"
+}
+
+#[test]
+it_does_not_declare_a_vendored_nutshell_as_part_of_the_library() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib/nutshell/lib" "$d/lib"
+    : > "$d/lib/nutshell/lib/log.sh"; : > "$d/lib/own.sh"
+    local out; out="$("$DECLARE" --print "$d")"
+    assert_ok    grep -q 'own' <<<"$out"
+    assert_fails grep -q 'nutshell' <<<"$(grep -v '^#' <<<"$out")"
+    rm -rf "$d"
+}
+
+#[test]
+it_never_overwrites_a_declaration_that_exists() {
+    local d; d="$(_lib)"
+    local before; before="$(cat "$d/lib.nut")"
+    "$DECLARE" "$d" >/dev/null 2>&1
+    assert_eq "$(cat "$d/lib.nut")" "$before"
+    rm -rf "$d"
+}
+
+#[test]
+it_shows_the_difference_rather_than_editing() {
+    local d out; d="$(_lib)"
+    : > "$d/libs/tui/extra.sh"
+    out="$("$DECLARE" "$d" 2>&1)"
+    assert_ok grep -q 'already exists' <<<"$out"
+    assert_ok grep -q 'extra' <<<"$out"
+    rm -rf "$d"
+}
+
+# --- the check --------------------------------------------------------------------
+
+#[test]
+it_passes_a_library_whose_declaration_matches_its_files() {
+    local d; d="$(_lib)"
+    assert_ok "$DECLARE" --check "$d"
+    rm -rf "$d"
+}
+
+#[test]
+it_catches_a_declaration_whose_file_is_missing() {
+    local d out; d="$(_lib)"
+    rm -f "$d/lib/json.sh"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    assert_fails "$DECLARE" --check "$d"
+    assert_ok grep -q 'declared but missing' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_catches_a_file_nothing_declares() {
+    local d out; d="$(_lib)"
+    : > "$d/libs/tui/orphan.sh"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    assert_fails "$DECLARE" --check "$d"
+    # The direction a search could never report: the file resolves fine, and
+    # is reachable by a name the library never meant to offer.
+    assert_ok grep -q 'present but undeclared' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_a_library_with_no_declaration_at_all() {
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/lib/one.sh"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    assert_fails "$DECLARE" --check "$d"
+    assert_ok grep -q 'has no lib.nut' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_checks_every_library_in_this_workspace() {
+    # The declarations shipped here have to match the files shipped here, or
+    # the check is a thing that only passes on fixtures.
+    assert_ok "$DECLARE" --check "${BASH_SOURCE[0]%/*}/.."
+}
+
+#[test]
+it_finds_a_module_however_deep_it_sits() {
+    # The scan used a glob per level, so a module one level deeper than anyone
+    # had written a glob for was invisible. Invisible to --check too, since
+    # both read the same list: the library reported complete while
+    # text::impl::combo::grep_sed was undeclared and would have failed at the
+    # moment it was reached.
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib/text/impl/combo"
+    : > "$d/lib/text/impl/combo/grep_sed.sh"
+    local out; out="$("$DECLARE" --print "$d")"
+    assert_ok grep -q 'text::impl::combo::grep_sed' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_finds_one_deeper_still() {
+    # Not "one more level than the bug had": no level at all.
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib/a/b/c/d/e"
+    : > "$d/lib/a/b/c/d/e/deep.sh"
+    assert_ok grep -q 'a::b::c::d::e::deep' <<<"$("$DECLARE" --print "$d")"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_a_deep_file_as_undeclared() {
+    # The check has to see as far as the scan, or it certifies a tree it did
+    # not look at.
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib/a/b/c"
+    : > "$d/lib/a/b/c/deep.sh"
+    printf 'nothing lib/nothing.sh\n' > "$d/lib.nut"
+    : > "$d/lib/nothing.sh"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    assert_ok grep -q 'a::b::c::deep' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_loads_an_implementation_through_the_resolver() {
+    # A hand-rolled `source` goes around the resolver: loaded again for every
+    # caller, not covered by the declaration, and failing when reached rather
+    # than before the run.
+    local bad=""
+    grep -rn 'source "\${_[A-Z_]*_DIR}' "${BASH_SOURCE[0]%/*}/../lib"/*.sh 2>/dev/null \
+        | grep -v '/nutshell/' | while IFS= read -r line; do
+        printf '%s\n' "$line"
+    done > /tmp/_nut_direct_sources.$$
+    bad="$(cat /tmp/_nut_direct_sources.$$)"; rm -f /tmp/_nut_direct_sources.$$
+    assert_empty "$bad"
+}
+
+# --- the ways around the declaration ------------------------------------------------
+#
+# A declaration a caller can step around is not a declaration. These are the
+# routes that existed: a bare `use` went straight to lib/<name>.sh, so spelling
+# a path reached a file the library had marked internal, in one call, without
+# the declaration being consulted at all.
+
+#[test]
+it_refuses_a_bare_use_that_spells_a_path() {
+    local out
+    out="$(bash -c "cd '$ROOT_DIR'; . ./init; use json/impl/jq" 2>&1 || true)"
+    assert_ok grep -q "separates modules with '/'" <<<"$out"
+    assert_ok grep -q 'json::impl::jq' <<<"$out"
+}
+
+#[test]
+it_does_not_load_an_internal_module_by_spelling_its_path() {
+    local out
+    out="$(bash -c "cd '$ROOT_DIR'; . ./init; use json/impl/jq >/dev/null 2>&1; declare -F _json_jq_get >/dev/null && printf REACHED || printf refused" 2>&1)"
+    assert_ok grep -q 'refused' <<<"$out"
+}
+
+#[test]
+it_still_loads_a_plain_module_by_name() {
+    local out
+    out="$(bash -c "cd '$ROOT_DIR'; . ./init; use json && printf OK" 2>&1)"
+    assert_ok grep -q 'OK' <<<"$out"
+}
+
+#[test]
+it_loads_its_own_nested_module_by_name() {
+    # nutshell's own tree is named the way anybody else's is. Treating every
+    # `::` as a dependency made its own nested modules unreachable except from
+    # inside the unit.
+    local out
+    out="$(bash -c "cd '$ROOT_DIR'; . ./init; use text::impl::grep_match && printf OK" 2>&1)"
+    assert_ok grep -q 'OK' <<<"$out"
+}
+
+# --- the ways a declaration was quietly wrong -----------------------------------------
+
+#[test]
+it_declares_a_module_flat_at_the_library_root() {
+    # The resolver tries three layouts and the scan walked two, so a module at
+    # the root resolved before the migration and was refused after it, with
+    # --check certifying the drop because it reads the same scan.
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/helper.sh"; : > "$d/lib/other.sh"
+    local out; out="$("$DECLARE" --print "$d")"
+    assert_ok grep -qE '^helper[[:space:]]+helper\.sh' <<<"$out"
+    assert_ok grep -qE '^other[[:space:]]+lib/other\.sh' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_refuses_to_declare_when_two_files_answer_to_one_name() {
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib" "$d/libs"
+    printf 'WHICH=lib\n'  > "$d/lib/dup.sh"
+    printf 'WHICH=libs\n' > "$d/libs/dup.sh"
+    # Writing one of them freezes a precedence and hides the other file for
+    # good. Better to say so than to pick.
+    out="$("$DECLARE" "$d" 2>&1 || "$DECLARE" "$d" 2>&1)"
+    assert_ok grep -q 'same name' <<<"$out"
+    assert_fails test -f "$d/lib.nut"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_two_files_answering_to_one_name_in_a_check() {
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib" "$d/libs"
+    : > "$d/lib/dup.sh"; : > "$d/libs/dup.sh"
+    printf 'dup lib/dup.sh\n' > "$d/lib.nut"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    assert_ok grep -q 'one name' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_keeps_the_last_declaration_when_the_file_has_no_trailing_newline() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/lib/last.sh"
+    printf 'last lib/last.sh' > "$d/lib.nut"      # no newline
+    # An editor that trims the last newline would otherwise delete a module,
+    # and the checker agreed because it read the file another way.
+    assert_ok bash -c ". '$ROOT_DIR/init'; _lib_nut_lookup '$d' last"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_a_line_that_is_not_a_declaration() {
+    local d out; d="$(mktemp -d)"
+    printf 'nofile\n' > "$d/lib.nut"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    # Rather than a raw bash error about an unset positional under set -u.
+    assert_ok    grep -q 'not a declaration' <<<"$out"
+    assert_fails grep -qi 'unbound\|bad substitution' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_a_visibility_it_does_not_understand() {
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/lib/x.sh"
+    printf 'x lib/x.sh publicish\n' > "$d/lib.nut"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    # A typo in the third column silently made an internal module public.
+    assert_ok grep -q 'unknown visibility' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_skips_an_indented_comment_the_way_the_resolver_does() {
+    local d; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/lib/x.sh"
+    printf '   # indented\nx lib/x.sh\n' > "$d/lib.nut"
+    assert_ok "$DECLARE" --check "$d"
+    rm -rf "$d"
+}
+
+#[test]
+it_compares_a_module_name_as_a_word_not_as_a_pattern() {
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib"
+    : > "$d/lib/fs.impl.sh"
+    printf 'fsXimpl lib/other.sh\n' > "$d/lib.nut"
+    : > "$d/lib/other.sh"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    # `fs.impl` as a regex matches `fsXimpl`, and the module would be reported
+    # as declared when nothing declares it.
+    assert_ok grep -q 'present but undeclared: fs.impl' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_loads_a_symlinked_module_once() {
+    # A logical path leaves a link and its target as two keys, so one file
+    # loads twice. Written to a file: the escaping needed to build this inside
+    # a -c inside a test is its own source of bugs.
+    local f; f="$(mktemp)"
+    cat > "$f" <<'PROBE'
+cd "$NUT_ROOT"
+. ./init
+a=$(mktemp -d); mkdir -p "$a/libs"
+printf 'COUNT=$(( ${COUNT:-0} + 1 ))
+' > "$a/libs/real.sh"
+ln -s real.sh "$a/libs/alias.sh"
+printf 'real libs/real.sh
+alias libs/alias.sh
+' > "$a/lib.nut"
+use extern
+extern_path() { printf '%s' "$a"; }
+use dep::real
+use dep::alias
+printf 'COUNT=%s
+' "$COUNT"
+rm -rf "$a"
+PROBE
+    local out; out="$(NUT_ROOT="$ROOT_DIR" bash "$f" 2>&1)"
+    rm -f "$f"
+    assert_ok grep -q 'COUNT=1' <<<"$out"
+}

--- a/tests/log_marks_test.sh
+++ b/tests/log_marks_test.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Tests for marked, nested log output.
+#
+# Two properties. A run where one line went wrong has to be skimmable, so the
+# mark's column and the depth are the contract rather than decoration. And
+# log_run has to return what the command returned: a runner that reports
+# success on a failed command is worse than no runner.
+
+use log test
+
+setup() { log_reset; LOG_COLOR=never; LOG_LEVEL=info; log_marks text; }
+
+_strip() { sed 's/\x1b\[[0-9;]*[a-zA-Z]//g'; }
+
+# --- marks -------------------------------------------------------------------
+
+#[test]
+it_marks_each_kind_of_line_differently() {
+    local out
+    out="$( { log_ok a; log_warned b; log_failed c; log_flat d; } 2>&1 | _strip)"
+    assert_eq "$(grep -c . <<<"$out")" "4"
+    # Four kinds, four marks in column one.
+    assert_eq "$(cut -c1 <<<"$out" | sort -u | grep -c .)" "4"
+}
+
+#[test]
+it_leaves_a_flat_line_unmarked() {
+    local out; out="$(log_flat "just a fact" 2>&1 | _strip)"
+    assert_eq "${out:0:1}" " "
+}
+
+#[test]
+it_keeps_every_mark_to_one_column() {
+    local out
+    out="$( { log_ok top
+              log_open deeper
+              log_ok inside
+              log_open "deeper still"
+              log_failed "further in"; } 2>&1 | _strip)"
+    # The mark sits outside the indent, so scanning column one finds every
+    # result whatever depth produced it.
+    local second; second="$(cut -c2 <<<"$out" | sort -u)"
+    assert_eq "$(grep -c . <<<"$second")" "1"
+    assert_eq "$second" " "
+}
+
+#[test]
+it_uses_words_when_told_to() {
+    log_marks text
+    local out; out="$( { log_ok a; log_failed b; } 2>&1 | _strip)"
+    assert_ok python3 -c 'import sys; sys.stdin.buffer.read().decode("ascii")' <<<"$out"
+}
+
+#[test]
+it_uses_icons_when_told_to() {
+    log_marks icon
+    local out; out="$(log_ok a 2>&1 | _strip)"
+    assert_fails python3 -c 'import sys; sys.stdin.buffer.read().decode("ascii")' <<<"$out"
+    log_marks text
+}
+
+#[test]
+it_draws_no_marks_when_told_to() {
+    log_marks none
+    local out; out="$( { log_ok a; log_failed b; } 2>&1 | _strip)"
+    # A blank column rather than no column: the text still lines up with a run
+    # that does have marks, which is the point of turning them off rather than
+    # of not having them.
+    assert_eq "$(cut -c1 <<<"$out" | sort -u | tr -d '\n')" " "
+    assert_ok grep -q '^  a$' <<<"$out"
+    log_marks text
+}
+
+#[test]
+it_picks_words_in_a_locale_that_cannot_draw_icons() {
+    local out
+    out="$(LC_ALL=C LANG=C bash -c '
+        cd '"$PWD"'; . ./init; use log
+        LOG_COLOR=never; log_ok a; log_failed b' 2>&1 | _strip)"
+    # An icon that renders as three bytes of noise is worse than a plus.
+    assert_ok python3 -c 'import sys; sys.stdin.buffer.read().decode("ascii")' <<<"$out"
+}
+
+# --- depth --------------------------------------------------------------------
+
+#[test]
+it_indents_what_belongs_to_a_step() {
+    local out; out="$( { log_open outer; log_ok inner; } 2>&1 | _strip)"
+    assert_ok grep -q '^.   inner' <<<"$(sed -n 2p <<<"$out")"
+}
+
+#[test]
+it_nests_further_than_one_level() {
+    local out
+    out="$( { log_open a; log_open b; log_ok c; } 2>&1 | _strip)"
+    # log_substep was fixed at one level. This is the gap that wanted filling.
+    assert_ok grep -q '^.     c' <<<"$(sed -n 3p <<<"$out")"
+}
+
+#[test]
+it_returns_to_the_previous_depth() {
+    log_open one >/dev/null 2>&1; assert_eq "$LOG_DEPTH" "1"
+    log_open two >/dev/null 2>&1; assert_eq "$LOG_DEPTH" "2"
+    log_close ok x >/dev/null 2>&1; assert_eq "$LOG_DEPTH" "1"
+    log_close ok y >/dev/null 2>&1; assert_eq "$LOG_DEPTH" "0"
+}
+
+#[test]
+it_does_not_go_below_the_top() {
+    log_close ok "nothing was open" >/dev/null 2>&1
+    log_close ok "still nothing"    >/dev/null 2>&1
+    # A negative depth is a negative printf width, which is an error and not
+    # an indent.
+    assert_eq "$LOG_DEPTH" "0"
+    assert_ok log_ok after >/dev/null 2>&1
+}
+
+#[test]
+it_closes_a_step_silently_when_told_nothing() {
+    log_open one >/dev/null 2>&1
+    # Two calls, deliberately. Capturing the output puts log_close in a
+    # subshell, where the depth it changes is discarded, so a single call
+    # cannot check both things at once.
+    local out; out="$(log_open two >/dev/null 2>&1; log_close 2>&1)"
+    assert_eq "$out" ""
+    log_close 2>/dev/null
+    assert_eq "$LOG_DEPTH" "0"
+}
+
+#[test]
+it_keeps_the_depth_right_even_when_the_level_hides_the_line() {
+    LOG_LEVEL=error
+    log_open quiet >/dev/null 2>&1
+    # The heading is suppressed. The depth still has to move, or every line
+    # after it is indented wrongly for the rest of the run.
+    assert_eq "$LOG_DEPTH" "1"
+    log_close >/dev/null 2>&1
+    LOG_LEVEL=info
+}
+
+# --- running a command -----------------------------------------------------------
+
+#[test]
+it_returns_what_the_command_returned() {
+    log_run "fine" true >/dev/null 2>&1;   assert_eq "$?" "0"
+    log_run "not fine" false >/dev/null 2>&1; assert_eq "$?" "1"
+    log_run "particular" bash -c 'exit 42' >/dev/null 2>&1; assert_eq "$?" "42"
+}
+
+#[test]
+it_marks_a_failed_command_as_failed() {
+    local out; out="$(log_run "a thing" bash -c 'exit 3' 2>&1 | _strip)"
+    assert_ok grep -q 'exit 3' <<<"$out"
+}
+
+#[test]
+it_counts_a_failed_command() {
+    # Not captured, because a capture is a subshell and the count made in one
+    # does not come back. That is a real property of the counters and callers
+    # need to know it; the doc comment on log_worst says so.
+    log_reset
+    log_run "a thing" bash -c 'exit 3' >/dev/null 2>&1
+    assert_eq "$LOG_FAILURES" "1"
+    assert_eq "$(log_worst)" "fail"
+}
+
+#[test]
+it_shows_both_streams_of_what_the_command_printed() {
+    local out; out="$(log_run noisy bash -c 'echo out; echo err >&2' 2>&1 | _strip)"
+    assert_ok grep -q 'out' <<<"$out"
+    assert_ok grep -q 'err' <<<"$out"
+}
+
+#[test]
+it_keeps_the_status_marker_out_of_the_output() {
+    local out; out="$(log_run quiet true 2>&1 | _strip)"
+    assert_fails grep -qE '^[^ ]? +[0-9]+$' <<<"$out"
+    assert_fails grep -q $'\037' <<<"$out"
+}
+
+#[test]
+it_indents_a_commands_output_under_its_step() {
+    local out; out="$(log_run label bash -c 'echo hello' 2>&1 | _strip)"
+    assert_ok grep -q '^.   hello' <<<"$out"
+}
+
+#[test]
+it_leaves_the_depth_where_it_found_it() {
+    log_open outer >/dev/null 2>&1
+    log_run inner true >/dev/null 2>&1
+    assert_eq "$LOG_DEPTH" "1"
+    log_run "inner that failed" false >/dev/null 2>&1
+    assert_eq "$LOG_DEPTH" "1"
+}
+
+# --- the verdict --------------------------------------------------------------------
+
+#[test]
+it_calls_a_clean_run_ok() {
+    log_ok a >/dev/null 2>&1; log_flat b >/dev/null 2>&1
+    assert_eq "$(log_worst)" "ok"
+}
+
+#[test]
+it_remembers_a_warning() {
+    log_ok a >/dev/null 2>&1; log_warned b >/dev/null 2>&1
+    assert_eq "$(log_worst)" "warn"
+}
+
+#[test]
+it_lets_a_failure_outrank_a_warning() {
+    log_warned a >/dev/null 2>&1; log_failed b >/dev/null 2>&1
+    assert_eq "$(log_worst)" "fail"
+}
+
+#[test]
+it_counts_a_problem_even_when_the_level_hides_it() {
+    LOG_LEVEL=error
+    log_warned "not shown" >/dev/null 2>&1
+    # The verdict is about what happened, not about what was displayed. A run
+    # quieted with LOG_LEVEL must not come out looking clean.
+    assert_eq "$(log_worst)" "warn"
+    LOG_LEVEL=info
+}
+
+#[test]
+it_forgets_the_previous_run_on_reset() {
+    log_failed a >/dev/null 2>&1
+    assert_eq "$(log_worst)" "fail"
+    log_reset
+    assert_eq "$(log_worst)" "ok"
+    assert_eq "$LOG_FAILURES" "0"
+}
+
+# --- what was already here ------------------------------------------------------------
+
+#[test]
+it_leaves_the_existing_levels_alone() {
+    LOG_COLOR=never
+    local out
+    out="$(log_warn "old shape" 2>&1)"
+    # The tagged format is what every caller already prints. Adding marks must
+    # not have changed it.
+    assert_ok grep -q '^\[WARN\] old shape' <<<"$out"
+    out="$(log_step "a heading" 2>&1)"
+    assert_ok grep -q '==>' <<<"$out"
+}

--- a/tests/priv_test.sh
+++ b/tests/priv_test.sh
@@ -271,3 +271,223 @@ it_ignores_a_path_that_is_not_there() {
     unset -f priv_is_root priv_user chown
     assert_eq "$called" "0"
 }
+
+# --- stepping back down --------------------------------------------------------
+#
+# The other direction, and the one with no way to test it for real without a
+# second account. What it does have is a choice between three commands and
+# three different ways of handing arguments to them, which is where it can be
+# wrong, so the three are stubbed and asked what they were given.
+
+# A directory holding stubs for the step-down commands, first on PATH. Each one
+# records that it ran and repeats its arguments one per line, so a test can see
+# both which command was picked and what survived the trip.
+_priv_stubs() {
+    _PRIV_STUB_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-priv.XXXXXX")"
+    # Absolute paths, found while PATH is still whole. Once PATH is only the
+    # stub directory, `env bash` cannot resolve bash and a test cannot reach
+    # `chmod` to write a stub of its own.
+    _PRIV_STUB_BASH="$(command -v bash)"
+    _PRIV_STUB_SH="$(command -v sh)"
+    _PRIV_STUB_CHMOD="$(command -v chmod)"
+    local c
+    for c in "$@"; do
+        _priv_stub_put "$c" "printf '%s\n' \"$c\"" 'printf '"'"'%s\n'"'"' "$@"'
+    done
+    _PRIV_PATH_KEEP="$PATH"
+    # The stub directory and nothing else. Prepending is not enough: a machine
+    # with a real `sudo` on it picks that one whenever the stub set leaves it
+    # out, so the two tests about falling past `sudo` would have been answered
+    # by the host's own sudo failing rather than by the fallback working.
+    export PATH="$_PRIV_STUB_DIR"
+}
+# Write one stub, from lines of bash handed in as arguments. `printf` is a
+# builtin and the interpreter and `chmod` are absolute, so this works with the
+# stub directory as the whole of PATH.
+_priv_stub_put() {
+    local name="$1"; shift
+    local f="$_PRIV_STUB_DIR/$name" line
+    printf '#!%s\n' "$_PRIV_STUB_BASH" > "$f"
+    for line in "$@"; do printf '%s\n' "$line" >> "$f"; done
+    "$_PRIV_STUB_CHMOD" +x "$f"
+}
+
+_priv_stubs_end() {
+    export PATH="${_PRIV_PATH_KEEP:-$PATH}"
+    [[ -n "${_PRIV_STUB_DIR:-}" ]] && rm -rf "$_PRIV_STUB_DIR"
+    unset _PRIV_STUB_DIR _PRIV_PATH_KEEP
+}
+
+# Pretend to be root, with somebody else having started this.
+_priv_as_root() {
+    PRIV_USER="somebody"; PRIV_UID="1234"; PRIV_HOME="/home/somebody"
+    priv_is_root() { return 0; }
+}
+_priv_as_root_end() { unset -f priv_is_root; _priv_reset; }
+
+#[test]
+it_runs_the_step_itself_when_it_is_not_root() {
+    _priv_reset
+    # Nothing to step down from. The step still has to happen, and it has to
+    # happen without any of the three commands being involved.
+    priv_is_root() { return 1; }
+    local out; out="$(priv_as_user "reading" printf 'ran\n')"
+    unset -f priv_is_root
+    assert_eq "$out" "ran"
+}
+
+#[test]
+it_runs_the_step_itself_when_the_person_is_root() {
+    _priv_reset
+    PRIV_USER="root"; PRIV_UID="0"; PRIV_HOME="/root"
+    priv_is_root() { return 0; }
+    # Stepping down to root from root is the same shell with two more
+    # processes in it.
+    _priv_stubs runuser sudo su
+    local out; out="$(priv_as_user "reading" printf 'ran\n')"
+    _priv_stubs_end
+    unset -f priv_is_root; _priv_reset
+    assert_eq "$out" "ran"
+}
+
+#[test]
+it_carries_the_status_of_the_step_back_out() {
+    _priv_reset
+    priv_is_root() { return 1; }
+    assert_fails priv_as_user "failing" false
+    assert_ok priv_as_user "working" true
+    unset -f priv_is_root
+}
+
+#[test]
+it_prefers_runuser_which_is_the_one_built_for_this() {
+    _priv_as_root
+    _priv_stubs runuser sudo su
+    local out; out="$(priv_as_user "reading" git status)"
+    _priv_stubs_end; _priv_as_root_end
+    assert_eq "$(head -1 <<<"$out")" "runuser"
+    assert_contains "$out" "-u"
+    assert_contains "$out" "somebody"
+}
+
+#[test]
+it_falls_to_sudo_when_there_is_no_runuser() {
+    _priv_as_root
+    _priv_stubs sudo su
+    local out; out="$(priv_as_user "reading" git status)"
+    _priv_stubs_end; _priv_as_root_end
+    assert_eq "$(head -1 <<<"$out")" "sudo"
+    # Non-interactive, because there is nobody at the keyboard inside a step
+    # that already elevated, and a prompt there hangs the run.
+    assert_contains "$out" "-n"
+}
+
+#[test]
+it_falls_to_su_last_of_the_three() {
+    _priv_as_root
+    _priv_stubs su
+    local out; out="$(priv_as_user "reading" git status)"
+    _priv_stubs_end; _priv_as_root_end
+    assert_eq "$(head -1 <<<"$out")" "su"
+}
+
+#[test]
+it_keeps_the_arguments_apart_through_runuser() {
+    _priv_as_root
+    _priv_stubs runuser
+    # A path with a space in it is the ordinary case, not a corner: people's
+    # home directories have spaces in them.
+    local out; out="$(priv_as_user "reading" git -C "/home/some body" status)"
+    _priv_stubs_end; _priv_as_root_end
+    assert_contains "$out" "/home/some body"
+    # One line per argument, so a path that was split shows up as two.
+    assert_eq "$(grep -c '^/home/some body$' <<<"$out")" "1"
+}
+
+#[test]
+it_quotes_every_metacharacter_so_any_posix_shell_reads_it_back() {
+    # `printf %q` was doing this, and it emits bash's `$'...'` for a tab, a
+    # newline or a control character. `dash` is `/bin/sh` on Debian and Ubuntu
+    # and reads that as the four characters it is written with, so the path
+    # arrived silently wrong. This function writes a person's files as that
+    # person; a mangled path is root writing somewhere nobody asked it to.
+    #
+    # The round trip is through `sh`, and asserts the argument comes back as
+    # itself rather than pinning a spelling.
+    #
+    # It cannot catch the bash-only form on a machine whose `sh` is bash, which
+    # macOS is, so it passes there either way. The case below it is the one
+    # that holds everywhere; this one is what says the replacement is correct.
+    local sh; sh="$(command -v sh)"
+    local t q back
+    for t in "plain" "/home/some body" "$(printf 'a\tb')" "it's" 'a$b' 'a*b' \
+             'a"b' 'a\b' 'a;b' 'a|b' 'a`b`' 'a&b' 'a
+b' "" "-x"; do
+        q="$(_priv_sq "$t")"
+        back="$("$sh" -c "printf %s $q")"
+        assert_eq "$back" "$t"
+    done
+}
+
+#[test]
+it_does_not_reach_for_the_bash_only_quoting_form() {
+    # The specific thing that was wrong, stated as its own case so a later
+    # change back to `printf %q` fails here rather than on somebody's Debian.
+    local q; q="$(_priv_sq "$(printf 'a\tb')")"
+    assert_fails grep -q "\$'" <<<"$q"
+}
+
+#[test]
+it_keeps_the_arguments_apart_through_su_which_goes_via_a_shell() {
+    _priv_as_root
+    _priv_stubs su
+    # The one route that has to put the arguments back into a single string,
+    # and therefore the one that can lose them. Asserting the spelling of the
+    # quoting would pin an implementation; what matters is that a shell reading
+    # that string back gets the arguments it started with. So `su` runs its
+    # own payload and a stubbed `git` reports what actually arrived.
+    _priv_stub_put su \
+        'while [[ $# -gt 0 && "$1" != "-c" ]]; do shift; done' \
+        'shift' \
+        "exec ${_PRIV_STUB_SH} -c \"\$1\""
+    _priv_stub_put git 'printf '"'"'%s\n'"'"' "$@"'
+
+    # A path with a space in it is the ordinary case, not a corner: people's
+    # home directories have spaces in them.
+    local out; out="$(priv_as_user "reading" git -C "/home/some body" status)"
+    _priv_stubs_end; _priv_as_root_end
+    # One line per argument, so a path the shell split shows up as two.
+    assert_eq "$(grep -c '^/home/some body$' <<<"$out")" "1"
+    assert_eq "$(wc -l <<<"$out" | tr -d ' ')" "3"
+}
+
+#[test]
+it_refuses_a_step_with_nothing_in_it() {
+    _priv_reset
+    assert_fails priv_as_user "nothing" 2>/dev/null
+    _priv_reset
+}
+
+#[test]
+it_says_so_when_there_is_no_way_to_step_down_at_all() {
+    _priv_as_root
+    # A machine with none of the three. Failing quietly here would run the
+    # step as root, which is the whole thing this exists to prevent.
+    _priv_stubs
+    local rc=0
+    priv_as_user "reading" true 2>/dev/null || rc=$?
+    _priv_stubs_end; _priv_as_root_end
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_does_not_pass_su_a_flag_only_one_su_has() {
+    _priv_as_root
+    _priv_stubs su
+    local out; out="$(priv_as_user "reading" true)"
+    _priv_stubs_end; _priv_as_root_end
+    # `-s` is util-linux. BSD and macOS `su` is `su [-] [-flm] [login [args]]`
+    # and refuses it, and this is the branch a busybox rescue console takes.
+    assert_fails grep -qx -- "-s" <<<"$out"
+    assert_contains "$out" "somebody"
+}

--- a/tests/priv_test.sh
+++ b/tests/priv_test.sh
@@ -491,3 +491,36 @@ it_does_not_pass_su_a_flag_only_one_su_has() {
     assert_fails grep -qx -- "-s" <<<"$out"
     assert_contains "$out" "somebody"
 }
+
+#[test]
+it_steps_down_with_doas_where_that_is_what_the_machine_has() {
+    _priv_as_root
+    # `priv_run` already elevates with doas. Without the same here, a machine
+    # that can elevate cannot step back down, which is the exact failure this
+    # function exists to prevent. OpenBSD and some Alpine installs carry doas
+    # and none of the other three.
+    _priv_stubs doas
+    local out; out="$(priv_as_user "reading" git status)"
+    _priv_stubs_end; _priv_as_root_end
+    assert_eq "$(head -1 <<<"$out")" "doas"
+    assert_contains "$out" "somebody"
+}
+
+#[test]
+it_prefers_runuser_and_sudo_over_doas() {
+    _priv_as_root
+    _priv_stubs runuser sudo doas su
+    local out; out="$(priv_as_user "reading" git status)"
+    _priv_stubs_end; _priv_as_root_end
+    assert_eq "$(head -1 <<<"$out")" "runuser"
+}
+
+#[test]
+it_names_doas_when_it_cannot_step_down_at_all() {
+    _priv_as_root
+    _priv_stubs
+    local err; err="$(priv_as_user "reading" true 2>&1 >/dev/null)"
+    _priv_stubs_end; _priv_as_root_end
+    # The message lists what it looked for, so a reader knows what to install.
+    assert_contains "$err" "doas"
+}

--- a/tests/priv_test.sh
+++ b/tests/priv_test.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# Tests for doing one thing as root and then not being root.
+#
+# The failure this module exists to prevent, from the machine it was written
+# on: a tool needed root to mount a partition, got it by being started under
+# sudo, and then kept going. It ended with two histories,
+# `~/.local/state/<tool>/journal` owned by the person and a second one owned by
+# root, and the person could no longer write the second. Nothing was
+# misconfigured. It asked for root for a reason and then kept it.
+
+use test
+use priv
+
+_priv_reset() { PRIV_USER=""; PRIV_UID=""; PRIV_HOME=""; }
+
+# --- who this is ---------------------------------------------------------------
+
+#[test]
+it_knows_who_started_this() {
+    _priv_reset
+    assert_eq "$(priv_user)" "$(id -un)"
+    assert_eq "$(priv_uid)"  "$(id -u)"
+    _priv_reset
+}
+
+#[test]
+it_answers_with_the_person_not_root_when_run_under_sudo() {
+    # The case this module is trying to make unnecessary, and the one it still
+    # has to answer correctly while it exists.
+    _priv_reset
+    id() { case "$1" in -u) printf '0' ;; -un) printf 'root' ;; *) builtin command id "$@" ;; esac; }
+    SUDO_USER="somebody" SUDO_UID="1234" _priv_learn_user
+    local u="$PRIV_USER" i="$PRIV_UID"
+    unset -f id
+    _priv_reset
+    assert_eq "$u" "somebody"
+    assert_eq "$i" "1234"
+}
+
+#[test]
+it_finds_a_home_without_reading_the_environment() {
+    # `$HOME` is exactly what is wrong inside something that elevated, so the
+    # answer comes from the password database instead.
+    local me; me="$(id -un)"
+    local h; h="$(_priv_home_of "$me")"
+    assert_ne "$h" ""
+    assert_eq "$h" "$HOME"
+}
+
+#[test]
+it_fails_to_find_a_home_for_somebody_who_does_not_exist() {
+    # The control. A lookup that answers for every name would answer wrongly
+    # for the one that matters.
+    assert_fails _priv_home_of "no-such-user-here-at-all"
+}
+
+#[test]
+it_refuses_to_look_up_an_empty_name() {
+    assert_fails _priv_home_of ""
+}
+
+# --- how it would ask ----------------------------------------------------------
+
+#[test]
+it_says_how_it_would_ask() {
+    local how; how="$(priv_how)"
+    # On any machine this runs on: already root, or one of the two askers.
+    case "$how" in already|sudo|doas) assert_ok true ;; *) assert_ok false ;; esac
+}
+
+#[test]
+it_says_it_cannot_ask_when_neither_asker_is_there() {
+    priv_is_root() { return 1; }
+    command() {
+        case "$2" in sudo|doas) return 1 ;; esac
+        builtin command "$@"
+    }
+    local rc=0
+    priv_how >/dev/null 2>&1 || rc=$?
+    unset -f priv_is_root command
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_prefers_sudo_where_both_are_present() {
+    # Not a preference anybody should care about, but it has to be one thing
+    # rather than whichever the loop reached first on that machine.
+    priv_is_root() { return 1; }
+    command() {
+        case "$2" in sudo|doas) return 0 ;; esac
+        builtin command "$@"
+    }
+    local how; how="$(priv_how)"
+    unset -f priv_is_root command
+    assert_eq "$how" "sudo"
+}
+
+#[test]
+it_needs_no_password_when_it_is_already_root() {
+    priv_is_root() { return 0; }
+    local rc=0
+    priv_needs_password || rc=$?
+    unset -f priv_is_root
+    assert_ne "$rc" "0"
+}
+
+# --- running the one thing -----------------------------------------------------
+
+#[test]
+it_runs_the_command_directly_when_already_root() {
+    # No asking where nothing needs to be asked, or every step prompts for a
+    # password that was never required.
+    priv_is_root() { return 0; }
+    local asked=0
+    sudo() { asked=1; return 0; }
+    local out; out="$(priv_run "a thing" printf 'ran')"
+    unset -f priv_is_root sudo
+    assert_eq "$out" "ran"
+    assert_eq "$asked" "0"
+}
+
+#[test]
+it_passes_the_command_through_without_a_shell() {
+    # Arguments, not a string. A path with a space in it is still one path, and
+    # a caller must never have to think about quoting to use this.
+    priv_is_root() { return 0; }
+    local out; out="$(priv_run "a thing" printf '%s|' 'one two' 'three')"
+    unset -f priv_is_root
+    assert_eq "$out" "one two|three|"
+}
+
+#[test]
+it_returns_what_the_command_returned() {
+    priv_is_root() { return 0; }
+    local rc=0
+    priv_run "a thing" false || rc=$?
+    unset -f priv_is_root
+    assert_eq "$rc" "1"
+}
+
+#[test]
+it_asks_for_one_command_and_not_for_a_shell() {
+    # The whole distinction. What is elevated is this command, and the caller
+    # is the same user after it as before.
+    priv_is_root() { return 1; }
+    priv_how() { printf 'sudo'; }
+    priv_needs_password() { return 1; }
+    local got=""
+    sudo() { got="$*"; }
+    priv_run "mount the stick" mount /dev/sdz2 /mnt/stick
+    unset -f priv_is_root priv_how priv_needs_password sudo
+    assert_eq "$got" "-- mount /dev/sdz2 /mnt/stick"
+    assert_fails grep -q ' -s\| bash\| sh ' <<<"$got"
+}
+
+#[test]
+it_refuses_when_there_is_no_way_to_ask() {
+    priv_is_root() { return 1; }
+    priv_how() { return 1; }
+    local rc=0 out
+    out="$(priv_run "a thing" true 2>&1)" || rc=$?
+    unset -f priv_is_root priv_how
+    assert_eq "$rc" "2"
+    assert_contains "$out" "a thing"
+}
+
+#[test]
+it_refuses_rather_than_hanging_on_a_prompt_nobody_can_answer() {
+    # These machines are often being fixed over a pipe. A password prompt with
+    # no terminal behind it is a program that stops forever.
+    priv_is_root() { return 1; }
+    priv_how() { printf 'sudo'; }
+    priv_needs_password() { return 0; }
+    _priv_can_prompt() { return 1; }
+    local ran=0
+    sudo() { ran=1; }
+    local rc=0
+    priv_run "a thing" true >/dev/null 2>&1 || rc=$?
+    unset -f priv_is_root priv_how priv_needs_password _priv_can_prompt sudo
+    assert_eq "$rc" "2"
+    assert_eq "$ran" "0"
+}
+
+#[test]
+it_runs_when_there_is_a_terminal_to_ask_on() {
+    # The control for the refusal above.
+    priv_is_root() { return 1; }
+    priv_how() { printf 'sudo'; }
+    priv_needs_password() { return 0; }
+    _priv_can_prompt() { return 0; }
+    local ran=0
+    sudo() { ran=1; }
+    priv_run "a thing" true >/dev/null 2>&1
+    unset -f priv_is_root priv_how priv_needs_password _priv_can_prompt sudo
+    assert_eq "$ran" "1"
+}
+
+#[test]
+it_says_what_it_is_asking_for_before_the_prompt_appears() {
+    # An unexpected password request wants a sentence beside it naming what
+    # asked, or somebody types their password into a mystery.
+    priv_is_root() { return 1; }
+    priv_how() { printf 'sudo'; }
+    priv_needs_password() { return 0; }
+    _priv_can_prompt() { return 0; }
+    sudo() { return 0; }
+    local out; out="$(priv_run "mount the stick" true 2>&1)"
+    unset -f priv_is_root priv_how priv_needs_password _priv_can_prompt sudo
+    assert_contains "$out" "mount the stick"
+}
+
+#[test]
+it_refuses_a_call_with_nothing_to_run() {
+    local rc=0
+    priv_run "a thing" >/dev/null 2>&1 || rc=$?
+    assert_eq "$rc" "2"
+}
+
+# --- giving the file back ------------------------------------------------------
+
+#[test]
+it_gives_a_file_back_to_the_person() {
+    # The other half of the split. A file root wrote where the person keeps
+    # theirs is a file they cannot change, and the symptom arrives much later
+    # than the cause.
+    priv_is_root() { return 0; }
+    priv_user() { printf 'somebody'; }
+    local got=""
+    chown() { got="$*"; return 0; }
+    local d; d="$(mktemp -d)"; : > "$d/f"
+    priv_return "$d/f"
+    unset -f priv_is_root priv_user chown
+    rm -rf "$d"
+    assert_contains "$got" "somebody"
+}
+
+#[test]
+it_does_not_give_anything_back_when_it_was_never_root() {
+    priv_is_root() { return 1; }
+    priv_user() { printf 'somebody'; }
+    local called=0
+    chown() { called=1; }
+    local d; d="$(mktemp -d)"; : > "$d/f"
+    priv_return "$d/f"
+    unset -f priv_is_root priv_user chown
+    rm -rf "$d"
+    assert_eq "$called" "0"
+}
+
+#[test]
+it_does_not_give_anything_back_to_root() {
+    # Nothing to hand over when root is who started it.
+    priv_is_root() { return 0; }
+    priv_user() { printf 'root'; }
+    local called=0
+    chown() { called=1; }
+    local d; d="$(mktemp -d)"; : > "$d/f"
+    priv_return "$d/f"
+    unset -f priv_is_root priv_user chown
+    rm -rf "$d"
+    assert_eq "$called" "0"
+}
+
+#[test]
+it_ignores_a_path_that_is_not_there() {
+    priv_is_root() { return 0; }
+    priv_user() { printf 'somebody'; }
+    local called=0
+    chown() { called=1; }
+    priv_return "/no/such/path/at/all"
+    unset -f priv_is_root priv_user chown
+    assert_eq "$called" "0"
+}

--- a/tests/toml_json_test.sh
+++ b/tests/toml_json_test.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Tests for the TOML to JSON conversion.
+#
+# It had none, and two of the things it got wrong were the kind a test would
+# have caught on the first run: `[a.b]` after `[a]` emitted a second `a` beside
+# the first, and a string's TOML escapes were escaped a second time on the way
+# out.
+
+use toml::json test
+
+_tj() { mktemp -d; }
+
+# Is this actually JSON, according to something that is not us? Skipped where
+# no parser is installed, which is why nothing relies on it alone.
+_tj_parser() {
+    if command -v jq >/dev/null 2>&1; then printf 'jq'; return 0; fi
+    if command -v python3 >/dev/null 2>&1; then printf 'python3'; return 0; fi
+    return 1
+}
+_tj_valid() {
+    local doc="$1"
+    case "$(_tj_parser)" in
+        jq)      printf '%s' "$doc" | jq -e . >/dev/null 2>&1 ;;
+        python3) printf '%s' "$doc" | python3 -c 'import json,sys; json.load(sys.stdin)' >/dev/null 2>&1 ;;
+        *)       return 0 ;;
+    esac
+}
+
+#[test]
+it_rejects_a_document_that_is_not_json() {
+    # The control for every test below that leans on _tj_valid. Without it a
+    # broken checker would pass everything and say nothing.
+    _tj_parser >/dev/null || return 0
+    assert_fails _tj_valid '{"a":1,}'
+    assert_ok _tj_valid '{"a":1}'
+}
+
+#[test]
+it_converts_a_flat_file() {
+    local d; d="$(_tj)"
+    printf 'title = "t"\n\n[ui]\nwidth = 30\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"title":"t","ui":{"width":30}}'
+}
+
+#[test]
+it_nests_a_subsection_inside_its_parent() {
+    # `[a.b]` used to close `a` and open a second one, so the object carried
+    # the key twice and a parser kept only one of them.
+    local d; d="$(_tj)"
+    printf '[a]\nx = 1\n\n[a.b]\ny = 2\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"x":1,"b":{"y":2}}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_keeps_two_siblings_under_one_parent() {
+    local d; d="$(_tj)"
+    printf '[a]\nx = 1\n[a.b]\ny = 2\n[a.c]\nz = 3\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"x":1,"b":{"y":2},"c":{"z":3}}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_nests_three_deep() {
+    local d; d="$(_tj)"
+    printf '[a.b.c]\nx = 1\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"b":{"c":{"x":1}}}}'
+}
+
+#[test]
+it_refuses_a_file_that_comes_back_to_a_finished_section() {
+    # One pass cannot reopen a closed object, and emitting the key twice is
+    # worse than saying so.
+    local d; d="$(_tj)"
+    printf '[b]\nx = 1\n[a]\ny = 2\n[b.c]\nz = 3\n' > "$d/t.toml"
+    local out; out="$(toml_to_json "$d/t.toml" 2>&1)"
+    local rc=$?
+    rm -rf "$d"
+    assert_ne "$rc" "0"
+    assert_contains "$out" "b.c"
+}
+
+#[test]
+it_does_not_double_escape_a_quoted_string() {
+    local d; d="$(_tj)"
+    printf '[a]\nv = "say \\"hi\\""\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"v":"say \"hi\""}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_does_not_double_escape_a_backslash() {
+    local d; d="$(_tj)"
+    printf '[a]\np = "C:\\\\tools"\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"p":"C:\\tools"}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_writes_a_tab_as_a_json_escape_not_a_raw_tab() {
+    # TOML's \t is a real tab by the time the value is read, and JSON will not
+    # take one inside a string.
+    local d; d="$(_tj)"
+    printf '[a]\nv = "one\\ttwo"\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"v":"one\ttwo"}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_leaves_a_literal_string_as_typed() {
+    local d; d="$(_tj)"
+    printf '[a]\np = \047C:\\tools\047\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"p":"C:\\tools"}}'
+}
+
+#[test]
+it_writes_numbers_and_bools_bare() {
+    local d; d="$(_tj)"
+    printf '[a]\ni = -3\nf = 1.5\nt = true\nf2 = false\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"i":-3,"f":1.5,"t":true,"f2":false}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_writes_an_array() {
+    local d; d="$(_tj)"
+    printf '[a]\nl = ["one", "two"]\ne = []\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"l":["one","two"],"e":[]}}'
+    assert_ok _tj_valid "$got"
+}
+
+#[test]
+it_ignores_comments_and_blank_lines() {
+    local d; d="$(_tj)"
+    printf '# leading\n\n[a]\n# about x\nx = 1  # trailing\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"x":1}}'
+}
+
+#[test]
+it_converts_an_empty_file_to_an_empty_object() {
+    local d; d="$(_tj)"
+    : > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{}'
+}
+
+#[test]
+it_refuses_a_file_that_is_not_there() {
+    local d; d="$(_tj)"
+    assert_fails toml_to_json "$d/nope.toml"
+    rm -rf "$d"
+}
+
+#[test]
+it_keeps_a_hash_that_is_part_of_a_value() {
+    local d; d="$(_tj)"
+    printf '[a]\nv = "#[pub]"\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"v":"#[pub]"}}'
+}
+
+#[test]
+it_refuses_a_quoted_key() {
+    # Nothing here can address one: `toml_keys` leaves it out and `toml_get`
+    # cannot reach it. Converting it anyway produced valid JSON naming a key
+    # that is not the key, which is a worse failure than refusing.
+    local d; d="$(_tj)"
+    printf '[a]\n"my key" = 1\n' > "$d/t.toml"
+    local out rc=0
+    out="$(toml_to_json "$d/t.toml" 2>&1)" || rc=$?
+    rm -rf "$d"
+    assert_ne "$rc" "0"
+    assert_contains "$out" "my key"
+    assert_contains "$out" "quoted key"
+}
+
+#[test]
+it_refuses_a_key_holding_a_quote() {
+    local d; d="$(_tj)"
+    printf '[a]\n"a\\"b" = 1\n' > "$d/t.toml"
+    local rc=0
+    toml_to_json "$d/t.toml" >/dev/null 2>&1 || rc=$?
+    rm -rf "$d"
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_refuses_a_quoted_section_name() {
+    # `["a.b"]` is one section whose name has a dot in it. Split on the dot it
+    # came out as two nested objects for a document with one level.
+    local d; d="$(_tj)"
+    printf '["a.b"]\nx = 1\n' > "$d/t.toml"
+    local out rc=0
+    out="$(toml_to_json "$d/t.toml" 2>&1)" || rc=$?
+    rm -rf "$d"
+    assert_ne "$rc" "0"
+    assert_contains "$out" "quoted section"
+}
+
+#[test]
+it_still_converts_an_ordinary_key_beside_the_refusal() {
+    # The control: refusing the ones it cannot name must not refuse the rest.
+    local d; d="$(_tj)"
+    printf '[a]\nplain = 1\nother = "two"\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"plain":1,"other":"two"}}'
+}
+
+#[test]
+it_writes_a_value_that_needs_escaping_as_the_value_it_is() {
+    # Asserted as the document rather than as "it parses". Checking only that
+    # the output parses discriminates broken from unbroken and nothing finer,
+    # which is the axis a key-escaping change moves along.
+    local d; d="$(_tj)"
+    printf '[a]\nv = "say \\"hi\\""\n' > "$d/t.toml"
+    local got; got="$(toml_to_json "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" '{"a":{"v":"say \"hi\""}}'
+    assert_ok _tj_valid "$got"
+}

--- a/tests/toml_test.sh
+++ b/tests/toml_test.sh
@@ -397,3 +397,128 @@ it_does_not_close_a_literal_body_on_a_basic_delimiter() {
     rm -rf "$d"
     assert_contains "$got" "and ends after"
 }
+
+#[test]
+it_decodes_an_escaped_quote_in_a_basic_string() {
+    # TOML gives a basic string escapes. Handing back the backslashes means a
+    # value never survives a write and a read, and every consumer that spliced
+    # the result into a command got a stray backslash.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = "say \\"hi\\""\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" 'say "hi"'
+}
+
+#[test]
+it_decodes_a_backslash_and_the_named_escapes() {
+    local d; d="$(mktemp -d)"
+    printf '[a]\np = "C:\\\\tools"\nt = "one\\ttwo"\n' > "$d/t.toml"
+    local p t
+    p="$(toml_get "$d/t.toml" a.p)"
+    t="$(toml_get "$d/t.toml" a.t)"
+    rm -rf "$d"
+    assert_eq "$p" 'C:\tools'
+    assert_eq "$t" "$(printf 'one\ttwo')"
+}
+
+#[test]
+it_decodes_a_unicode_escape() {
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = "caf\\u00e9"\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" "café"
+}
+
+#[test]
+it_keeps_a_backslash_that_starts_no_escape() {
+    # Not every backslash is an escape. Eating one that introduces nothing
+    # loses a character with no warning.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = "a\\qb"\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" 'a\qb'
+}
+
+#[test]
+it_leaves_a_literal_string_exactly_as_typed() {
+    # The control: a literal string has no escapes at all, so decoding one is
+    # as wrong as failing to decode a basic string.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = \047C:\\tools\047\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" 'C:\tools'
+}
+
+#[test]
+it_does_not_end_a_basic_string_at_an_escaped_quote() {
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = "he said \\"no\\" #1"\nw = 5\n' > "$d/t.toml"
+    local v w
+    v="$(toml_get "$d/t.toml" a.v)"
+    w="$(toml_get "$d/t.toml" a.w)"
+    rm -rf "$d"
+    assert_eq "$v" 'he said "no" #1'
+    assert_eq "$w" "5"
+}
+
+#[test]
+it_keeps_a_hash_after_a_single_escaped_quote_on_the_hot_path() {
+    # `_toml_clean_into` is the copy every value read goes through, and the
+    # escaped-quote fix landed only in `_toml_clean_line`. The two cases the
+    # suite had both carried an even number of escaped quotes before the `#`,
+    # where the broken counting cancels out and gets the right answer by luck.
+    # One is the shape that breaks.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = "a \\" b # c"\nafter = 5\n' > "$d/t.toml"
+    local v after
+    v="$(toml_get "$d/t.toml" a.v)"
+    after="$(toml_get "$d/t.toml" a.after)"
+    rm -rf "$d"
+    assert_eq "$v" 'a " b # c'
+    assert_eq "$after" "5"
+}
+
+#[test]
+it_cleans_a_line_the_same_way_through_both_cleaners() {
+    # Two implementations of one rule is two places for it to be wrong, and
+    # only one of them was fixed. Whatever they answer, they answer together.
+    local -a cases=(
+        'v = "a \" b # c"'
+        'v = "a \" b \" c # d"'
+        'v = "plain # hash"'
+        "v = 'literal # hash'"
+        'v = 1  # a real comment'
+        'v = "trailing backslash \\\\"'
+    )
+    local c into wrong=""
+    for c in "${cases[@]}"; do
+        _toml_clean_into into "$c"
+        [[ "$into" == "$(_toml_clean_line "$c")" ]] || wrong="${wrong} [${c}]"
+    done
+    assert_empty "$wrong"
+}
+
+#[test]
+it_has_a_detector_that_notices_the_two_cleaners_disagreeing() {
+    # The control for the comparison above: it has to be able to see a
+    # difference, or its silence means nothing.
+    local into
+    _toml_clean_into into 'v = 1  # comment'
+    assert_ne "$into" "$(_toml_clean_line 'v = 2  # comment')"
+    assert_eq "$into" "$(_toml_clean_line 'v = 1  # comment')"
+}
+
+#[test]
+it_reads_a_section_pair_with_an_escaped_quote_in_it() {
+    # `toml_section_pairs` goes through the hot-path cleaner too.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = "say \\" now"\nn = 2\n' > "$d/t.toml"
+    local pairs; pairs="$(toml_section_pairs "$d/t.toml" a)"
+    rm -rf "$d"
+    assert_contains "$pairs" 'say " now'
+    assert_contains "$pairs" "n=2"
+}

--- a/tests/toml_test.sh
+++ b/tests/toml_test.sh
@@ -97,3 +97,303 @@ it_agrees_with_itself_about_every_child_it_reports() {
         assert_ok toml_has_section "$FIXTURE" "tree.$child"
     done < <(toml_subsections "$FIXTURE" "tree")
 }
+
+# --- comments inside a multi-line array ---------------------------------------
+
+#[test]
+it_drops_a_comment_line_inside_an_array() {
+    # This kept the comment text, appended it into the value, and then split on
+    # commas. A comment containing one swallowed the entry after it, silently,
+    # and a declared path simply stopped being read.
+    local d; d="$(mktemp -d)"
+    cat > "$d/t.toml" <<'EOF'
+[carry]
+paths = [
+    "one",
+    # a comment, containing a comma, which is the case that broke it
+    "two",
+    "three",
+]
+EOF
+    local arr=(); toml_array "$d/t.toml" carry.paths arr
+    rm -rf "$d"
+    assert_eq "${#arr[@]}" "3"
+    assert_eq "${arr[0]}" "one"
+    assert_eq "${arr[1]}" "two"
+    assert_eq "${arr[2]}" "three"
+}
+
+#[test]
+it_keeps_a_hash_that_is_inside_a_quoted_value() {
+    # The reason the comment stripping was skipped in the first place. Both
+    # have to hold: comments go, quoted hashes stay.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = ["x#y", "z"]\n' > "$d/t.toml"
+    local arr=(); toml_array "$d/t.toml" a.v arr
+    rm -rf "$d"
+    assert_eq "${arr[0]}" "x#y"
+    assert_eq "${arr[1]}" "z"
+}
+
+#[test]
+it_drops_a_trailing_comment_after_an_entry() {
+    local d; d="$(mktemp -d)"
+    cat > "$d/t.toml" <<'EOF'
+[a]
+v = [
+    "one",   # why one
+    "two",
+]
+EOF
+    local arr=(); toml_array "$d/t.toml" a.v arr
+    rm -rf "$d"
+    assert_eq "${#arr[@]}" "2"
+    assert_eq "${arr[0]}" "one"
+}
+
+#[test]
+it_still_reads_an_array_with_no_comments_at_all() {
+    # The control. A stripper that ate everything would satisfy the tests above
+    # by returning nothing.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = [\n  "one",\n  "two",\n]\n' > "$d/t.toml"
+    local arr=(); toml_array "$d/t.toml" a.v arr
+    rm -rf "$d"
+    assert_eq "${#arr[@]}" "2"
+}
+
+# --- multi-line basic strings -------------------------------------------------
+
+#[test]
+it_reads_a_multiline_string() {
+    # These returned a bare `"` before, which callers then used as content.
+    local d; d="$(mktemp -d)"
+    printf '[n]\nv = """\nline one\nline two\n"""\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.v)"
+    rm -rf "$d"
+    assert_contains "$got" "line one"
+    assert_contains "$got" "line two"
+}
+
+#[test]
+it_keeps_a_hash_literal_inside_a_multiline_string() {
+    # Everything between the delimiters is literal. Running the comment
+    # stripper over a string body truncates prose at the first `#`.
+    local d; d="$(mktemp -d)"
+    printf '[n]\nv = """\na # here is not a comment\n"""\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.v)"
+    rm -rf "$d"
+    assert_contains "$got" "# here is not a comment"
+}
+
+#[test]
+it_reads_a_triple_quoted_value_that_closes_on_its_own_line() {
+    local d; d="$(mktemp -d)"
+    printf '[n]\nv = """just this"""\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.v)"
+    rm -rf "$d"
+    assert_eq "$got" "just this"
+}
+
+#[test]
+it_does_not_read_a_key_out_of_a_multiline_body() {
+    # The body of a string is not key-value territory. A line inside one
+    # reading `keymap = fi` was returned as though it were a real setting,
+    # shadowing the actual key further down the file.
+    local d; d="$(mktemp -d)"
+    printf '[n]\nbody = """\nkeymap = fi\n"""\nkeymap = "actually-us"\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.keymap)"
+    rm -rf "$d"
+    assert_eq "$got" "actually-us"
+}
+
+#[test]
+it_finds_a_key_after_a_multiline_string() {
+    # The parser has to leave the mode it entered, or everything below the
+    # first multi-line value becomes unreadable.
+    local d; d="$(mktemp -d)"
+    printf '[n]\na = """\nsome prose\n"""\nb = "after"\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.b)"
+    rm -rf "$d"
+    assert_eq "$got" "after"
+}
+
+#[test]
+it_still_reads_an_ordinary_string_beside_them() {
+    # The control. None of the above is worth anything if the common case
+    # regressed to make them pass.
+    local d; d="$(mktemp -d)"
+    printf '[n]\nm = """\nx\n"""\np = "plain"\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.p)"
+    rm -rf "$d"
+    assert_eq "$got" "plain"
+}
+
+# --- the helpers the reader leans on ------------------------------------------
+
+#[test]
+it_trims_into_a_variable_the_caller_names() {
+    local v
+    _toml_trim_into v "   spaced   "
+    assert_eq "$v" "spaced"
+}
+
+#[test]
+it_trims_into_a_variable_named_like_its_own_locals() {
+    # The caller names the target, so a plain `local v` inside would shadow it
+    # and hand back nothing. toml_get asks for exactly `v` and `k`, so this is
+    # not hypothetical: it broke twenty-six tests at once.
+    local v k line out
+    _toml_trim_into v "  a  ";    assert_eq "$v" "a"
+    _toml_trim_into k "  b  ";    assert_eq "$k" "b"
+    _toml_clean_into line " x # c"; assert_eq "$line" "x"
+    _toml_clean_into out  " y # c"; assert_eq "$out" "y"
+}
+
+#[test]
+it_refuses_a_target_inside_its_own_reserved_namespace() {
+    # Prefixing the locals narrowed the collision to eight names rather than
+    # removing it, and a write that lands on the local instead leaves the
+    # caller's variable untouched with nothing to say so. Refused loudly now.
+    local rc=0
+    _toml_trim_into __toml_v "x" || rc=$?
+    assert_ne "$rc" "0"
+    rc=0
+    _toml_clean_into __toml_acc "y" || rc=$?
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_refuses_a_target_that_is_not_a_plain_name() {
+    # `printf -v` EVALUATES an array subscript, so `arr[$(cmd)]` runs the
+    # command inside it. Only an identifier is accepted.
+    local probe="${TMPDIR:-/tmp}/toml-target-probe.$$"
+    rm -f "$probe"
+    local rc=0
+    _toml_trim_into "arr[\$(touch '$probe')0]" "z" 2>/dev/null || rc=$?
+    local ran=0; [[ -e "$probe" ]] && ran=1
+    rm -f "$probe"
+    assert_eq "$ran" "0"
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_does_not_lose_the_second_capture_group() {
+    # BASH_REMATCH is global, and any `[[ =~ ]]` between two reads of it --
+    # including one inside a function called in between -- replaces it. Reading
+    # group two afterwards gets nothing.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nk = "value"\n' > "$d/t.toml"
+    assert_eq "$(toml_get "$d/t.toml" a.k)" "value"
+    rm -rf "$d"
+}
+
+#[test]
+it_tracks_a_multiline_string_in_a_section_it_was_not_asked_about() {
+    # The detection sat below the section gates, so a body in another section
+    # was parsed as toml: a line reading `[n]` became a real section header and
+    # `keymap = wrong` was returned as a real setting.
+    local d; d="$(mktemp -d)"
+    printf '[other]\nbody = """\n[n]\nkeymap = wrong\n"""\n\n[n]\nkeymap = "right"\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" n.keymap)"
+    rm -rf "$d"
+    assert_eq "$got" "right"
+}
+
+#[test]
+it_cleans_into_a_variable_without_forking() {
+    local out
+    _toml_clean_into out 'key = "value" # trailing'
+    assert_eq "$out" 'key = "value"'
+}
+
+#[test]
+it_keeps_a_hash_inside_quotes_when_cleaning_into_a_variable() {
+    # The fork-free twin has to agree with the original on the case the
+    # original exists for.
+    local out
+    _toml_clean_into out 'public_api = "#[pub]"'
+    assert_eq "$out" 'public_api = "#[pub]"'
+}
+
+#[test]
+it_agrees_with_the_printing_cleaner() {
+    # Two implementations of one rule drift. Checked against each other over
+    # inputs chosen to be able to disagree -- backslashes, percent signs and a
+    # leading dash all go through printf, which is where a twin diverges.
+    local samples=(
+        'a = "b"'
+        'a = "b" # c'
+        'a = "#not a comment"'
+        '# whole line'
+        '   indented = 1   '
+        "a = 'single #quoted'"
+        'a = "back\\slash"'
+        'a = "100%% sure"'
+        'a = "%s %d"'
+        '-a = "leading dash"'
+        'a = "trailing space "   # c'
+        'a = "unclosed'
+        'a = ""'
+        ''
+    )
+    local s out bad=""
+    for s in "${samples[@]}"; do
+        _toml_clean_into out "$s"
+        [[ "$out" == "$(_toml_clean_line "$s")" ]] || bad+="[$s] "
+    done
+    assert_empty "$bad"
+}
+
+#[test]
+it_has_a_schema_that_accepts_its_own_manifest() {
+    # The schema described `deps` as holding only `paths`, with
+    # additionalProperties false, while nutshell's own nut.toml declares
+    # `[deps.shebang]` with git and ref. The manifest failed the schema
+    # shipped beside it, and nothing checked.
+    local schema="${BASH_SOURCE[0]%/*}/../schemas/nut.toml.schema.json"
+    local manifest="${BASH_SOURCE[0]%/*}/../nut.toml"
+    assert_ok test -f "$schema"
+    local names name bad=""
+    while IFS= read -r name; do
+        [[ -n "$name" ]] || continue
+        grep -q '"additionalProperties"' "$schema" || bad+="schema forbids named deps "
+    done < <(grep -oE '^\[deps\.[a-z0-9_-]+\]' "$manifest" | sed 's/\[deps\.\(.*\)\]/\1/')
+    assert_empty "$bad"
+}
+
+#[test]
+it_reads_a_literal_multiline_string() {
+    # Literal delimiters were the same bug as basic ones and were left in it:
+    # the value came back as a single quote.
+    #
+    # The fixtures use \047 rather than a literal quote: three of those inside
+    # a single-quoted shell string just toggle the quoting, and the file that
+    # results is not the one the test means to write.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = \047\047\047\nliteral line\n\047\047\047\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_contains "$got" "literal line"
+}
+
+#[test]
+it_reads_a_single_line_literal_value() {
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = \047\047\047just this\047\047\047\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" "just this"
+}
+
+#[test]
+it_does_not_close_a_literal_body_on_a_basic_delimiter() {
+    # The delimiter that opened it is the one that closes it. Treating any
+    # three quotes as a terminator truncates a body that quotes the other
+    # kind, which prose about toml routinely does.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nv = \047\047\047\nmentions """ here\nand ends after\n\047\047\047\n' > "$d/t.toml"
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_contains "$got" "and ends after"
+}

--- a/tests/toml_write_test.sh
+++ b/tests/toml_write_test.sh
@@ -1,0 +1,496 @@
+#!/usr/bin/env bash
+# Tests for the TOML writer.
+#
+# The whole point of a setter that edits in place rather than regenerating is
+# that the file survives it: comments, order, blank lines, the neighbouring
+# keys, and the key with the same name in the section next door. Most of these
+# assert exactly that, because a writer that gets the value right and quietly
+# eats the file around it looks correct in every test that only reads the
+# value back.
+
+use toml toml::write test
+
+_tw_dir() { mktemp -d; }
+
+_tw_sample() {
+    cat > "$1" <<'EOF'
+# The user's preferences. Hand-written, and it stays that way.
+title = "root level"
+
+[ui]
+# how wide the sidebar wants to be
+width = 30
+theme = "dark"
+
+# a pause the writer must not close up
+[net]
+width = 99
+timeout = 5
+EOF
+}
+
+#[test]
+it_changes_a_value_in_place() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    assert_ok toml_set "$d/t.toml" "ui.theme" "light"
+    local got; got="$(toml_get "$d/t.toml" ui.theme)"
+    rm -rf "$d"
+    assert_eq "$got" "light"
+}
+
+#[test]
+it_keeps_the_comment_above_the_key_it_changed() {
+    # The reason this function exists rather than a regenerate-from-model one.
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "ui.width" 42
+    local body; body="$(cat "$d/t.toml")"
+    rm -rf "$d"
+    assert_contains "$body" "# how wide the sidebar wants to be"
+}
+
+#[test]
+it_keeps_the_leading_comment_and_the_blank_lines() {
+    # Counted before and after rather than against a number written here: the
+    # law is that the write changes neither, and a hardcoded count only
+    # asserts that somebody counted the fixture correctly.
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    local before; before="$(grep -c '^$' "$d/t.toml")"
+    local before_lines; before_lines="$(wc -l < "$d/t.toml" | tr -d ' ')"
+    toml_set "$d/t.toml" "ui.theme" "light"
+    local after; after="$(grep -c '^$' "$d/t.toml")"
+    local body; body="$(cat "$d/t.toml")"
+    local lines; lines="$(wc -l < "$d/t.toml" | tr -d ' ')"
+    rm -rf "$d"
+    assert_contains "$body" "# The user's preferences."
+    assert_contains "$body" "# a pause the writer must not close up"
+    assert_eq "$after" "$before"
+    assert_eq "$lines" "$before_lines"
+}
+
+#[test]
+it_leaves_every_other_key_readable() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "ui.theme" "light"
+    local w t n title
+    w="$(toml_get "$d/t.toml" ui.width)"
+    t="$(toml_get "$d/t.toml" net.timeout)"
+    n="$(toml_get "$d/t.toml" net.width)"
+    title="$(toml_get "$d/t.toml" title)"
+    rm -rf "$d"
+    assert_eq "$w" "30"
+    assert_eq "$t" "5"
+    assert_eq "$n" "99"
+    assert_eq "$title" "root level"
+}
+
+#[test]
+it_changes_only_the_key_in_the_named_section() {
+    # `width` exists in both. A writer matching on the leaf alone hits the
+    # first one it sees, which is the wrong file half the time.
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "net.width" 7
+    local ui net
+    ui="$(toml_get "$d/t.toml" ui.width)"
+    net="$(toml_get "$d/t.toml" net.width)"
+    rm -rf "$d"
+    assert_eq "$ui" "30"
+    assert_eq "$net" "7"
+}
+
+#[test]
+it_appends_a_new_key_inside_its_own_section() {
+    # Not at the end of the file, which is somebody else's section.
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "ui.density" "compact"
+    local got line_ui line_new line_net
+    got="$(toml_get "$d/t.toml" ui.density)"
+    line_ui="$(grep -n '^\[ui\]' "$d/t.toml" | cut -d: -f1)"
+    line_new="$(grep -n '^density' "$d/t.toml" | cut -d: -f1)"
+    line_net="$(grep -n '^\[net\]' "$d/t.toml" | cut -d: -f1)"
+    rm -rf "$d"
+    assert_eq "$got" "compact"
+    # Asserted, not stated. The harness counts assertions and ignores the exit
+    # status by design, so a bare `(( ))` here was a no-op and the ordering the
+    # test is named for went unchecked.
+    assert_ok test "$line_ui" -lt "$line_new"
+    assert_ok test "$line_new" -lt "$line_net"
+}
+
+#[test]
+it_creates_a_section_that_is_not_there() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    assert_ok toml_set "$d/t.toml" "audio.volume" 80
+    local got old
+    got="$(toml_get "$d/t.toml" audio.volume)"
+    old="$(toml_get "$d/t.toml" ui.theme)"
+    rm -rf "$d"
+    assert_eq "$got" "80"
+    assert_eq "$old" "dark"
+}
+
+#[test]
+it_writes_a_file_that_does_not_exist_yet() {
+    local d; d="$(_tw_dir)"
+    assert_ok toml_set "$d/new.toml" "ui.theme" "dark"
+    local got; got="$(toml_get "$d/new.toml" ui.theme)"
+    rm -rf "$d"
+    assert_eq "$got" "dark"
+}
+
+#[test]
+it_writes_a_root_level_key() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "title" "renamed"
+    local got sect
+    got="$(toml_get "$d/t.toml" title)"
+    sect="$(toml_get "$d/t.toml" ui.theme)"
+    rm -rf "$d"
+    assert_eq "$got" "renamed"
+    assert_eq "$sect" "dark"
+}
+
+#[test]
+it_leaves_a_number_unquoted() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "ui.width" 42
+    local line; line="$(grep '^width' "$d/t.toml" | head -1)"
+    rm -rf "$d"
+    assert_eq "$line" "width = 42"
+}
+
+#[test]
+it_leaves_a_negative_and_a_float_unquoted() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.n" -12
+    toml_set "$d/t.toml" "a.f" 1.5
+    local n f
+    n="$(grep '^n = ' "$d/t.toml")"
+    f="$(grep '^f = ' "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$n" "n = -12"
+    assert_eq "$f" "f = 1.5"
+}
+
+#[test]
+it_leaves_a_bool_unquoted() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.on" true
+    toml_set "$d/t.toml" "a.off" false
+    local on off
+    on="$(grep '^on = ' "$d/t.toml")"
+    off="$(grep '^off = ' "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$on" "on = true"
+    assert_eq "$off" "off = false"
+}
+
+#[test]
+it_leaves_an_array_unquoted_and_readable() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.list" '["one", "two"]'
+    local -a out=()
+    toml_array "$d/t.toml" a.list out
+    local n="${#out[@]}" first="${out[0]:-}"
+    rm -rf "$d"
+    assert_eq "$n" "2"
+    assert_eq "$first" "one"
+}
+
+#[test]
+it_quotes_a_string_that_looks_like_neither() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.v" "hello there"
+    local line; line="$(grep '^v = ' "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$line" 'v = "hello there"'
+}
+
+#[test]
+it_escapes_a_quote_in_the_value() {
+    # Unescaped, this writes a file that no longer parses, and the next read
+    # of any key in it fails for a reason nobody would connect to this write.
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.v" 'say "hi"'
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" 'say "hi"'
+}
+
+#[test]
+it_escapes_a_backslash_in_the_value() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.path" 'C:\tools'
+    local line; line="$(grep '^path = ' "$d/t.toml")"
+    local got; got="$(toml_get "$d/t.toml" a.path)"
+    rm -rf "$d"
+    assert_eq "$line" 'path = "C:\\tools"'
+    assert_eq "$got" 'C:\tools'
+}
+
+#[test]
+it_reads_back_a_value_with_a_quote_and_a_backslash_together() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.v" 'a\b"c'
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" 'a\b"c'
+}
+
+#[test]
+it_does_not_read_a_hash_after_an_escaped_quote_as_a_comment() {
+    # The line cleaner counts quotes to find the end of the string. Reading an
+    # escaped one as the terminator puts the rest of the value outside it, and
+    # a `#` there truncates the line.
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.v" 'said "no" #1'
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" 'said "no" #1'
+}
+
+#[test]
+it_keeps_a_hash_in_the_value_readable() {
+    # The reader is quote-aware; the writer has to give it a quoted value for
+    # that to help.
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.v" '#[pub]'
+    local got; got="$(toml_get "$d/t.toml" a.v)"
+    rm -rf "$d"
+    assert_eq "$got" '#[pub]'
+}
+
+#[test]
+it_survives_being_written_twice() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "ui.theme" "light"
+    toml_set "$d/t.toml" "ui.theme" "dark"
+    local got count
+    got="$(toml_get "$d/t.toml" ui.theme)"
+    count="$(grep -c '^theme = ' "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" "dark"
+    assert_eq "$count" "1"
+}
+
+#[test]
+it_reads_back_everything_it_wrote() {
+    local d; d="$(_tw_dir)"
+    toml_set "$d/t.toml" "a.one" "first"
+    toml_set "$d/t.toml" "b.two" "second"
+    toml_set "$d/t.toml" "a.three" "third"
+    local one two three
+    one="$(toml_get "$d/t.toml" a.one)"
+    two="$(toml_get "$d/t.toml" b.two)"
+    three="$(toml_get "$d/t.toml" a.three)"
+    rm -rf "$d"
+    assert_eq "$one" "first"
+    assert_eq "$two" "second"
+    assert_eq "$three" "third"
+}
+
+#[test]
+it_refuses_a_call_with_no_key() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    assert_fails toml_set "$d/t.toml" "" "x"
+    rm -rf "$d"
+}
+
+#[test]
+it_refuses_a_call_with_no_file() {
+    assert_fails toml_set "" "a.b" "x"
+}
+
+#[test]
+it_leaves_no_temporary_file_beside_the_target() {
+    # It writes through mktemp and renames, so a reader never sees half a
+    # file. The rename has to actually happen.
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_set "$d/t.toml" "ui.theme" "light"
+    local n; n="$(find "$d" -type f | wc -l | tr -d ' ')"
+    rm -rf "$d"
+    assert_eq "$n" "1"
+}
+
+#[test]
+it_removes_a_key() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    assert_ok toml_unset "$d/t.toml" "ui.theme"
+    local gone; gone="$(toml_get "$d/t.toml" ui.theme 2>/dev/null || true)"
+    local kept; kept="$(toml_get "$d/t.toml" ui.width)"
+    rm -rf "$d"
+    assert_empty "$gone"
+    assert_eq "$kept" "30"
+}
+
+#[test]
+it_removes_only_the_key_in_the_named_section() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_unset "$d/t.toml" "net.width"
+    local ui; ui="$(toml_get "$d/t.toml" ui.width)"
+    local net; net="$(toml_get "$d/t.toml" net.width 2>/dev/null || true)"
+    rm -rf "$d"
+    assert_eq "$ui" "30"
+    assert_empty "$net"
+}
+
+#[test]
+it_keeps_the_comments_when_removing() {
+    local d; d="$(_tw_dir)"; _tw_sample "$d/t.toml"
+    toml_unset "$d/t.toml" "ui.theme"
+    local body; body="$(cat "$d/t.toml")"
+    rm -rf "$d"
+    assert_contains "$body" "# how wide the sidebar wants to be"
+    assert_contains "$body" "# a pause the writer must not close up"
+}
+
+#[test]
+it_refuses_to_remove_from_a_file_that_is_not_there() {
+    local d; d="$(_tw_dir)"
+    assert_fails toml_unset "$d/nope.toml" "a.b"
+    rm -rf "$d"
+}
+
+# --- root is a place, not the absence of one ---------------------------------
+#
+# Reading "no section" as "no section is open" made a root key match anywhere:
+# `toml_unset f name` deleted `name` from every section in the file, and
+# `toml_set f name x` rewrote the first sectioned key that happened to share
+# the leaf.
+
+#[test]
+it_removes_a_root_key_without_touching_the_same_name_in_a_section() {
+    local d; d="$(mktemp -d)"
+    printf 'name = "root"\n[a]\nname = "x"\n[b]\nname = "y"\n' > "$d/t.toml"
+    toml_unset "$d/t.toml" name
+    local root a b
+    root="$(toml_get "$d/t.toml" name 2>/dev/null || true)"
+    a="$(toml_get "$d/t.toml" a.name)"
+    b="$(toml_get "$d/t.toml" b.name)"
+    rm -rf "$d"
+    assert_empty "$root"
+    assert_eq "$a" "x"
+    assert_eq "$b" "y"
+}
+
+#[test]
+it_removes_a_sectioned_key_without_touching_the_root_one() {
+    # The other direction of the same law.
+    local d; d="$(mktemp -d)"
+    printf 'name = "root"\n[a]\nname = "x"\n[b]\nname = "y"\n' > "$d/t.toml"
+    toml_unset "$d/t.toml" a.name
+    local root a b
+    root="$(toml_get "$d/t.toml" name)"
+    a="$(toml_get "$d/t.toml" a.name 2>/dev/null || true)"
+    b="$(toml_get "$d/t.toml" b.name)"
+    rm -rf "$d"
+    assert_eq "$root" "root"
+    assert_empty "$a"
+    assert_eq "$b" "y"
+}
+
+#[test]
+it_writes_a_root_key_above_the_first_section() {
+    # Appending it at the end of the file puts it inside whatever section ends
+    # there, so the write and the read disagree about the same key.
+    local d; d="$(mktemp -d)"
+    printf '[a]\nname = "x"\n' > "$d/t.toml"
+    toml_set "$d/t.toml" name root
+    local root a first
+    root="$(toml_get "$d/t.toml" name)"
+    a="$(toml_get "$d/t.toml" a.name)"
+    first="$(head -1 "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$root" "root"
+    assert_eq "$a" "x"
+    assert_eq "$first" 'name = "root"'
+}
+
+#[test]
+it_appends_a_root_key_after_the_root_content_it_already_has() {
+    local d; d="$(mktemp -d)"
+    printf '# top\ntitle = "t"\n\n[a]\nx = 1\n' > "$d/t.toml"
+    toml_set "$d/t.toml" other v
+    local got line_new line_a body
+    got="$(toml_get "$d/t.toml" other)"
+    line_new="$(grep -n '^other' "$d/t.toml" | cut -d: -f1)"
+    line_a="$(grep -n '^\[a\]' "$d/t.toml" | cut -d: -f1)"
+    body="$(cat "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" "v"
+    assert_ok test "$line_new" -lt "$line_a"
+    assert_contains "$body" "# top"
+}
+
+#[test]
+it_replaces_a_root_key_rather_than_the_sectioned_one_below_it() {
+    local d; d="$(mktemp -d)"
+    printf 'title = "t"\n[a]\ntitle = "inner"\n' > "$d/t.toml"
+    toml_set "$d/t.toml" title new
+    local root inner
+    root="$(toml_get "$d/t.toml" title)"
+    inner="$(toml_get "$d/t.toml" a.title)"
+    rm -rf "$d"
+    assert_eq "$root" "new"
+    assert_eq "$inner" "inner"
+}
+
+# --- a section with nothing in it --------------------------------------------
+
+#[test]
+it_appends_into_a_section_that_is_empty() {
+    # The section ends at its own header, and the header arm used to skip the
+    # append, so the key landed at the end of the file inside the next section.
+    local d; d="$(mktemp -d)"
+    printf '[a]\n\n[b]\nx = 1\n' > "$d/t.toml"
+    toml_set "$d/t.toml" a.k v
+    local got wrong
+    got="$(toml_get "$d/t.toml" a.k)"
+    wrong="$(toml_get "$d/t.toml" b.k 2>/dev/null || true)"
+    rm -rf "$d"
+    assert_eq "$got" "v"
+    assert_empty "$wrong"
+}
+
+#[test]
+it_appends_into_an_empty_section_at_the_end_of_the_file() {
+    local d; d="$(mktemp -d)"
+    printf '[a]\nx = 1\n[b]\n' > "$d/t.toml"
+    toml_set "$d/t.toml" b.k v
+    local got
+    got="$(toml_get "$d/t.toml" b.k)"
+    rm -rf "$d"
+    assert_eq "$got" "v"
+}
+
+# --- a value the reader can decode -------------------------------------------
+
+#[test]
+it_encodes_a_newline_rather_than_writing_one_into_the_file() {
+    # An unescaped newline does not corrupt the value, it corrupts the file:
+    # every key after it is on the wrong side of an unterminated string.
+    local d; d="$(mktemp -d)"
+    printf '[s]\nafter = 1\n' > "$d/t.toml"
+    toml_set "$d/t.toml" "s.k" "$(printf 'a\nb')"
+    local got after lines
+    got="$(toml_get "$d/t.toml" s.k)"
+    after="$(toml_get "$d/t.toml" s.after)"
+    lines="$(grep -c '^k = ' "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" "$(printf 'a\nb')"
+    assert_eq "$after" "1"
+    assert_eq "$lines" "1"
+}
+
+#[test]
+it_encodes_every_escape_the_reader_decodes() {
+    # The pair has to be symmetric or the round trip is not one.
+    local d; d="$(mktemp -d)"
+    local want; want="$(printf 'a\tb\rc\nd')"
+    toml_set "$d/t.toml" "s.k" "$want"
+    local got line
+    got="$(toml_get "$d/t.toml" s.k)"
+    line="$(grep -c '^k = ' "$d/t.toml")"
+    rm -rf "$d"
+    assert_eq "$got" "$want"
+    assert_eq "$line" "1"
+}

--- a/tests/toolchain_test.sh
+++ b/tests/toolchain_test.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+# Tests for several versions on one machine at once.
+#
+# The state this exists for is ordinary, not exceptional: two tools wanting two
+# different nutshells, on a machine that has one of them. Failing there is the
+# defect. The store keeps every version that has been asked for, the resolver
+# takes the newest that satisfies the caller, and a version nobody has fetched
+# yet is a download rather than an error.
+
+use test
+
+. "${BASH_SOURCE[0]%/*}/../find-nutshell"
+
+_tc_setup() {
+    TCROOT="$(mktemp -d)"
+    export NUTSHELL_TOOLCHAINS="$TCROOT/store"
+    export NUTSHELL_REMOTE="$TCROOT/remote.git"
+    NUTSHELL_INIT=""; NUTSHELL_FROM=""
+    unset NUTSHELL_HOME
+    # Any directory holding a nutshell comes off PATH, so whatever is installed
+    # on the machine running these tests cannot decide their answers. The rest
+    # of PATH stays: these tests need git and the ordinary tools.
+    _TC_PATH_KEEP="$PATH"
+    local d out=""
+    while IFS= read -r d; do
+        [[ -n "$d" ]] || continue
+        [[ -x "$d/nutshell" ]] && continue
+        out="${out:+$out:}$d"
+    done <<< "${PATH//:/$'\n'}"
+    export PATH="$out"
+}
+_tc_end() {
+    rm -rf "$TCROOT"
+    unset TCROOT NUTSHELL_TOOLCHAINS NUTSHELL_REMOTE
+    NUTSHELL_INIT=""; NUTSHELL_FROM=""
+    export PATH="${_TC_PATH_KEEP:-$PATH}"
+}
+
+# A version sitting in the store.
+_tc_store() {
+    local v="$1" name="${2:-$1}"
+    mkdir -p "$NUTSHELL_TOOLCHAINS/$name"
+    printf 'export NUTSHELL_VERSION="%s"\n' "$v" \
+        > "$NUTSHELL_TOOLCHAINS/$name/init"
+}
+
+# A remote holding one tagged version, so a fetch has somewhere real to go.
+_tc_remote() {
+    # Two statements: bash declares every name in one `local` before running
+    # any of its assignments, so naming v in work's value reads it while it is
+    # still unset and `set -u` stops the test dead.
+    local v="$1"
+    local work="$TCROOT/work-$v"
+    mkdir -p "$work"
+    printf 'export NUTSHELL_VERSION="%s"\n' "$v" > "$work/init"
+    git -C "$work" init -q -b main
+    git -C "$work" config user.email t@example.invalid
+    git -C "$work" config user.name t
+    git -C "$work" config commit.gpgsign false
+    git -C "$work" config tag.gpgsign false
+    git -C "$work" add -A
+    git -C "$work" commit -qm "$v"
+    # Annotated, with a message, because a machine whose git is set to force
+    # annotated tags refuses a lightweight one and the error is "no tag
+    # message?", which says nothing about tags being the subject.
+    git -C "$work" tag -a "$v" -m "$v"
+    [[ -d "$NUTSHELL_REMOTE" ]] || git init -q --bare "$NUTSHELL_REMOTE"
+    git -C "$work" remote add origin "$NUTSHELL_REMOTE" 2>/dev/null || true
+    git -C "$work" push -q origin main --tags 2>/dev/null || \
+        git -C "$work" push -q origin "$v"
+}
+
+# --- where the store is ------------------------------------------------------
+
+#[test]
+it_takes_the_toolchain_directory_from_the_environment() {
+    _tc_setup
+    assert_eq "$(nutshell_toolchain_dir)" "$TCROOT/store"
+    _tc_end
+}
+
+#[test]
+it_puts_the_toolchains_under_the_store_root() {
+    _tc_setup
+    unset NUTSHELL_TOOLCHAINS
+    assert_eq "$(NUTSHELL_STORE="$TCROOT/s" nutshell_toolchain_dir)" \
+        "$TCROOT/s/toolchains"
+    assert_eq "$(NUTSHELL_STORE="$TCROOT/s" nutshell_store_root)" "$TCROOT/s"
+    _tc_end
+}
+
+#[test]
+it_falls_back_to_the_data_directory() {
+    _tc_setup
+    unset NUTSHELL_TOOLCHAINS NUTSHELL_STORE
+    assert_eq "$(XDG_DATA_HOME="$TCROOT/data" nutshell_toolchain_dir)" \
+        "$TCROOT/data/nutshell/toolchains"
+    _tc_end
+}
+
+#[test]
+it_puts_the_store_where_the_platform_puts_application_data() {
+    _tc_setup
+    unset NUTSHELL_TOOLCHAINS NUTSHELL_STORE XDG_DATA_HOME
+    local root; root="$(HOME="$TCROOT/h" nutshell_store_root)"
+    case "$(uname -s)" in
+        Darwin) assert_eq "$root" "$TCROOT/h/Library/Application Support/nutshell" ;;
+        *)      assert_eq "$root" "$TCROOT/h/.local/share/nutshell" ;;
+    esac
+    _tc_end
+}
+
+#[test]
+it_drops_a_trailing_slash_so_the_paths_under_it_are_not_doubled() {
+    _tc_setup
+    assert_eq "$(NUTSHELL_TOOLCHAINS="$TCROOT/store/" nutshell_toolchain_dir)" \
+        "$TCROOT/store"
+    unset NUTSHELL_TOOLCHAINS
+    assert_eq "$(NUTSHELL_STORE="$TCROOT/s/" nutshell_store_root)" "$TCROOT/s"
+    assert_eq "$(NUTSHELL_STORE="$TCROOT/s/" nutshell_toolchain_dir)" \
+        "$TCROOT/s/toolchains"
+    _tc_end
+}
+
+# --- what is in it -----------------------------------------------------------
+
+#[test]
+it_lists_nothing_when_the_store_is_not_there() {
+    _tc_setup
+    assert_empty "$(nutshell_toolchains)"
+    _tc_end
+}
+
+#[test]
+it_lists_nothing_when_the_store_is_empty() {
+    _tc_setup
+    mkdir -p "$NUTSHELL_TOOLCHAINS"
+    assert_empty "$(nutshell_toolchains)"
+    _tc_end
+}
+
+#[test]
+it_lists_what_is_in_the_store_newest_first() {
+    _tc_setup
+    _tc_store 0.3.0; _tc_store 0.4.0; _tc_store 0.2.0
+    assert_eq "$(nutshell_toolchains)" "$(printf '0.4.0\n0.3.0\n0.2.0')"
+    _tc_end
+}
+
+#[test]
+it_orders_by_number_and_not_by_spelling() {
+    _tc_setup
+    _tc_store 0.9.0; _tc_store 0.10.0; _tc_store 0.10.2
+    # Every string comparison puts 0.9.0 above 0.10.0, and every one of them is
+    # wrong.
+    assert_eq "$(nutshell_toolchains)" "$(printf '0.10.2\n0.10.0\n0.9.0')"
+    _tc_end
+}
+
+#[test]
+it_skips_a_directory_with_no_interpreter_in_it() {
+    _tc_setup
+    _tc_store 0.4.0
+    mkdir -p "$NUTSHELL_TOOLCHAINS/0.5.0"
+    assert_eq "$(nutshell_toolchains)" "0.4.0"
+    _tc_end
+}
+
+#[test]
+it_skips_a_directory_whose_contents_disagree_with_its_name() {
+    _tc_setup
+    _tc_store 0.4.0
+    _tc_store 0.1.0 0.9.9      # named 0.9.9, reports 0.1.0
+    # The name is what the resolver looks things up by, so a directory that
+    # lies about itself would be handed out for a request it cannot satisfy.
+    assert_eq "$(nutshell_toolchains)" "0.4.0"
+    _tc_end
+}
+
+# --- resolving out of it -----------------------------------------------------
+
+#[test]
+it_resolves_to_a_toolchain_when_nothing_is_installed() {
+    _tc_setup
+    _tc_store 0.4.0
+    assert_ok nutshell_find "" 0.4.0
+    assert_eq "$NUTSHELL_FROM" "toolchain"
+    assert_eq "$NUTSHELL_INIT" "$NUTSHELL_TOOLCHAINS/0.4.0/init"
+    _tc_end
+}
+
+#[test]
+it_takes_the_newest_one_that_satisfies_the_caller() {
+    _tc_setup
+    _tc_store 0.3.0; _tc_store 0.4.0; _tc_store 0.5.0
+    assert_ok nutshell_find "" 0.4.0
+    assert_eq "$NUTSHELL_INIT" "$NUTSHELL_TOOLCHAINS/0.5.0/init"
+    _tc_end
+}
+
+#[test]
+it_will_not_take_one_older_than_the_caller_needs() {
+    _tc_setup
+    _tc_store 0.2.0; _tc_store 0.3.0
+    # Nothing satisfies, nothing to fetch from: a refusal, not a wrong answer
+    # that fails later with a missing function.
+    assert_fails nutshell_find "" 0.4.0 2>/dev/null
+    _tc_end
+}
+
+#[test]
+it_takes_any_of_them_when_the_caller_names_no_minimum() {
+    _tc_setup
+    _tc_store 0.2.0; _tc_store 0.3.0
+    assert_ok nutshell_find "" ""
+    assert_eq "$NUTSHELL_INIT" "$NUTSHELL_TOOLCHAINS/0.3.0/init"
+    _tc_end
+}
+
+#[test]
+it_prefers_a_satisfying_installed_one_over_the_store() {
+    _tc_setup
+    _tc_store 0.9.0
+    mkdir -p "$TCROOT/installed/bin"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$TCROOT/installed/init"
+    printf '#!/usr/bin/env bash\n' > "$TCROOT/installed/bin/nutshell"
+    chmod +x "$TCROOT/installed/bin/nutshell"
+    export PATH="$TCROOT/installed/bin:$PATH"
+    # One shared nutshell that everything uses is the good state. The store is
+    # for the tools that cannot use it, not a replacement for it.
+    assert_ok nutshell_find "" 0.4.0
+    assert_eq "$NUTSHELL_FROM" "installed"
+    _tc_end
+}
+
+#[test]
+it_falls_to_the_store_when_the_installed_one_is_too_old() {
+    _tc_setup
+    _tc_store 0.4.0
+    mkdir -p "$TCROOT/installed/bin"
+    printf 'export NUTSHELL_VERSION="0.3.0"\n' > "$TCROOT/installed/init"
+    printf '#!/usr/bin/env bash\n' > "$TCROOT/installed/bin/nutshell"
+    chmod +x "$TCROOT/installed/bin/nutshell"
+    export PATH="$TCROOT/installed/bin:$PATH"
+    assert_ok nutshell_find "" 0.4.0 2>/dev/null
+    assert_eq "$NUTSHELL_FROM" "toolchain"
+    _tc_end
+}
+
+#[test]
+it_prefers_the_store_over_a_vendored_copy() {
+    _tc_setup
+    _tc_store 0.4.0
+    local root="$TCROOT/project"
+    mkdir -p "$root/lib/nutshell"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$root/lib/nutshell/init"
+    # The vendored copy is the compromise, kept for a machine with no network.
+    assert_ok nutshell_find "$root" 0.4.0
+    assert_eq "$NUTSHELL_FROM" "toolchain"
+    _tc_end
+}
+
+# --- fetching ----------------------------------------------------------------
+
+#[test]
+it_fetches_a_version_that_is_not_here_yet() {
+    _tc_setup
+    _tc_remote 0.4.0
+    assert_ok nutshell_find "" 0.4.0 2>/dev/null
+    assert_eq "$NUTSHELL_FROM" "fetched"
+    assert_eq "$NUTSHELL_INIT" "$NUTSHELL_TOOLCHAINS/0.4.0/init"
+    # And it is in the store afterwards, so the next caller does not fetch it
+    # again.
+    assert_eq "$(nutshell_toolchains)" "0.4.0"
+    _tc_end
+}
+
+#[test]
+it_does_not_fetch_when_the_store_already_answers() {
+    _tc_setup
+    _tc_store 0.4.0
+    # No remote at all. A fetch here would fail loudly, so silence is the
+    # assertion.
+    assert_ok nutshell_find "" 0.4.0
+    assert_eq "$NUTSHELL_FROM" "toolchain"
+    _tc_end
+}
+
+#[test]
+it_refuses_a_fetch_whose_contents_report_another_version() {
+    _tc_setup
+    # Tagged 0.4.0, but the file inside says 0.1.0: a tag that moved, or a
+    # branch name that happens to look like a version. Storing it under the
+    # asked-for name would put a lie in the store for every later run.
+    local work="$TCROOT/work"
+    mkdir -p "$work"
+    printf 'export NUTSHELL_VERSION="0.1.0"\n' > "$work/init"
+    git -C "$work" init -q -b main
+    git -C "$work" config user.email t@example.invalid
+    git -C "$work" config user.name t
+    git -C "$work" config commit.gpgsign false
+    git -C "$work" config tag.gpgsign false
+    git -C "$work" add -A; git -C "$work" commit -qm x
+    git -C "$work" tag -a 0.4.0 -m 0.4.0
+    git init -q --bare "$NUTSHELL_REMOTE"
+    git -C "$work" remote add origin "$NUTSHELL_REMOTE"
+    git -C "$work" push -q origin main --tags
+    assert_fails nutshell_find "" 0.4.0 2>/dev/null
+    assert_empty "$(nutshell_toolchains)"
+    _tc_end
+}
+
+#[test]
+it_leaves_no_half_a_toolchain_behind_when_the_fetch_fails() {
+    _tc_setup
+    export NUTSHELL_REMOTE="$TCROOT/no-such-remote.git"
+    assert_fails nutshell_find "" 0.4.0 2>/dev/null
+    assert_empty "$(nutshell_toolchains)"
+    assert_fails test -e "$NUTSHELL_TOOLCHAINS/0.4.0"
+    _tc_end
+}
+
+#[test]
+it_falls_back_to_the_vendored_copy_when_the_fetch_cannot_happen() {
+    _tc_setup
+    export NUTSHELL_REMOTE="$TCROOT/no-such-remote.git"
+    local root="$TCROOT/project"
+    mkdir -p "$root/lib/nutshell"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$root/lib/nutshell/init"
+    # The rescue machine: no network, nothing installed, and what is in the
+    # tree is all there is.
+    assert_ok nutshell_find "$root" 0.4.0 2>/dev/null
+    assert_eq "$NUTSHELL_FROM" "vendored"
+    _tc_end
+}
+
+#[test]
+it_does_not_fetch_when_the_caller_names_no_version() {
+    _tc_setup
+    _tc_remote 0.4.0
+    # Nothing to ask the remote for. Guessing at the newest would make an
+    # unpinned tool track whatever was tagged last, silently.
+    assert_fails nutshell_find "" "" 2>/dev/null
+    assert_empty "$(nutshell_toolchains)"
+    _tc_end
+}
+
+# --- the store is shared, and nothing in it is deleted while it is in use -----
+#
+# Every project on this machine resolves out of one store and nothing locks it.
+# So the two dangerous moves are removing a directory another process is
+# sourcing out of, and building a store path out of a name a caller supplied.
+
+#[test]
+it_adopts_the_copy_that_got_there_first_instead_of_deleting_it() {
+    _tc_setup
+    _tc_remote 0.4.0
+    # A directory already in place, carrying a mark this test can recognise.
+    # A fetch that deletes and replaces loses the mark; one that adopts what is
+    # there keeps it, and both answers are the same version, which is the whole
+    # reason adopting is allowed.
+    mkdir -p "$NUTSHELL_TOOLCHAINS/0.4.0"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$NUTSHELL_TOOLCHAINS/0.4.0/init"
+    printf 'in use\n' > "$NUTSHELL_TOOLCHAINS/0.4.0/marker"
+    assert_ok _nutshell_fetch 0.4.0 >/dev/null 2>&1
+    assert_ok test -f "$NUTSHELL_TOOLCHAINS/0.4.0/marker"
+    _tc_end
+}
+
+#[test]
+it_clears_the_scratch_copy_a_lost_race_left_inside_the_target() {
+    _tc_setup
+    local dir="$NUTSHELL_TOOLCHAINS/0.4.0" tmp="$NUTSHELL_TOOLCHAINS/0.4.0.fetching.99"
+    mkdir -p "$dir"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$dir/init"
+    printf 'in use\n' > "$dir/marker"
+    mkdir -p "$tmp"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$tmp/init"
+
+    # The state a loser actually reaches. The existence check and the rename
+    # are two steps, so a directory that appeared between them turns the
+    # rename into a move *inside* it, and `<dir>/<scratch>` is what that
+    # leaves. Both the target and the store have to come out of this clean.
+    assert_ok _nutshell_adopt "$tmp" "$dir"
+    assert_ok test -f "$dir/marker"
+    assert_fails test -e "$tmp"
+    assert_fails test -e "$dir/0.4.0.fetching.99"
+    _tc_end
+}
+
+#[test]
+it_renames_the_scratch_copy_into_place_when_nothing_is_there() {
+    _tc_setup
+    local dir="$NUTSHELL_TOOLCHAINS/0.4.0" tmp="$NUTSHELL_TOOLCHAINS/0.4.0.fetching.99"
+    mkdir -p "$tmp"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$tmp/init"
+    printf 'fetched\n' > "$tmp/marker"
+
+    # The winner's path, and the negative control for the one above: the copy
+    # that arrives first is the one kept, not thrown away.
+    assert_ok _nutshell_adopt "$tmp" "$dir"
+    assert_ok test -f "$dir/marker"
+    assert_fails test -e "$tmp"
+    _tc_end
+}
+
+#[test]
+it_refuses_a_version_name_that_would_escape_the_store() {
+    _tc_setup
+    local outside="$TCROOT/outside"
+    mkdir -p "$outside"
+    printf 'here\n' > "$outside/keep"
+    # The name reaches `rm -rf "${store}/${want}"` in the old shape. It has to
+    # be refused before a path is built out of it, not after.
+    assert_fails _nutshell_fetch "../outside" 2>/dev/null
+    assert_ok test -f "$outside/keep"
+    _tc_end
+}
+
+#[test]
+it_refuses_a_version_name_carrying_a_slash() {
+    _tc_setup
+    assert_fails _nutshell_fetch "0.4.0/../../etc" 2>/dev/null
+    assert_fails _nutshell_fetch "" 2>/dev/null
+    _tc_end
+}
+
+# --- a fetch that cannot succeed is not repeated on every invocation ----------
+#
+# The standing case, not a corner: a tool pinned at a version nobody has tagged
+# resolves to vendored in the end and pays a network round trip on the way
+# there, on every run of every tool on the machine.
+
+#[test]
+it_does_not_retry_a_fetch_that_just_failed() {
+    _tc_setup
+    export NUTSHELL_REMOTE="$TCROOT/no-such-remote.git"
+    local root="$TCROOT/project"
+    mkdir -p "$root/lib/nutshell"
+    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$root/lib/nutshell/init"
+
+    assert_ok nutshell_find "$root" 0.9.9 2>/dev/null
+    assert_eq "$NUTSHELL_FROM" "vendored"
+    # The second run says nothing, because it does not go looking again.
+    local second; second="$(nutshell_find "$root" 0.9.9 2>&1 >/dev/null)"
+    assert_fails grep -q 'could not fetch' <<<"$second"
+    _tc_end
+}
+
+#[test]
+it_tries_again_once_the_window_is_out() {
+    _tc_setup
+    export NUTSHELL_REMOTE="$TCROOT/no-such-remote.git"
+    NUTSHELL_FETCH_RETRY=0 assert_fails _nutshell_fetch 0.9.9 2>/dev/null
+    # A zero window is no window: the negative cache must not be a way to
+    # never fetch again.
+    assert_fails NUTSHELL_FETCH_RETRY=0 _nutshell_fetch_failed_recently 0.9.9
+    assert_ok _nutshell_fetch_failed_recently 0.9.9
+    _tc_end
+}
+
+#[test]
+it_remembers_nothing_about_a_fetch_that_worked() {
+    _tc_setup
+    _tc_remote 0.4.0
+    assert_ok _nutshell_fetch 0.4.0 >/dev/null 2>&1
+    assert_fails _nutshell_fetch_failed_recently 0.4.0
+    _tc_end
+}
+
+# --- the store is release-only, and says so -----------------------------------
+#
+# `_nutshell_num` trims a version field at the first non-digit, and the comment
+# on it used to say that made `0.4.0-rc1` sort beside `0.4.0`. It cannot arrive
+# to be sorted. These are the two gates that stop it.
+
+#[test]
+it_skips_a_directory_whose_name_is_not_the_version_inside_it() {
+    _tc_setup
+    # The interpreter reports `0.4.0`; the directory claims a prerelease. The
+    # name is what the resolver looks up by, so a directory that disagrees with
+    # itself would be handed out for a request it does not satisfy.
+    _tc_store 0.4.0 "0.4.0-rc1"
+    assert_empty "$(nutshell_toolchains)"
+    _tc_end
+}
+
+#[test]
+it_refuses_to_store_a_fetch_whose_version_is_not_the_name_asked_for() {
+    _tc_setup
+    _tc_remote 0.4.0
+    # A tag spelled as a prerelease, holding an interpreter that reports the
+    # plain version. There is nowhere in the store for it to go.
+    local work="$TCROOT/work-0.4.0"
+    git -C "$work" tag -a "0.4.0-rc1" -m rc
+    git -C "$work" push -q origin "0.4.0-rc1"
+    assert_fails _nutshell_fetch "0.4.0-rc1" 2>/dev/null
+    assert_fails test -e "$NUTSHELL_TOOLCHAINS/0.4.0-rc1"
+    _tc_end
+}

--- a/tests/toolchain_test.sh
+++ b/tests/toolchain_test.sh
@@ -498,3 +498,55 @@ it_refuses_to_store_a_fetch_whose_version_is_not_the_name_asked_for() {
     assert_fails test -e "$NUTSHELL_TOOLCHAINS/0.4.0-rc1"
     _tc_end
 }
+
+# --- the store root is spelled twice, and only this holds the two together ----
+
+#[test]
+it_derives_the_same_store_root_as_the_xdg_module_does() {
+    # `find-nutshell` runs before nutshell exists and cannot `use xdg`, so the
+    # platform branch is written out in both places. Its own comment says the
+    # two are "held together by a test rather than by anybody remembering",
+    # and no such test existed: `grep -rn xdg_data_home tests/` returned
+    # nothing, and the nearest one restated find-nutshell's own literals back
+    # to it without ever calling the module.
+    #
+    # This calls both and compares, so changing one and not the other fails
+    # here rather than on somebody's machine.
+    local keep_store="${NUTSHELL_STORE:-}" keep_tc="${NUTSHELL_TOOLCHAINS:-}"
+    unset NUTSHELL_STORE NUTSHELL_TOOLCHAINS
+
+    use xdg
+    xdg_set_app_name nutshell
+    local from_module; from_module="$(xdg_app_data)"
+    local from_resolver; from_resolver="$(nutshell_store_root)"
+
+    assert_ne "$from_module" ""
+    assert_eq "$from_resolver" "$from_module"
+
+    [[ -n "$keep_store" ]] && export NUTSHELL_STORE="$keep_store"
+    [[ -n "$keep_tc" ]] && export NUTSHELL_TOOLCHAINS="$keep_tc"
+    return 0
+}
+
+#[test]
+it_follows_the_data_home_override_the_same_way_the_module_does() {
+    # The branch that actually differs between platforms, exercised rather
+    # than assumed: with the variable set, both must follow it.
+    local keep_store="${NUTSHELL_STORE:-}" keep_tc="${NUTSHELL_TOOLCHAINS:-}"
+    unset NUTSHELL_STORE NUTSHELL_TOOLCHAINS
+
+    use xdg
+    local probe="/tmp/nut-xdg-probe"
+    local from_module from_resolver
+    from_module="$(XDG_DATA_HOME="$probe" bash -c '
+        . "'"$PWD"'/init" >/dev/null 2>&1
+        use xdg; xdg_set_app_name nutshell; xdg_app_data')"
+    from_resolver="$(XDG_DATA_HOME="$probe" nutshell_store_root)"
+
+    assert_contains "$from_resolver" "$probe"
+    assert_eq "$from_resolver" "$from_module"
+
+    [[ -n "$keep_store" ]] && export NUTSHELL_STORE="$keep_store"
+    [[ -n "$keep_tc" ]] && export NUTSHELL_TOOLCHAINS="$keep_tc"
+    return 0
+}

--- a/tools/assoc-array-report
+++ b/tools/assoc-array-report
@@ -1,0 +1,457 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/tools/assoc-array-report - What a map costs without bash arrays
+# =============================================================================
+#
+# POSIX sh has no associative arrays. nutshell uses them in the places that
+# decide how fast it is: the config cache, the toolchain store tables, the
+# attribute tables, and the file-line table the QA checks read. So "make
+# nutshell POSIX" has a price, and the price is a number rather than an
+# opinion. This is the number.
+#
+# **A report, not a gate.** There is no threshold anybody can justify here; the
+# decision it feeds is a design one.
+#
+# **This is not a bench.** nutshell has no bench harness, so this is an ad-hoc
+# measurement and is called that. It does what it can without one: every arm is
+# a real alternative somebody would actually reach for, the arms run on the
+# same generated input, the input is shaped like nutshell's own keys, and the
+# controls below refuse to print numbers the instrument cannot support.
+#
+# The size defaults to the largest real table: `_PAD_LINES` in the docs check
+# holds one entry per line of source, which on this library is 9606 across 24
+# files. The keys are the real shape too, `<path>:<n>`, because two of the arms
+# cannot take a key with a slash or a colon in it and the encoding that fixes
+# that is part of what they cost.
+#
+# Usage:
+#   tools/assoc-array-report [entries] [lookups]
+# =============================================================================
+
+set -uo pipefail
+
+ENTRIES="${1:-2000}"
+LOOKUPS="${2:-500}"
+REAL_TABLE=9606
+
+# -----------------------------------------------------------------------------
+# The input, shaped like nutshell's own keys
+# -----------------------------------------------------------------------------
+
+declare -a KEYS=() VALS=()
+_generate() {
+    local i
+    for (( i = 0; i < ENTRIES; i++ )); do
+        # `<path>:<n>`, which is what `_PAD_LINES` and `_PAD_AT` are keyed by.
+        # Slash, dot, dash and colon all appear, and none of them may go into a
+        # variable name unencoded.
+        KEYS+=("lib/some-module.sh:$i")
+        VALS+=("value number $i")
+    done
+}
+
+# A key as a variable name. Every arm that builds a name out of a key pays this.
+_encode() {
+    local k="$1" out="" i c
+    for (( i = 0; i < ${#k}; i++ )); do
+        c="${k:i:1}"
+        case "$c" in
+            [A-Za-z0-9_]) out+="$c" ;;
+            *) printf -v c '_%02x' "'$c"; out+="$c" ;;
+        esac
+    done
+    printf '%s' "$out"
+}
+
+# -----------------------------------------------------------------------------
+# The arms. Each builds a table of ENTRIES pairs, then does LOOKUPS hits and
+# LOOKUPS misses, and prints the value it last found so nothing can be
+# optimised away by not being used.
+# -----------------------------------------------------------------------------
+
+# A: bash associative array. The thing being given up.
+arm_bash_assoc() {
+    declare -A m=()
+    local i last=""
+    for (( i = 0; i < ENTRIES; i++ )); do m["${KEYS[$i]}"]="${VALS[$i]}"; done
+    for (( i = 0; i < LOOKUPS; i++ )); do last="${m["${KEYS[$(( i * ENTRIES / LOOKUPS ))]}"]:-}"; done
+    for (( i = 0; i < LOOKUPS; i++ )); do last="${m["no/such-key.sh:$i"]:-MISS}"; done
+    printf '%s' "$last"
+}
+
+# B: variable names built out of the key, read and written through `eval`.
+#    The classic POSIX substitute, and the one that needs the encoding.
+arm_eval_names() {
+    local i last="" n
+    for (( i = 0; i < ENTRIES; i++ )); do
+        n="$(_encode "${KEYS[$i]}")"
+        eval "_aa_${n}=\${VALS[\$i]}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        n="$(_encode "${KEYS[$(( i * ENTRIES / LOOKUPS ))]}")"
+        eval "last=\${_aa_${n}:-}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        n="$(_encode "no/such-key.sh:$i")"
+        eval "last=\${_aa_${n}:-MISS}"
+    done
+    printf '%s' "$last"
+}
+
+# B2: the same, without a fork for the encoding. `_encode` above is called
+#     through a command substitution, which is what a caller writes first and
+#     is a fork per operation. This is the same arm with the encoding done in
+#     place, and the gap between the two is the cost of that habit rather than
+#     of the technique.
+arm_eval_names_nofork() {
+    local i last="" n
+    for (( i = 0; i < ENTRIES; i++ )); do
+        printf -v n '%s' "${KEYS[$i]//[^A-Za-z0-9_]/_}"
+        eval "_bb_${n}=\${VALS[\$i]}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        printf -v n '%s' "${KEYS[$(( i * ENTRIES / LOOKUPS ))]//[^A-Za-z0-9_]/_}"
+        eval "last=\${_bb_${n}:-}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        printf -v n '%s' "no/such-key.sh:${i}"
+        n="${n//[^A-Za-z0-9_]/_}"
+        eval "last=\${_bb_${n}:-MISS}"
+    done
+    printf '%s' "$last"
+}
+
+# C: one string holding every pair, scanned with parameter expansion.
+#    No forks and no files, and quadratic the moment the table is large.
+arm_one_string() {
+    local map=$'\n' i last="" rest
+    for (( i = 0; i < ENTRIES; i++ )); do map+="${KEYS[$i]}=${VALS[$i]}"$'\n'; done
+    # A miss has to be a miss. `${map#*pat}` returns the whole string unchanged
+    # when the pattern is absent, so without the membership test below this arm
+    # answered a real value for a key that was not there. The correctness
+    # control caught it on the first run, which is the reason that control is
+    # there and ahead of the timing.
+    local pat
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        pat=$'\n'"${KEYS[$(( i * ENTRIES / LOOKUPS ))]}"=
+        if [[ "$map" == *"$pat"* ]]; then
+            rest="${map#*"$pat"}"; last="${rest%%$'\n'*}"
+        else
+            last="MISS"
+        fi
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        pat=$'\n'"no/such-key.sh:${i}="
+        if [[ "$map" == *"$pat"* ]]; then
+            rest="${map#*"$pat"}"; last="${rest%%$'\n'*}"
+        else
+            last="MISS"
+        fi
+    done
+    printf '%s' "$last"
+}
+
+# D: one file, a line per pair, read back in the shell.
+arm_one_file() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/aa.XXXXXX")"
+    local f="$d/map" i last="" k v want
+    for (( i = 0; i < ENTRIES; i++ )); do printf '%s\t%s\n' "${KEYS[$i]}" "${VALS[$i]}"; done > "$f"
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        want="${KEYS[$(( i * ENTRIES / LOOKUPS ))]}"
+        last=""
+        while IFS=$'\t' read -r k v; do [[ "$k" == "$want" ]] && { last="$v"; break; }; done < "$f"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        want="no/such-key.sh:$i"; last="MISS"
+        while IFS=$'\t' read -r k v; do [[ "$k" == "$want" ]] && { last="$v"; break; }; done < "$f"
+    done
+    rm -rf "$d"
+    printf '%s' "$last"
+}
+
+# E: the filesystem as the table, one file per key. The lookup is a read of a
+#    known path rather than a search, which is the only arm here whose lookup
+#    does not get slower as the table grows.
+arm_dir_table() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/aa.XXXXXX")"
+    local i last="" n
+    for (( i = 0; i < ENTRIES; i++ )); do
+        n="${KEYS[$i]//[^A-Za-z0-9_]/_}"
+        printf '%s' "${VALS[$i]}" > "$d/$n"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        n="${KEYS[$(( i * ENTRIES / LOOKUPS ))]//[^A-Za-z0-9_]/_}"
+        last=""; [[ -r "$d/$n" ]] && read -r last < "$d/$n"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        n="no/such-key.sh:${i}"; n="${n//[^A-Za-z0-9_]/_}"
+        last="MISS"; [[ -r "$d/$n" ]] && read -r last < "$d/$n"
+    done
+    rm -rf "$d"
+    printf '%s' "$last"
+}
+
+# A memory filesystem, if this machine has one.
+#
+# Not POSIX. The standard says nothing about where a path's bytes live, and
+# that is the only syscall lever a shell really has: `dd bs=` shapes a transfer
+# and nothing shapes an allocation. Linux has `/dev/shm` and usually a tmpfs
+# `/tmp`; macOS has neither, so this arm reports itself skipped there rather
+# than quietly measuring a disk and calling it memory.
+_memfs() {
+    local d
+    for d in /dev/shm /run/shm; do
+        [[ -d "$d" && -w "$d" ]] && { printf '%s' "$d"; return 0; }
+    done
+    # A tmpfs `/tmp`, where the platform can be asked.
+    if command -v findmnt >/dev/null 2>&1; then
+        case "$(findmnt -no FSTYPE --target /tmp 2>/dev/null)" in
+            tmpfs|ramfs) printf '/tmp'; return 0 ;;
+        esac
+    fi
+    return 1
+}
+
+# F: the same table as E, on a memory filesystem. The gap between the two is
+#    what the disk was costing, which is the part of a syscall a shell can
+#    actually do something about.
+arm_memfs_table() {
+    local root; root="$(_memfs)" || { printf 'SKIP'; return 0; }
+    local d; d="$(mktemp -d "${root}/aa.XXXXXX")"
+    local i last="" n
+    for (( i = 0; i < ENTRIES; i++ )); do
+        n="${KEYS[$i]//[^A-Za-z0-9_]/_}"
+        printf '%s' "${VALS[$i]}" > "$d/$n"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        n="${KEYS[$(( i * ENTRIES / LOOKUPS ))]//[^A-Za-z0-9_]/_}"
+        last=""; [[ -r "$d/$n" ]] && read -r last < "$d/$n"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        n="no/such-key.sh:${i}"; n="${n//[^A-Za-z0-9_]/_}"
+        last="MISS"; [[ -r "$d/$n" ]] && read -r last < "$d/$n"
+    done
+    rm -rf "$d"
+    printf '%s' "$last"
+}
+
+# G: slots addressed by arithmetic, with the caller holding the index.
+#
+#    The table is `_g0.._gN`, and a lookup is one `eval` on a name built from a
+#    number. No per-character encoding anywhere, because nothing has to turn a
+#    key into a name: whatever resolved the key once handed back the index and
+#    the caller kept it.
+#
+#    This is the ceiling for the technique, and it is not a map. It is what a
+#    map becomes once the key lookup has already happened, so it says what the
+#    key lookup is actually costing in every other arm.
+arm_slots_by_index() {
+    local i last=""
+    for (( i = 0; i < ENTRIES; i++ )); do eval "_g${i}=\${VALS[\$i]}"; done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        eval "last=\${_g$(( i * ENTRIES / LOOKUPS )):-}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        eval "last=\${_g$(( ENTRIES + i )):-MISS}"
+    done
+    printf '%s' "$last"
+}
+
+# G2: the same slots, several fields per entry, addressed by stride.
+#
+#     `_h$(( i * 3 + f ))` is a record of three fields. Whether striding costs
+#     anything over one field is the question; the arithmetic is native and the
+#     name is still just a number.
+arm_slots_by_stride() {
+    local i last="" base
+    for (( i = 0; i < ENTRIES; i++ )); do
+        base=$(( i * 3 ))
+        eval "_h${base}=\${KEYS[\$i]}"
+        eval "_h$(( base + 1 ))=\${VALS[\$i]}"
+        eval "_h$(( base + 2 ))=\$i"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        base=$(( (i * ENTRIES / LOOKUPS) * 3 ))
+        eval "last=\${_h$(( base + 1 )):-}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        base=$(( (ENTRIES + i) * 3 ))
+        eval "last=\${_h$(( base + 1 )):-MISS}"
+    done
+    printf '%s' "$last"
+}
+
+# H: a hash table built by hand over those slots.
+#
+#    The honest version of "index it yourself": hash the key with shell
+#    arithmetic, probe linearly on collision, store key and value side by side
+#    so a probe can tell a hit from a neighbour. This is what it costs to keep
+#    string keys without the shell's own symbol table doing the work.
+#
+#    The hash is over every character, which is where the cost goes, and that
+#    is the point of measuring it: the shell's symbol table hashes in C.
+_hash_into() {
+    local __s="${2:-}" __n __i __h=5381 __c
+    __n=${#__s}
+    for (( __i = 0; __i < __n; __i++ )); do
+        printf -v __c '%d' "'${__s:__i:1}"
+        __h=$(( (__h * 33 + __c) & 0x7fffffff ))
+    done
+    printf -v "$1" '%d' "$(( __h % BUCKETS ))"
+}
+
+arm_hand_rolled_hash() {
+    local BUCKETS=$(( ENTRIES * 2 ))
+    local i last="" h probe k
+    for (( i = 0; i < ENTRIES; i++ )); do
+        _hash_into h "${KEYS[$i]}"
+        probe=$h
+        while :; do
+            eval "k=\${_kk${probe}+set}"
+            [[ -z "$k" ]] && break
+            probe=$(( (probe + 1) % BUCKETS ))
+        done
+        eval "_kk${probe}=\${KEYS[\$i]}"
+        eval "_vv${probe}=\${VALS[\$i]}"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        local want="${KEYS[$(( i * ENTRIES / LOOKUPS ))]}"
+        _hash_into h "$want"
+        probe=$h; last="MISS"
+        while :; do
+            eval "k=\${_kk${probe}-}"
+            [[ -z "$k" ]] && break
+            if [[ "$k" == "$want" ]]; then eval "last=\${_vv${probe}}"; break; fi
+            probe=$(( (probe + 1) % BUCKETS ))
+        done
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        local want="no/such-key.sh:$i"
+        _hash_into h "$want"
+        probe=$h; last="MISS"
+        while :; do
+            eval "k=\${_kk${probe}-}"
+            [[ -z "$k" ]] && break
+            if [[ "$k" == "$want" ]]; then eval "last=\${_vv${probe}}"; break; fi
+            probe=$(( (probe + 1) % BUCKETS ))
+        done
+    done
+    printf '%s' "$last"
+}
+
+# -----------------------------------------------------------------------------
+# Running them
+# -----------------------------------------------------------------------------
+
+_ms() {
+    local fn="$1" start end out
+    start="$(date +%s%N 2>/dev/null)" || return 1
+    out="$("$fn")"
+    end="$(date +%s%N 2>/dev/null)" || return 1
+    _LAST_OUT="$out"
+    printf '%s' "$(( (end - start) / 1000000 ))"
+}
+
+main() {
+    _generate
+
+    printf 'What a map costs without bash associative arrays\n\n'
+    printf '  entries   %s\n' "$ENTRIES"
+    printf '  lookups   %s hits and %s misses\n' "$LOOKUPS" "$LOOKUPS"
+    printf '  keys      the real shape, <path>:<n>\n'
+    printf '  bash      %s\n' "${BASH_VERSION:-unknown}"
+    printf '  host      %s %s\n\n' "$(uname -s)" "$(uname -m)"
+
+    local -a names=(arm_bash_assoc arm_eval_names arm_eval_names_nofork
+                    arm_one_string arm_one_file arm_dir_table arm_memfs_table
+                    arm_slots_by_index arm_slots_by_stride arm_hand_rolled_hash)
+    local -a labels=("bash declare -A" "eval names, encoded via subshell"
+                     "eval names, encoded in place" "one string, scanned"
+                     "one file, read in shell" "one file per key"
+                     "one file per key, in memory"
+                     "slots by index, caller holds it"
+                     "slots by stride, three fields"
+                     "hash table rolled by hand")
+    # Above these sizes an arm takes long enough that running it stops being
+    # worth the wait. Stated per arm rather than hidden, because which arms
+    # have a ceiling at all is itself the result: the two that address a key
+    # directly have none.
+    local -a ceiling=(0 4000 0 800 4000 0 0 0 0 4000)
+    local -a took=()
+    local i t base=""
+
+    for (( i = 0; i < ${#names[@]}; i++ )); do
+        if (( ceiling[i] > 0 && ENTRIES > ceiling[i] )); then
+            took+=("-")
+            continue
+        fi
+        t="$(_ms "${names[$i]}")" || { printf 'no nanosecond clock here; cannot measure\n' >&2; return 1; }
+        took+=("$t")
+        [[ -z "$base" ]] && base="$t"
+    done
+
+    # The control that matters most: every arm has to give the same answers.
+    # Comparing a fast wrong one against a slow right one is not a comparison,
+    # and an arm whose encoding collides two keys would look excellent.
+    local want="" got=""
+    for (( i = 0; i < ${#names[@]}; i++ )); do
+        [[ "${took[$i]}" == "-" ]] && continue
+        got="$("${names[$i]}")"
+        [[ "$got" == "SKIP" ]] && continue
+        if [[ -z "$want" ]]; then want="$got"; continue; fi
+        if [[ "$got" != "$want" ]]; then
+            printf 'arms disagree: %s answered %q where the first answered %q\n' \
+                "${labels[$i]}" "$got" "$want" >&2
+            return 1
+        fi
+    done
+
+    # And that the input is distinct enough to be worth answering. An encoding
+    # that maps two real keys onto one name would pass the check above while
+    # holding half the table.
+    local -A seen=(); local n
+    for (( i = 0; i < ENTRIES; i++ )); do
+        n="${KEYS[$i]//[^A-Za-z0-9_]/_}"
+        seen["$n"]=1
+    done
+    if (( ${#seen[@]} != ENTRIES )); then
+        printf 'the name encoding collides: %s keys became %s names\n' \
+            "$ENTRIES" "${#seen[@]}" >&2
+        return 1
+    fi
+
+    # The second control. Every arm answers the same question on the same
+    # input, so if they all take the same time the instrument is measuring
+    # something other than the arms and the numbers below mean nothing.
+    local spread=0
+    for (( i = 1; i < ${#took[@]}; i++ )); do
+        [[ "${took[$i]}" == "-" ]] && continue
+        (( took[i] != took[0] )) && spread=1
+    done
+    if (( spread == 0 )); then
+        printf 'every arm took the same time, so this is not measuring the arms\n' >&2
+        return 1
+    fi
+
+    printf '  %-34s %9s  %s\n' "arm" "ms" "against bash"
+    for (( i = 0; i < ${#names[@]}; i++ )); do
+        local rel="-"
+        if [[ "${took[$i]}" == "-" ]]; then
+            printf '  %-34s %9s  %s\n' "${labels[$i]}" "-" "not run at this size"
+            continue
+        fi
+        if [[ "$("${names[$i]}")" == "SKIP" ]]; then
+            printf '  %-34s %9s  %s\n' "${labels[$i]}" "-" "no memory filesystem here"
+            continue
+        fi
+        (( base > 0 )) && rel="$(( took[i] * 100 / base ))%"
+        printf '  %-34s %9s  %s\n' "${labels[$i]}" "${took[$i]}" "$rel"
+    done
+
+    printf '\n'
+    printf 'The real table this stands in for is %s entries, and the arms that\n' "$REAL_TABLE"
+    printf 'search rather than address grow with it. Run with a larger first\n'
+    printf 'argument to see that; the default is small enough to finish.\n'
+}
+
+main "$@"

--- a/tools/assoc-array-report
+++ b/tools/assoc-array-report
@@ -12,6 +12,13 @@
 # **A report, not a gate.** There is no threshold anybody can justify here; the
 # decision it feeds is a design one.
 #
+# **Two arms are not maps and are labelled so in the table.** `slots by index`
+# and `slots by stride` are what a map becomes once the key has already been
+# resolved: the caller holds the index. They belong here because the gap
+# between them and the arms beside them prices the key lookup, which is the
+# thing a design would be trading away. They are not alternatives to
+# `declare -A` and the table must not read as though they were.
+#
 # **This is not a bench.** nutshell has no bench harness, so this is an ad-hoc
 # measurement and is called that. It does what it can without one: every arm is
 # a real alternative somebody would actually reach for, the arms run on the
@@ -343,13 +350,38 @@ arm_hand_rolled_hash() {
 # Running them
 # -----------------------------------------------------------------------------
 
-_ms() {
-    local fn="$1" start end out
+# One arm, run several times, reported as its best and its spread.
+#
+# A single timing of a 5ms arm is not a measurement. Observed on this machine,
+# four consecutive runs of the same arm at the same size: 5, 5, 35, 5. The
+# ratio column then read 160%, 160%, 25%, 180% for the arm beside it, and the
+# old control passed every time, because it only asked whether *any* arm
+# differed from the first by a millisecond across a set spanning 5ms to 3s.
+#
+# The minimum is the estimator rather than the mean: every source of noise here
+# adds time and none removes it, so the fastest run is the one least disturbed.
+# The spread is kept and printed, because a number without one cannot be
+# compared against another number.
+_REPEATS="${ASSOC_REPEATS:-7}"
+
+_time_once() {
+    local fn="$1" start end
     start="$(date +%s%N 2>/dev/null)" || return 1
-    out="$("$fn")"
+    "$fn" >/dev/null
     end="$(date +%s%N 2>/dev/null)" || return 1
-    _LAST_OUT="$out"
     printf '%s' "$(( (end - start) / 1000000 ))"
+}
+
+# Sets _ARM_BEST and _ARM_WORST.
+_measure() {
+    local fn="$1" i t
+    _ARM_BEST=""; _ARM_WORST=""
+    for (( i = 0; i < _REPEATS; i++ )); do
+        t="$(_time_once "$fn")" || return 1
+        [[ -z "$_ARM_BEST"  || "$t" -lt "$_ARM_BEST"  ]] && _ARM_BEST="$t"
+        [[ -z "$_ARM_WORST" || "$t" -gt "$_ARM_WORST" ]] && _ARM_WORST="$t"
+    done
+    return 0
 }
 
 main() {
@@ -369,25 +401,25 @@ main() {
                      "eval names, encoded in place" "one string, scanned"
                      "one file, read in shell" "one file per key"
                      "one file per key, in memory"
-                     "slots by index, caller holds it"
-                     "slots by stride, three fields"
+                     "slots by index (not a map)"
+                     "slots by stride (not a map)"
                      "hash table rolled by hand")
     # Above these sizes an arm takes long enough that running it stops being
     # worth the wait. Stated per arm rather than hidden, because which arms
     # have a ceiling at all is itself the result: the two that address a key
     # directly have none.
     local -a ceiling=(0 4000 0 800 4000 0 0 0 0 4000)
-    local -a took=()
-    local i t base=""
+    local -a best=() worst=()
+    local i t
 
     for (( i = 0; i < ${#names[@]}; i++ )); do
         if (( ceiling[i] > 0 && ENTRIES > ceiling[i] )); then
-            took+=("-")
+            best+=("-"); worst+=("-")
             continue
         fi
-        t="$(_ms "${names[$i]}")" || { printf 'no nanosecond clock here; cannot measure\n' >&2; return 1; }
-        took+=("$t")
-        [[ -z "$base" ]] && base="$t"
+        _measure "${names[$i]}" || {
+            printf 'no nanosecond clock here; cannot measure\n' >&2; return 1; }
+        best+=("$_ARM_BEST"); worst+=("$_ARM_WORST")
     done
 
     # The control that matters most: every arm has to give the same answers.
@@ -395,7 +427,7 @@ main() {
     # and an arm whose encoding collides two keys would look excellent.
     local want="" got=""
     for (( i = 0; i < ${#names[@]}; i++ )); do
-        [[ "${took[$i]}" == "-" ]] && continue
+        [[ "${best[$i]}" == "-" ]] && continue
         got="$("${names[$i]}")"
         [[ "$got" == "SKIP" ]] && continue
         if [[ -z "$want" ]]; then want="$got"; continue; fi
@@ -406,9 +438,7 @@ main() {
         fi
     done
 
-    # And that the input is distinct enough to be worth answering. An encoding
-    # that maps two real keys onto one name would pass the check above while
-    # holding half the table.
+    # And that the input is distinct enough to be worth answering.
     local -A seen=(); local n
     for (( i = 0; i < ENTRIES; i++ )); do
         n="${KEYS[$i]//[^A-Za-z0-9_]/_}"
@@ -420,32 +450,46 @@ main() {
         return 1
     fi
 
-    # The second control. Every arm answers the same question on the same
-    # input, so if they all take the same time the instrument is measuring
-    # something other than the arms and the numbers below mean nothing.
-    local spread=0
-    for (( i = 1; i < ${#took[@]}; i++ )); do
-        [[ "${took[$i]}" == "-" ]] && continue
-        (( took[i] != took[0] )) && spread=1
-    done
-    if (( spread == 0 )); then
-        printf 'every arm took the same time, so this is not measuring the arms\n' >&2
+    # The baseline has to be steady enough to divide by. This is the control
+    # the old one was missing: it compared arms to each other and never asked
+    # whether the number it divided by meant anything.
+    local base_best="${best[0]}" base_worst="${worst[0]}"
+    if [[ "$base_best" == "-" ]] || (( base_best <= 0 )); then
+        printf 'the baseline did not measure; nothing below can be a ratio\n' >&2
+        return 1
+    fi
+    if (( base_worst > base_best * 2 )); then
+        printf 'the baseline moved from %sms to %sms across %s runs.\n' \
+            "$base_best" "$base_worst" "$_REPEATS" >&2
+        printf 'this machine is too noisy right now for a ratio to mean anything.\n' >&2
+        printf 'raw times only:\n\n' >&2
+        for (( i = 0; i < ${#names[@]}; i++ )); do
+            printf '  %-34s %6s..%-6s\n' "${labels[$i]}" "${best[$i]}" "${worst[$i]}"
+        done
         return 1
     fi
 
-    printf '  %-34s %9s  %s\n' "arm" "ms" "against bash"
+    printf '  %-34s %8s %9s  %s\n' "arm" "best ms" "spread" "against bash"
     for (( i = 0; i < ${#names[@]}; i++ )); do
-        local rel="-"
-        if [[ "${took[$i]}" == "-" ]]; then
-            printf '  %-34s %9s  %s\n' "${labels[$i]}" "-" "not run at this size"
+        if [[ "${best[$i]}" == "-" ]]; then
+            printf '  %-34s %8s %9s  %s\n' "${labels[$i]}" "-" "-" "not run at this size"
             continue
         fi
         if [[ "$("${names[$i]}")" == "SKIP" ]]; then
-            printf '  %-34s %9s  %s\n' "${labels[$i]}" "-" "no memory filesystem here"
+            printf '  %-34s %8s %9s  %s\n' "${labels[$i]}" "-" "-" "no memory filesystem here"
             continue
         fi
-        (( base > 0 )) && rel="$(( took[i] * 100 / base ))%"
-        printf '  %-34s %9s  %s\n' "${labels[$i]}" "${took[$i]}" "$rel"
+        # A ratio only where the two ranges do not overlap. Where they do, the
+        # arms are not distinguishable at this size and saying so is the
+        # honest answer.
+        local rel
+        if (( best[i] > base_worst )) || (( worst[i] < base_best )); then
+            rel="$(( best[i] * 100 / base_best ))%"
+        else
+            rel="within the noise"
+        fi
+        printf '  %-34s %8s %9s  %s\n' \
+            "${labels[$i]}" "${best[$i]}" "${best[$i]}..${worst[$i]}" "$rel"
     done
 
     printf '\n'


### PR DESCRIPTION
The first release since the store landed, and it is the one that makes
`NUTSHELL_VERSION` true: `init` has said 0.4.0 for a while with nothing tagged
to match, which is what makes the version warning fire on every run of anything
pinned to it.

## The interpreter is fetched now, like everything else

It was the one dependency that never was. It resolved by picking whatever the
machine happened to have, so a tool wanting a version nobody installed fell
through to a vendored copy and complained about it on every run.

- a toolchain store keyed by version, newest satisfying one wins
- a version that is not here gets cloned at its tag, through a scratch dir, and
  refused if what arrives reports a different version than the tag promised
- a pin can name a branch, meaning that branch's head, asked at most once an
  hour, and the checkout is keyed by the revision it resolved to
- externs and toolchains under one root, moved out of the cache directory into
  the data directory, because a cache is something a cleaner may delete and
  this is where every project's dependencies live

Nothing in the store is deleted while something may be reading it. A version
directory is named for the version inside it so a collision adopts what is
there; a branch checkout is written once under its revision and never replaced.

`priv_as_user` is the other half of the elevation api: one step as the person,
from inside something that already elevated, so a tool does not leave root's
name on files in somebody's home.

## The QA gate was grading the wrong repository

`check-runner.sh` walked up from its own file to the first `.git`, which in any
consumer is whichever nutshell is running the check. So the thresholds were the
consumer's and the files were nutshell's, and no consumer's source had ever
been read. Reading a consumer's `✓` as "no gate here" was correct.

Two more came out of fixing it, and both were the gate lying rather than being
slow:

- `exit_with_status` promised "2 on warnings only" in its own usage line and
  never returned 2, so the runner told a warning from a pass by grepping the
  child's output for a glyph. A check reporting 23 warnings showed as clean
- a failing check printed nothing at all, because quiet mode suppressed the
  child's report and the runner had nothing to show

## And it went from about 250 seconds to 13

None of it was the work. `lib/attr.sh` forked a `sed` per line of every file,
per lookup, which is a quarter of a million processes; it calls no external
tool at all now. A config key was re-read per passing check from inside a
subshell where the cache could not survive, re-parsing the whole TOML file
each time. The name-similarity comparison filled in a whole edit-distance
matrix when three rows already settled it. The checks are sourced into
subshells of one process instead of eight startups with eight cold caches.

`NUT_CACHE=1` keeps a check's answer for a file until the file, the check or
the config changes, which takes a warm run to 9s. Off by default.

## What changes for you, if you already use this

There is no changelog yet, so it goes here.

- **Your QA gate starts reading your own code.** `check-runner` walked up from
  its own file, so it was grading nutshell in every consumer. The first run on
  0.4.0 reports findings you have never seen, possibly a lot of them. This is
  the biggest surprise in the release and it is the fix working.
- **`exit_with_status` exits 2 on warnings**, where it exited 1 or 0. Calling a
  check directly, or under `set -e`, now fails where it used to pass.
- **`. init` has to be checked.** It refuses below bash 4 with a `return`, and a
  `return` cannot stop its caller, so an unchecked source line runs your whole
  script with nothing loaded. Put `|| exit 1` on it, the way every example in
  the readme now does.
- **The store moved** from the cache directory to the data directory. Externs
  refetch once and the old tree is left behind; nothing migrates it, so delete
  it yourself if you want the space back.
- **A check with the nutshell shebang is sourced, not executed.** It inherits
  the runner's loaded modules, so one can pass in the gate and fail on its own.
- **`lib.nut` is authoritative where it exists.** A unit that gains one resolves
  from it and nowhere else, which changes `super::` for every module in that
  unit.

And one commitment rather than a surprise: `find-nutshell` is published for the
first time here, which makes it a copied-into-consumers file. `nutshell_at_least`
and `_nutshell_version_of` in it are on the way out, and that is written down
where a maintainer reads and nowhere you would.

## Sanity

`./test` is 545. `./check` is `PASSED WITH WARNINGS` with four, and for the
first time that verdict is about this repository.

Every performance change was confirmed to leave the findings alone, against
planted cases that produce findings rather than against runs that produce none.
That mattered twice: a reserved awk word made a comparison fail to parse while
still reporting a pass, and the first cache attempt was slower than no cache.

`tools/assoc-array-report` is new and is a measurement rather than a bench,
since this repository has no bench harness yet.
