### PR TITLE
fix: the four release blockers, and what the release review found

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ git clone https://github.com/orgrinrt/nutshell.git
 
 ### When a project needs a version the machine does not have
 
-Copy `find-nutshell` into the project and let it resolve. It is one file, it
-depends on nothing, and it is what has to be on disk before anything else can
-be found:
+Copy `find-nutshell` into the project and let it resolve. It is one file, it needs no nutshell module, and it is what has to be on disk
+before anything else can be found. It does use `git`, `date`, `uname` and the
+ordinary file tools, since fetching is what it is for:
 
 ```bash
 # in the project
@@ -74,9 +74,10 @@ machine carrying four of them is the ordinary state.
   toolchains/branches/<ref>/<revision>/
 ```
 
-The store is `${XDG_DATA_HOME:-~/.local/share}/nutshell` on Linux and
-`~/Library/Application Support/nutshell` on macOS. Both are where that platform
-puts application data, which is the point: it is not the cache directory.
+`XDG_DATA_HOME` names the store wherever it is set, on any platform. With it
+unset the store is `~/.local/share/nutshell` on Linux and
+`~/Library/Application Support/nutshell` on macOS, which is where each puts
+application data. The point of both is that neither is the cache directory.
 
 `NUTSHELL_STORE` moves the root, `NUTSHELL_TOOLCHAINS` just the toolchains, and
 `NUTSHELL_REMOTE` says where a fetch goes. Under the data directory and not the
@@ -114,21 +115,36 @@ revision runs and says which one it is.
 
 ## Quick Start
 
-Every script that uses nutshell needs **one line** at the top:
+With nutshell installed, a script needs no boilerplate at all. The shebang is
+the whole of it:
 
 ```bash
-#!/usr/bin/env bash
-. "${0%/*}/lib/nutshell/init"
+#!/usr/bin/env nutshell
 
 use os log
 
-log_info "Hello from nutshell!"
+log_info "hello"
 ```
 
-The `. "${0%/*}/lib/nutshell/init"` line is the **only boilerplate**. Copy it exactly.
+For a script that has to run where nutshell may not be installed, source the
+resolver instead and let it find one:
 
-> **What does `${0%/*}` mean?**  
-> It's bash for "directory containing this script". It ensures the script works regardless of where it's called from.
+```bash
+#!/usr/bin/env bash
+HERE="${BASH_SOURCE[0]%/*}"
+. "$HERE/find-nutshell"
+nutshell_find "$HERE" dev || exit 1
+. "$NUTSHELL_INIT"
+
+use os log
+
+log_info "hello"
+```
+
+That second form is what a project carries when it pins a version, and
+`find-nutshell` is the only file it needs beside its own source. There is no
+third form: a copy of nutshell in the tree is the arrangement the section above
+tells you not to adopt.
 
 ---
 
@@ -136,7 +152,7 @@ The `. "${0%/*}/lib/nutshell/init"` line is the **only boilerplate**. Copy it ex
 
 ```
 nutshell/
-├── init                    # Source this: . "${0%/*}/lib/nutshell/init"
+├── init                    # what `nutshell` and `find-nutshell` source
 ├── check                   # Main QA entry point (executable)
 ├── bin/
 │   └── nutshell           # Interpreter for #!/usr/bin/env nutshell
@@ -195,7 +211,7 @@ Each script is independent. Each one has the init line:
 ```bash
 #!/usr/bin/env bash
 # scripts/build.sh
-. "${0%/*}/lib/nutshell/init"
+. "$NUTSHELL_INIT"
 
 use os log fs
 
@@ -213,7 +229,7 @@ One script bootstraps, others use the clean shebang:
 ```bash
 #!/usr/bin/env bash
 # scripts/main.sh - The entry point
-. "${0%/*}/lib/nutshell/init"
+. "$NUTSHELL_INIT"
 
 # PATH is already set by init, so internal scripts can use nutshell shebang
 "${0%/*}/internal/build.sh" "$@"
@@ -306,9 +322,6 @@ use os log json http
 | `srcfile` | A source file read once (`nut_load_file`, `nut_defined_at`, `nut_body_of`) |
 | `checkcache` | A check's answer kept until it can change (`nut_cache_hit`, `nut_cache_read`) |
 | `priv` | Elevating for one step and stepping back (`priv_run`, `priv_as_user`) |
-| `extern` | Declared dependencies out of the store (`extern_path`, `extern_declared`) |
-| `modgraph` | What a module declares against what it calls |
-| `git` | Repository questions (`git_root`, `git_branch`, `git_is_clean`) |
 | `git` | Reading a repository (`git_trunk`, `git_changed_files`, `git_trailers`) |
 | `modgraph` | The module graph and its violations (`modgraph_build`, `modgraph_audit`) |
 | `extern` | Libraries from elsewhere (`extern_path`, `extern_resolve`) |
@@ -503,7 +516,7 @@ happens.
 ```bash
 #!/usr/bin/env bash
 # scripts/build.sh
-. "${0%/*}/lib/nutshell/init"
+. "$NUTSHELL_INIT"
 
 use os log deps fs
 
@@ -530,7 +543,7 @@ log_success "Build complete!"
 ```bash
 #!/usr/bin/env bash
 # scripts/fetch-data.sh
-. "${0%/*}/lib/nutshell/init"
+. "$NUTSHELL_INIT"
 
 use log http json
 
@@ -553,7 +566,7 @@ fi
 ```bash
 #!/usr/bin/env bash
 # scripts/install.sh
-. "${0%/*}/lib/nutshell/init"
+. "$NUTSHELL_INIT"
 
 use log prompt fs color
 
@@ -581,13 +594,13 @@ log_success "Installation complete!"
 Every script needs this line:
 
 ```bash
-. "${0%/*}/lib/nutshell/init"
+. "$NUTSHELL_INIT"
 ```
 
 Breaking it down:
 - `.` sources a file (same as `source`)
 - `"${0%/*}"` is the directory containing this script
-- `/lib/nutshell/init` is the path to nutshell's init file
+- `find-nutshell` is the resolver a project carries when it pins a version
 
 This works regardless of:
 - Where the script is called from (`./scripts/build.sh` or `scripts/build.sh`)
@@ -651,17 +664,27 @@ See `examples/configs/` for configuration templates:
 
 ## Why This Design?
 
-**Q: Why not a global install?**  
-A: Nutshell is designed to be bundled with your project. When someone clones your repo and runs `npm run build`, it should just work, with no "please install nutshell first".
+**Q: Why a global install rather than a copy in the project?**  
+A: Because a copy in the project is a second version, and it drifts from the
+machine's without saying so. It resolves the modules that existed when it was
+added and none added since, so what you get is an error naming a missing
+function rather than one naming a stale copy. That happened twice in one day in
+the projects this was written for.
 
-**Q: Why not `#!/usr/bin/env nutshell` everywhere?**  
-A: That requires `nutshell` to be on PATH. `./install` links it there in one step, but the source line works on a fresh clone with no setup at all, so it stays the default.
+**Q: Then what about a fresh clone with nothing installed?**  
+A: `find-nutshell` is for that. One file in the project, depending on nothing,
+which finds an installed one or fetches the version the project pins. It is
+what the second Quick Start form uses.
 
-**Q: Can I use the pretty shebang?**  
-A: Yes. The `init` file adds nutshell's `bin/` to PATH, so any scripts called after sourcing init can use `#!/usr/bin/env nutshell`, and `./install` makes it resolve everywhere else. This suits internal scripts in larger script suites.
+**Q: Can I use `#!/usr/bin/env nutshell` everywhere?**  
+A: Yes, once `./install` has linked it onto PATH, and that is the shape to
+prefer. `init` also puts nutshell's `bin/` on PATH, so anything a script starts
+after sourcing it can use the shebang without the install.
 
 **Q: What if I have many scripts?**  
-A: Each standalone script needs the init line. It's one line of boilerplate per file. For large script suites, consider Pattern 2 (entry point + internal scripts).
+A: Then the shebang is worth the one-time install: no boilerplate per file at
+all. Where that is not available, an entry point resolves once and everything
+it calls inherits PATH, which is Pattern 2 below.
 
 ---
 

--- a/bin/nutshell
+++ b/bin/nutshell
@@ -26,6 +26,22 @@
 # through the shebang or sourced `init` directly.
 # =============================================================================
 
+# The floor, before anything that needs it. `init` carries the same refusal,
+# and it is repeated here because this file is also an entry point: run under
+# bash 3 it would otherwise get as far as sourcing init before saying so, and
+# it used to get all the way to exit 0.
+#
+# Spelled through `case` on the version string rather than `BASH_VERSINFO`,
+# so the block itself parses under any shell.
+case "${BASH_VERSION:-}" in
+    ""|1.*|2.*|3.*)
+        printf 'nutshell needs bash 4.0 or newer.\n' >&2
+        printf '  this is: %s\n' "${BASH_VERSION:-not bash at all}" >&2
+        printf '  macOS ships 3.2 at /bin/bash. Install a current one and put\n' >&2
+        printf '  it first on PATH, or run this under it directly.\n' >&2
+        exit 1 ;;
+esac
+
 set -uo pipefail
 
 # The shebang line names whatever is on PATH, which is normally a symlink into

--- a/bin/nutshell
+++ b/bin/nutshell
@@ -79,7 +79,7 @@ use extern log
 # scalar. Same shape mockspace.toml uses for the same job, because it is the
 # same job and a reader should not have to learn two spellings:
 #
-#     nutshell_version = "0.3.0"     the released form
+#     nutshell_version = "0.4.0"     the released form
 #     nutshell_branch  = "dev"       when there is no release yet
 #
 # Root level, before any [table] header. A bare key written after one belongs

--- a/check
+++ b/check
@@ -212,7 +212,11 @@ _run_check() {
         # check whose own source moved has to read everything again, and
         # without this the cache would keep answering with the old one's
         # opinion.
-        output=$( set +e; NUT_CACHE_CHECKER="$check_script" . "$check_script" 2>&1 )
+        # `set --` first, so the check does not inherit this function's own
+        # arguments. Sourced, `$1` was the check's path and `$2` its display
+        # name, so any check reading `$1` or `$@` silently operated on itself.
+        # Started as its own process it had none, which is what it expects.
+        output=$( set +e; set --; NUT_CACHE_CHECKER="$check_script" . "$check_script" 2>&1 )
         exit_code=$?
     else
         output=$("$check_script" 2>&1)
@@ -283,13 +287,19 @@ _run_builtin_checks() {
     echo -e "${BOLD}Built-in Checks${NC}"
     echo ""
 
-    # Once, here, so every check below inherits it rather than building its own.
+    # Once, here, so every check below inherits it rather than building its
+    # own. `get_lib_files` lives in `check-runner`, which this file does not
+    # load, so the loop was reading nothing and pre-warming zero files while
+    # its comment said otherwise.
     use srcfile 2>/dev/null || true
     use checkcache 2>/dev/null || true
-    local f
-    while IFS= read -r f; do
-        [[ -n "$f" ]] && nut_load_file "$f" 2>/dev/null
-    done < <(get_lib_files 2>/dev/null)
+    if declare -F get_lib_files >/dev/null 2>&1 \
+       && declare -F nut_load_file >/dev/null 2>&1; then
+        local f
+        while IFS= read -r f; do
+            [[ -n "$f" ]] && nut_load_file "$f" 2>/dev/null
+        done < <(get_lib_files 2>/dev/null)
+    fi
     
     for check in "${NUTSHELL_ROOT}"/examples/checks/check_*.sh; do
         [[ ! -f "$check" ]] && continue

--- a/examples/configs/empty.nut.toml
+++ b/examples/configs/empty.nut.toml
@@ -22,7 +22,7 @@
 # key written after one belongs to that table, which is a quiet way to have a
 # pin that is never read.
 #
-#   nutshell_version = "0.3.0"    the released form
+#   nutshell_version = "0.4.0"    the released form
 #   nutshell_branch  = "dev"      when the version you need has no release yet
 #
 # Same spelling mockspace.toml uses for the same job, so a reader who knows one

--- a/find-nutshell
+++ b/find-nutshell
@@ -44,7 +44,13 @@
 NUTSHELL_INIT=""
 NUTSHELL_FROM=""
 
-# The root of a nutshell given its `init`, or nothing when that file is not one.
+# An `init` path, given one, when the file at it really is a nutshell's.
+#
+# Named `_nutshell_root_of` and documented as returning the root. It returns
+# the init path, and every caller assigns it to `NUTSHELL_INIT`, so the
+# behaviour was right and the name and the comment were both false. Left named
+# this way rather than renamed here: this file is copied verbatim into
+# consumers and a rename is a change every copy has to take at once.
 _nutshell_root_of() {
     [[ -f "${1:-}" ]] || return 1
     # `init` alone is not proof: a tool with its own file of that name would be

--- a/find-nutshell
+++ b/find-nutshell
@@ -212,12 +212,21 @@ _nutshell_branch_head() {
     printf '%s' "$sha"
 }
 
-# Throw away revisions of this branch that nothing has touched for a day.
+# Throw away revisions of this branch that nothing has used for a day.
 #
-# The checkouts are keyed by revision and never overwritten, so they would
-# otherwise accumulate one directory per push. A day is long enough that
-# nothing can still be sourcing out of one: resolution takes milliseconds and
-# the window it resolves inside is an hour.
+# **Used, not fetched.** Reading files inside a directory does not move its
+# mtime, so age alone measures time since the fetch, and modules load lazily
+# through `use` at call time: a program holds its revision for its whole run.
+# A TUI or a watch loop started three days ago, still running, was `rm -rf`'d
+# out from under itself by any other process that fetched a new head, and every
+# later `use` in it then failed.
+#
+# So resolution touches the directory it hands back, and the age below is time
+# since something last resolved to it. That is a `touch` per resolution, inside
+# the hour-long window, against a delete that breaks a running program.
+#
+# A day is then long enough: it means nothing has *started* using this revision
+# for a day, and a program that started before that has been touching it.
 _nutshell_branch_prune() {
     local base="$1" keep="$2" d name
     for d in "$base"/*/; do
@@ -268,6 +277,8 @@ _nutshell_branch() {
     # Inside the window, what is here is what the pin means.
     if [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]] \
        && (( now - last < ${NUTSHELL_BRANCH_TTL:-3600} )); then
+        # Touched so the prune can tell time-since-use from time-since-fetch.
+        touch "${base}/${known}" 2>/dev/null
         printf '%s' "${base}/${known}/init"
         return 0
     fi
@@ -287,6 +298,7 @@ _nutshell_branch() {
         if [[ -n "$known" ]] && [[ -f "${base}/${known}/init" ]]; then
             printf 'nutshell: could not reach %s, running %s from %s\n' \
                 "$remote" "$ref" "${known:0:12}" >&2
+            touch "${base}/${known}" 2>/dev/null
             printf '%s' "${base}/${known}/init"
             return 0
         fi
@@ -297,6 +309,7 @@ _nutshell_branch() {
     if [[ -f "${base}/${head}/init" ]]; then
         mkdir -p "$base" 2>/dev/null \
             && { printf '%s\n' "$now" > "$stamp"; printf '%s\n' "$head" > "${base}/.head"; }
+        touch "${base}/${head}" 2>/dev/null
         printf '%s' "${base}/${head}/init"
         return 0
     fi

--- a/find-nutshell
+++ b/find-nutshell
@@ -5,8 +5,10 @@
 # Part of nutshell - Everything you need, in a nutshell.
 # https://github.com/orgrinrt/nutshell
 #
-# Sourced by a tool before nutshell exists, so it is plain bash and depends on
-# nothing.
+# Sourced by a tool before nutshell exists, so it is plain bash and uses no
+# nutshell module. It does call `git`, `date`, `uname` and the ordinary file
+# tools; fetching an interpreter is what it is for. What it must not have is a
+# dependency on the thing it is looking for.
 #
 # Versions coexist. A tool asks for the one it needs and gets that one, and a
 # machine carrying four of them is the ordinary state rather than a mess to

--- a/init
+++ b/init
@@ -13,6 +13,35 @@
 #
 # =============================================================================
 
+# =============================================================================
+# The floor, before anything that needs it
+# =============================================================================
+#
+# Everything below this point needs bash 4: associative arrays, `declare -g`,
+# `[[ =~ ]]` with `BASH_REMATCH`. macOS ships 3.2 at `/bin/bash` and that is
+# the machine this is most often reached from, so the refusal has to be here
+# and it has to be loud.
+#
+# It used to be neither. `declare -A` failed twice, `_NUTSHELL_LOADED` was not
+# an associative array, the first `use` died on an unbound variable, and the
+# interpreter **exited 0**. A Makefile, a task runner or CI read that as
+# success. Measured on bash 3.2.57: three errors and `EXIT=0`.
+#
+# Written so any shell can read it. `${BASH_VERSINFO...}` is a bash-only
+# expansion, so it is spelled through `case` on `$BASH_VERSION`, which is a
+# plain string, and the whole block parses under `sh` and under bash 3.
+_nutshell_refuse_old_bash() {
+    printf 'nutshell needs bash 4.0 or newer.\n' >&2
+    printf '  this is: %s\n' "${BASH_VERSION:-not bash at all}" >&2
+    printf '  macOS ships 3.2 at /bin/bash. Install a current one and put it\n' >&2
+    printf '  first on PATH, or run this under it directly.\n' >&2
+}
+
+case "${BASH_VERSION:-}" in
+    "")        _nutshell_refuse_old_bash; return 1 2>/dev/null || exit 1 ;;
+    1.*|2.*|3.*) _nutshell_refuse_old_bash; return 1 2>/dev/null || exit 1 ;;
+esac
+
 # Prevent multiple inclusion
 [[ -n "${_NUTSHELL_INIT:-}" ]] && return 0
 _NUTSHELL_INIT=1

--- a/lib/attr.sh
+++ b/lib/attr.sh
@@ -44,6 +44,31 @@ nut_once || return 0
 # parenthesised argument, `]`. Anything else is an ordinary comment.
 readonly ATTR_PATTERN='^[[:space:]]*#\[[a-z_][a-z0-9_]*(\(.*\))?\][[:space:]]*$'
 
+# What a function definition looks like, in one place.
+#
+# Both spellings bash accepts, and both were being missed. `function name {`
+# has no parentheses at all; `name ()` puts a space before them. A `#[pub]` on
+# either was invisible, so the public-API check skipped those functions in
+# silence rather than reporting them undocumented.
+#
+# One pattern because there were two, here and in `srcfile`, and they had
+# already drifted apart: this one took no hyphen and no `function` keyword,
+# that one took both. A definition is one thing and the readers of it agree
+# about what it is.
+#
+# Group 2 is the name after `function`, group 3 the name before `()`. Exactly
+# one of them matches.
+readonly ATTR_DEFINES_PATTERN='^[[:space:]]*(function[[:space:]]+([a-zA-Z_][a-zA-Z0-9_-]*)|([a-zA-Z_][a-zA-Z0-9_-]*)[[:space:]]*\(\))'
+
+#[pub]
+# The function a line defines, or nothing. The one answer both this module and
+# `srcfile` use, so a definition means the same thing to each.
+# Usage: attr_defines_on "foo() {" -> prints "foo"
+attr_defines_on() {
+    [[ "${1:-}" =~ $ATTR_DEFINES_PATTERN ]] || return 1
+    printf '%s' "${BASH_REMATCH[2]:-${BASH_REMATCH[3]}}"
+}
+
 # The three below are matched with bash's own regex rather than by piping each
 # line through `sed`.
 #
@@ -72,11 +97,7 @@ _attr_arg() {
 }
 
 # _attr_defines <line> -> the function name this line defines, or nothing
-_attr_defines() {
-    local l="$1"
-    [[ "$l" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\) ]] || return 1
-    printf '%s' "${BASH_REMATCH[1]}"
-}
+_attr_defines() { attr_defines_on "${1:-}"; }
 
 # attr_on <file> <function>
 #
@@ -100,8 +121,8 @@ attr_on() {
         # The helper stays for callers and for the tests; the loop cannot
         # afford it.
         defines=""
-        [[ "$line" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\) ]] \
-            && defines="${BASH_REMATCH[1]}"
+        [[ "$line" =~ $ATTR_DEFINES_PATTERN ]] \
+            && defines="${BASH_REMATCH[2]:-${BASH_REMATCH[3]}}"
         if [[ -n "$defines" ]]; then
             if [[ "$defines" == "$want" ]]; then
                 for line in "${pending[@]}"; do
@@ -184,8 +205,8 @@ attr_find() {
         fi
 
         defines=""
-        [[ "$line" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\) ]] \
-            && defines="${BASH_REMATCH[1]}"
+        [[ "$line" =~ $ATTR_DEFINES_PATTERN ]] \
+            && defines="${BASH_REMATCH[2]:-${BASH_REMATCH[3]}}"
         if [[ -n "$defines" ]]; then
             [[ "$pending" -eq 1 ]] && printf '%s\n' "$defines"
             pending=0

--- a/lib/checkcache.sh
+++ b/lib/checkcache.sh
@@ -15,10 +15,27 @@
 # be no way to tell. The config counts for the same reason: the thresholds come
 # out of `nut.toml` and they are what the answer was measured against.
 #
-# Freshness is decided with `-nt` rather than by hashing. A hash is a process
-# per file, which is the cost this is trying to avoid; the file test is a stat
-# the shell does itself. The trade is that touching a file without changing it
-# re-runs the check, which is the harmless direction to be wrong in.
+# Freshness is a recorded stamp, not `-nt`.
+#
+# `-nt` only sees mtime moving forward, and `tar -x`, `rsync -a`, `cp -p` and
+# `touch -t` all move it backward. A review reproduced it: content replaced
+# wholesale, mtime set to 2000, and the cache served "no findings" for the new
+# file. That is the one direction a cache must never be wrong in, and the
+# header used to assert it could not happen.
+#
+# So an entry records what its inputs were, and a hit needs every one to match:
+# the file's mtime and size, the same for the check script and the config, the
+# newest mtime anywhere under the interpreter, and a format number.
+#
+# The interpreter is in there because a check is not one file. Editing
+# `lib/srcfile.sh` changes what `check_trivial_wrappers` reports while touching
+# neither the check nor the config, and op's ruling is explicit that a check
+# gaining a step has to read everything again.
+#
+# The stamps come from one `stat` for every input at once rather than one per
+# file, because a fork per lookup is the cost this exists to avoid, and the
+# first version of this cache was measurably slower than no cache for exactly
+# that reason.
 #
 # Usage:
 #   use checkcache
@@ -43,6 +60,59 @@ fi
 # worse than a check that is slow.
 declare -g NUT_CACHE_ENABLED="${NUT_CACHE:-0}"
 
+# Bumped when the entry format or the meaning of a stamp changes, so entries
+# written by an older nutshell are misses rather than lies.
+declare -g _NUT_CACHE_FORMAT=2
+
+declare -gA _NUT_CACHE_STAMP=()
+declare -g  _NUT_CACHE_BASE=""
+
+# `<mtime> <size>` for a set of paths, in one call.
+_nut_cache_stat_into() {
+    local out line path
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        _NUT_CACHE_STAMP["${line#* * }"]="${line%% * *} ${line#* }"
+    done < <(
+        if stat -f '%m %z %N' "$@" 2>/dev/null; then :
+        else stat -c '%Y %s %n' "$@" 2>/dev/null; fi
+    )
+    return 0
+}
+
+# The stamp for one path, or nothing when it could not be read.
+_nut_cache_stamp_of() {
+    local p="${1:-}" v
+    [[ -n "$p" ]] || return 1
+    v="${_NUT_CACHE_STAMP[$p]:-}"
+    if [[ -z "$v" ]]; then
+        _nut_cache_stat_into "$p"
+        v="${_NUT_CACHE_STAMP[$p]:-}"
+    fi
+    [[ -n "$v" ]] || return 1
+    printf '%s' "${v%% *} ${v##* }"
+}
+
+# What every entry shares: the interpreter's newest file and the format.
+#
+# One `find` per run, not per file. Editing any module under the interpreter
+# moves it and every entry becomes a miss, which is the coarse but correct
+# answer to "the checker is more than one file".
+_nut_cache_base() {
+    [[ -n "$_NUT_CACHE_BASE" ]] && { printf '%s' "$_NUT_CACHE_BASE"; return 0; }
+    local root="${NUTSHELL_ROOT:-}" newest=""
+    if [[ -n "$root" && -d "$root/lib" ]]; then
+        newest="$(find "$root/lib" -type f -newer "$root/lib" -print 2>/dev/null | head -1)"
+        newest="$(
+            if stat -f '%m' "$root/lib" "$root/init" 2>/dev/null; then :
+            else stat -c '%Y' "$root/lib" "$root/init" 2>/dev/null; fi
+        )"
+        newest="${newest//$'\n'/-}"
+    fi
+    _NUT_CACHE_BASE="f${_NUT_CACHE_FORMAT}:${newest:-none}"
+    printf '%s' "$_NUT_CACHE_BASE"
+}
+
 # Where an answer is kept. Under the store, beside the toolchains and externs,
 # because it is derived data about this machine and not part of any project.
 _nut_cache_root() {
@@ -57,61 +127,83 @@ _nut_cache_root() {
     printf '%s/nutshell/checks' "${XDG_CACHE_HOME:-${HOME:-/tmp}/.cache}"
 }
 
-# One file's answer, for one check. The path a source file flattens to.
+# One file's answer, for one check.
+#
+# The path is percent-encoded rather than flattened. Replacing every `/` with
+# `_` maps `lib/toml/json.sh` and `lib/toml_json.sh` onto one entry, and the
+# answer for one is then served for the other.
+_nut_cache_escape() {
+    local in="${1:-}" out="" i c
+    for (( i = 0; i < ${#in}; i++ )); do
+        c="${in:i:1}"
+        case "$c" in
+            [A-Za-z0-9._-]) out+="$c" ;;
+            *) printf -v c '%%%02X' "'$c"; out+="$c" ;;
+        esac
+    done
+    printf '%s' "$out"
+}
+
 _nut_cache_path() {
-    local check="${1:-}" file="${2:-}" flat
+    local check="${1:-}" file="${2:-}"
     [[ -n "$check" && -n "$file" ]] || return 1
-    flat="${file//\//_}"
-    flat="${flat//[^A-Za-z0-9._-]/_}"
-    printf '%s/%s/%s' "$(_nut_cache_root)" "${check//[^A-Za-z0-9._-]/_}" "$flat"
+    printf '%s/%s/%s' "$(_nut_cache_root)" \
+        "$(_nut_cache_escape "$check")" "$(_nut_cache_escape "$file")"
+}
+
+# Everything an entry's freshness depends on, as one line.
+_nut_cache_key() {
+    local file="${1:-}" src="${NUT_CACHE_CHECKER:-}" cfg="${CONFIG_FILE:-}"
+    local sf sc sg
+    sf="$(_nut_cache_stamp_of "$file")" || return 1
+    sc="$(_nut_cache_stamp_of "$src")"  || return 1
+    sg="$(_nut_cache_stamp_of "$cfg")"  || return 1
+    printf '%s|%s|%s|%s' "$(_nut_cache_base)" "$sf" "$sc" "$sg"
 }
 
 #[pub]
 # Is there an answer for this file that nothing has invalidated?
 #
-# Fresh means newer than the file, newer than the check that produced it, and
-# newer than the config the thresholds came from. Any of the three moving means
-# the answer could be different and has to be worked out again.
+# Every input has to be exactly as it was: the file, the check script, the
+# config, the interpreter, and the entry format. Any of them unreadable is a
+# miss rather than a hit, because an input that cannot be checked has not been
+# checked.
+#
+# `NUT_CACHE_CHECKER` and `CONFIG_FILE` are both required. The config used to
+# be tested only when the variable happened to be set, so an unset one skipped
+# the test and the entry hit anyway.
 # Usage: nut_cache_hit <check> <file> -> returns 0 on a usable answer
 nut_cache_hit() {
     [[ "${NUT_CACHE_ENABLED:-0}" == "1" ]] || return 1
-    local check="${1:-}" file="${2:-}" entry
+    local check="${1:-}" file="${2:-}" entry want have
     entry="$(_nut_cache_path "$check" "$file")" || return 1
     [[ -f "$entry" ]] || return 1
-    [[ -e "$file" ]] || return 1
-    [[ "$entry" -nt "$file" ]] || return 1
-
-    # The check itself. Named by the caller, because only it knows which file
-    # it is; a check that does not say cannot be cached.
-    local src="${NUT_CACHE_CHECKER:-}"
-    [[ -n "$src" && -e "$src" ]] || return 1
-    [[ "$entry" -nt "$src" ]] || return 1
-
-    # And the thresholds it measured against.
-    if [[ -n "${CONFIG_FILE:-}" && -e "${CONFIG_FILE}" ]]; then
-        [[ "$entry" -nt "$CONFIG_FILE" ]] || return 1
-    fi
-    return 0
+    want="$(_nut_cache_key "$file")" || return 1
+    IFS= read -r have < "$entry" 2>/dev/null || return 1
+    [[ "$have" == "$want" ]]
 }
 
 #[pub]
-# The answer that was kept. Nothing, and non-zero, when there is none.
+# The answer that was kept, without its stamp line.
 # Usage: nut_cache_read <check> <file> -> prints what was cached
 nut_cache_read() {
     local entry; entry="$(_nut_cache_path "$1" "$2")" || return 1
     [[ -r "$entry" ]] || return 1
-    cat "$entry"
+    tail -n +2 "$entry"
 }
 
 #[pub]
-# Keep an answer. A failure to write is not a failure of the check: the run
-# still has the answer, it just will not have it next time.
+# Keep an answer, with the stamp of everything it depended on. A failure to
+# write is not a failure of the check: the run still has the answer, it just
+# will not have it next time.
 # Usage: nut_cache_write <check> <file> <findings>
 nut_cache_write() {
     [[ "${NUT_CACHE_ENABLED:-0}" == "1" ]] || return 0
-    local entry; entry="$(_nut_cache_path "$1" "$2")" || return 0
+    local entry key
+    entry="$(_nut_cache_path "$1" "$2")" || return 0
+    key="$(_nut_cache_key "$2")" || return 0
     mkdir -p "${entry%/*}" 2>/dev/null || return 0
-    printf '%s' "${3:-}" > "$entry" 2>/dev/null || return 0
+    { printf '%s\n' "$key"; printf '%s' "${3:-}"; } > "$entry" 2>/dev/null || return 0
     return 0
 }
 
@@ -121,7 +213,7 @@ nut_cache_write() {
 nut_cache_clear() {
     local root; root="$(_nut_cache_root)"
     if [[ -n "${1:-}" ]]; then
-        rm -rf "${root}/${1//[^A-Za-z0-9._-]/_}"
+        rm -rf "${root}/$(_nut_cache_escape "$1")"
     else
         rm -rf "$root"
     fi

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -319,6 +319,12 @@ _extern_guard() {
     local dir="$1"; shift
     local lock="${dir}.lock" waited=0
 
+    # The parent, first. `mkdir "$lock"` is the lock, so it must not have a
+    # second reason to fail: a missing parent directory failed it exactly the
+    # way contention does, and the loop below then waited out the full eleven
+    # minutes for a lock nobody was holding.
+    mkdir -p "${lock%/*}" 2>/dev/null || true
+
     while ! mkdir "$lock" 2>/dev/null; do
         # Ready means ready, so a waiter never returns a half-written tree.
         _extern_is_repo "$dir" && return 0
@@ -351,7 +357,15 @@ _extern_guard() {
         fi
     done
 
-    printf '%s' "$$" > "${lock}/pid" 2>/dev/null
+    # `$BASHPID`, not `$$`.
+    #
+    # This runs inside a command substitution: `init` calls `extern_resolve`
+    # in `$( )`, which calls `extern_path`, which calls this. `$$` in a
+    # subshell is the *parent's* pid, so the lock recorded a process that
+    # outlives the one holding it. A subshell that died mid-clone left a lock
+    # naming a pid that `kill -0` still says is alive, and the takeover branch
+    # below never fired: the next process sat out the full wait instead.
+    printf '%s' "$BASHPID" > "${lock}/pid" 2>/dev/null
 
     local rc=0
     if ! _extern_is_repo "$dir"; then

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -178,6 +178,17 @@ extern_declared() {
 # git will answer for them. None of that can change while a script runs, and a
 # program taking five modules out of one library paid it five times -- about
 # four hundred milliseconds before anything of its own happened.
+# What has been resolved this process.
+#
+# It reads as a working memo and has never been one: everything that writes to
+# it is reached through a command substitution, so the assignment happens in a
+# subshell and is gone when that returns. The per-process property callers
+# actually get comes from `init`'s loaded-module table short-circuiting the
+# `use` before this is reached.
+#
+# Left in place rather than deleted, because `extern_forget` is a public door
+# onto it and removing that is a change for consumers. Marked so the next
+# person to optimise this path does not find it and believe it.
 declare -gA _EXTERN_RESOLVED=()
 
 #[pub]

--- a/lib/priv.sh
+++ b/lib/priv.sh
@@ -153,14 +153,19 @@ priv_as_user() {
         return $?
     fi
 
+    # `doas` is in here because `priv_run` already handles it. Without it a
+    # machine that can elevate cannot step back down, which is precisely the
+    # failure this function exists to prevent: OpenBSD and some Alpine
+    # installs carry doas and none of the other three.
     local c
-    for c in runuser sudo su; do
+    for c in runuser sudo doas su; do
         command -v "$c" >/dev/null 2>&1 || continue
         case "$c" in
             # runuser is the one built for this: root to another user, no
             # password, no login shell in the way.
             runuser) runuser -u "$u" -- "$@"; return $? ;;
             sudo)    sudo -n -u "$u" -- "$@"; return $? ;;
+            doas)    doas -u "$u" -- "$@"; return $? ;;
             # Last, and through a shell, so the arguments have to be quoted
             # back into one string. Every other route avoids that.
             su)
@@ -175,7 +180,7 @@ priv_as_user() {
         esac
     done
 
-    log_error "${what}: cannot step down to ${u}; there is no runuser, sudo or su"
+    log_error "${what}: cannot step down to ${u}; there is no runuser, sudo, doas or su"
     return 2
 }
 

--- a/lib/srcfile.sh
+++ b/lib/srcfile.sh
@@ -22,6 +22,9 @@
 [[ -n "${_NUTSHELL_SRCFILE_SH:-}" ]] && return 0
 readonly _NUTSHELL_SRCFILE_SH=1
 
+# For `ATTR_DEFINES_PATTERN`: one answer about what a definition is.
+use attr
+
 declare -gA _NUT_FILE_BODY=()
 declare -gA _NUT_FILE_AT=()
 declare -gA _NUT_FILE_N=()
@@ -46,8 +49,12 @@ nut_load_file() {
     for (( i = 0; i < ${#lines[@]}; i++ )); do
         line="${lines[$i]}"
         _NUT_FILE_BODY["${file}:$((i + 1))"]="$line"
-        if [[ "$line" =~ ^[[:space:]]*(function[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_-]*)[[:space:]]*\( ]]; then
-            name="${BASH_REMATCH[2]}"
+        # The shared pattern, so a definition means the same thing here as it
+        # does to `attr`. The two had drifted: this one missed
+        # `function name {` and that one missed both a hyphen and a space
+        # before the parentheses.
+        if [[ "$line" =~ $ATTR_DEFINES_PATTERN ]]; then
+            name="${BASH_REMATCH[2]:-${BASH_REMATCH[3]}}"
             [[ -n "${_NUT_FILE_AT["${file}:${name}"]:-}" ]] \
                 || _NUT_FILE_AT["${file}:${name}"]=$((i + 1))
         fi

--- a/tests/attr_test.sh
+++ b/tests/attr_test.sh
@@ -105,3 +105,88 @@ it_still_reads_an_attribute_with_an_argument_out_of_a_real_file() {
     assert_eq "$(attr_find "$d/x.sh" pub)" "big_fn"
     rm -rf "$d"
 }
+
+# --- one answer about what a definition is ------------------------------------
+#
+# bash accepts several spellings and this module took one of them, so a
+# `#[pub]` on any of the others was invisible and the public-API check skipped
+# those functions in silence rather than reporting them undocumented.
+#
+# `srcfile` had its own pattern for the same question and the two had already
+# drifted: this one took no hyphen and no `function` keyword, that one took
+# both. They share `ATTR_DEFINES_PATTERN` now.
+
+_ad_file() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-defines.XXXXXX")"
+    cat > "$d/f.sh" <<'EOS'
+#[pub]
+function old_style {
+  :
+}
+#[pub]
+function with_parens() {
+  :
+}
+#[pub]
+spaced_paren ()
+{
+  :
+}
+#[pub]
+has-hyphen() { :; }
+#[pub]
+plain() { :; }
+not_marked() { :; }
+EOS
+    printf '%s' "$d"
+}
+
+#[test]
+it_reads_every_spelling_bash_accepts_for_a_definition() {
+    local d; d="$(_ad_file)"
+    local n
+    for n in old_style with_parens spaced_paren has-hyphen plain; do
+        assert_ok attr_has "$d/f.sh" "$n" pub
+    done
+    rm -rf "$d"
+}
+
+#[test]
+it_finds_all_of_them_and_not_the_unmarked_one() {
+    local d; d="$(_ad_file)"
+    local found; found="$(attr_find "$d/f.sh" pub | sort | tr '\n' ' ')"
+    assert_contains "$found" "old_style"
+    assert_contains "$found" "with_parens"
+    assert_contains "$found" "spaced_paren"
+    assert_contains "$found" "has-hyphen"
+    assert_contains "$found" "plain"
+    # The control: a function with no attribute is not swept up by widening
+    # what counts as a definition.
+    assert_fails grep -q 'not_marked' <<<"$found"
+    rm -rf "$d"
+}
+
+#[test]
+it_gives_the_same_answer_as_srcfile_for_every_line() {
+    # The divergence, as its own case. Two readers of one question have to
+    # agree, and these two did not.
+    use srcfile
+    local d; d="$(_ad_file)"
+    nut_load_file "$d/f.sh"
+    local n
+    for n in old_style with_parens spaced_paren has-hyphen plain; do
+        assert_ok attr_has "$d/f.sh" "$n" pub
+        assert_ok nut_defined_at "$d/f.sh" "$n"
+    done
+    rm -rf "$d"
+}
+
+#[test]
+it_says_nothing_for_a_line_that_defines_nothing() {
+    assert_fails attr_defines_on 'x=1'
+    assert_fails attr_defines_on '# plain() { :; }'
+    assert_fails attr_defines_on ''
+    assert_fails attr_defines_on '  if foo(); then'
+    assert_eq "$(attr_defines_on 'plain() { :; }')" "plain"
+    assert_eq "$(attr_defines_on 'function old_style {')" "old_style"
+}

--- a/tests/branch_test.sh
+++ b/tests/branch_test.sh
@@ -269,3 +269,47 @@ it_says_a_slashed_ref_is_a_name_problem_and_not_a_network_one() {
     assert_fails grep -q "could not reach" <<<"$said"
     _br_end
 }
+
+#[test]
+it_keeps_a_revision_something_is_still_using() {
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    local old; old="$(_br_head)"
+
+    # Aged past the prune's cutoff, as a long-running program's revision would
+    # be: modules load lazily through `use`, so a program started three days
+    # ago still holds its revision, and reading files inside a directory does
+    # not move the directory's mtime.
+    touch -t "$(date -v-2d +%Y%m%d%H%M 2>/dev/null || date -d '2 days ago' +%Y%m%d%H%M)" \
+        "$(_br_base)/$old"
+
+    # Something resolves to it again, which is what a running program does.
+    NUTSHELL_BRANCH_TTL=9999 nutshell_find "" dev >/dev/null 2>&1
+
+    # Now somebody else's push moves the head and prunes.
+    _br_move second
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+
+    # The old revision survives, because it was used within the day even though
+    # it was fetched days ago. Deleting it pulled the floor out from under a
+    # running program and every later `use` in it failed.
+    assert_ok test -f "$(_br_base)/$old/init"
+    _br_end
+}
+
+#[test]
+it_still_drops_a_revision_nothing_has_used() {
+    # The control for the one above. Touch-on-use must not turn the prune off.
+    _br_setup; _br_remote dev 0.4.0
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev
+    local old; old="$(_br_head)"
+    _br_move second
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+    # Aged after the last resolution, so nothing has used it since.
+    touch -t "$(date -v-2d +%Y%m%d%H%M 2>/dev/null || date -d '2 days ago' +%Y%m%d%H%M)" \
+        "$(_br_base)/$old"
+    _br_move third
+    NUTSHELL_BRANCH_TTL=0 nutshell_find "" dev 2>/dev/null
+    assert_fails test -d "$(_br_base)/$old"
+    _br_end
+}

--- a/tests/check_reporting_test.sh
+++ b/tests/check_reporting_test.sh
@@ -123,3 +123,59 @@ exit_with_status')"
     _crp_run "$d" >/dev/null
     assert_eq "$(grep -c . "$d/ran.log" 2>/dev/null || printf 0)" "1"
 }
+
+
+# --- a check sourced into this process must not inherit it ---------------------
+#
+# The runner sources a check with the nutshell shebang into a subshell rather
+# than starting eight interpreters. All eight built-in checks take that branch
+# and every fixture in this file used `#!/usr/bin/env bash`, so the branch that
+# runs in production had no coverage at all.
+
+# A project whose check carries the nutshell shebang, which is the branch the
+# built-in checks take.
+_crp_nut_project() {
+    local name="$1" body="$2"
+    local d="$_CRP_TMP/$name"
+    mkdir -p "$d/checks"
+    printf '[qa]\ncustom_checks = ["checks/probe.sh"]\nrun_builtins = false\n' > "$d/nut.toml"
+    printf '#!/usr/bin/env nutshell\n%s\n' "$body" > "$d/checks/probe.sh"
+    chmod +x "$d/checks/probe.sh"
+    printf '%s' "$d"
+}
+
+#[test]
+it_gives_a_sourced_check_no_arguments_of_its_own() {
+    local d; d="$(_crp_nut_project args '
+if [[ $# -ne 0 ]]; then
+    printf "  ✗ inherited %s argument(s): %s\n" "$#" "$*"
+    exit 1
+fi
+exit 0')"
+    local out; out="$(_crp_run "$d")"
+    # It used to get the runner's `$1` and `$2`: the check path and its display
+    # name. Any check reading `$1` or `$@` was operating on itself.
+    assert_fails grep -q 'inherited' <<<"$out"
+    assert_contains "$out" "✓"
+}
+
+#[test]
+it_runs_a_sourced_check_at_all() {
+    # The control for the one above: the nutshell-shebang branch is genuinely
+    # taken and its exit code is genuinely read.
+    local d; d="$(_crp_nut_project taken '
+printf "  ✗ this check ran and failed on purpose\n"
+exit 1')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "ran and failed on purpose"
+}
+
+#[test]
+it_reports_a_sourced_checks_warnings_through_its_exit_code() {
+    local d; d="$(_crp_nut_project warned '
+use check-runner
+TESTS_WARNED=1
+exit_with_status')"
+    local out; out="$(_crp_run "$d")"
+    assert_contains "$out" "⚠"
+}

--- a/tests/checkcache_test.sh
+++ b/tests/checkcache_test.sh
@@ -132,11 +132,102 @@ it_can_be_thrown_away() {
 }
 
 #[test]
-it_does_not_let_a_path_escape_the_cache_directory() {
+it_keeps_every_computed_entry_inside_the_cache_directory() {
     _cc_setup
-    local outside="$CCROOT/outside"; mkdir -p "$outside"; printf 'keep\n' > "$outside/f"
-    nut_cache_write '../../outside' '../../outside/f' 'nope'
-    assert_ok test -f "$outside/f"
-    assert_eq "$(cat "$outside/f")" "keep"
+    local root; root="$(_nut_cache_root)"
+    local name entry
+    # The old version of this asserted a file outside was not overwritten,
+    # which held for every possible argument because the substitution had
+    # already removed every `/`. It read as a security test and restated a
+    # substitution. This asserts the computed path instead, over names chosen
+    # to escape if anything could.
+    for name in '../../etc/passwd' '/etc/passwd' '..' '.' '-rf' \
+                'a/b/../../../c' "$(printf 'new\nline')" '$(touch /tmp/nut-pwn)' \
+                '~/x' 'a b' "*"; do
+        entry="$(_nut_cache_path probe "$name")" || continue
+        assert_contains "$entry" "$root"
+        assert_fails grep -q '/\.\./' <<<"$entry"
+    done
+    assert_fails test -e /tmp/nut-pwn
+    _cc_end
+}
+
+#[test]
+it_does_not_give_one_file_the_answer_meant_for_another() {
+    _cc_setup
+    # Flattening every separator to `_` mapped `lib/toml/json.sh` and
+    # `lib/toml_json.sh` onto one entry, so the answer for one was served for
+    # the other. Both exist in this repository.
+    printf 'one\n' > "$CCROOT/a.sh"; printf 'two\n' > "$CCROOT/b.sh"
+    sleep 1
+    nut_cache_write probe "$CCROOT/a.sh" "answer for a"
+    assert_ne "$(_nut_cache_path probe 'lib/toml/json.sh')" \
+              "$(_nut_cache_path probe 'lib/toml_json.sh')"
+    assert_fails nut_cache_hit probe "$CCROOT/b.sh"
+    _cc_end
+}
+
+#[test]
+it_forgets_when_a_file_changes_without_its_time_moving_forward() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'FINDING: none'
+    # `tar -x`, `rsync -a`, `cp -p` and `touch -t` all move mtime backwards,
+    # and `-nt` only sees it move forward. Reproduced before this was fixed:
+    # the cache served "no findings" for a file whose contents had been
+    # replaced wholesale, which is the one direction a cache must not be wrong.
+    printf 'COMPLETELY DIFFERENT AND LONGER\n' > "$CCROOT/src.sh"
+    touch -t 200001010000 "$CCROOT/src.sh"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_forgets_when_the_file_changes_size_but_not_its_time() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    local when; when="$(stat -f '%Sm' -t '%Y%m%d%H%M.%S' "$CCROOT/src.sh" 2>/dev/null                         || stat -c '%y' "$CCROOT/src.sh")"
+    printf 'a much longer line than before\n' > "$CCROOT/src.sh"
+    touch -t 200001010000 "$CCROOT/src.sh"
+    # Size alone is enough to know it moved.
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_forgets_when_a_module_the_check_uses_changes() {
+    _cc_setup
+    # A check is not one file. `check_trivial_wrappers` gets its behaviour from
+    # `lib/srcfile.sh`, so editing that changes what it reports while touching
+    # neither the check nor the config. op's ruling is that a check gaining a
+    # step reads everything again.
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    assert_ok nut_cache_hit probe "$CCROOT/src.sh"
+    # The interpreter's own stamp is part of the key, so moving it is a miss.
+    _NUT_CACHE_BASE="f2:something-else"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_refuses_a_hit_when_the_config_is_not_named_at_all() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    unset CONFIG_FILE
+    # The config test used to sit inside `if [[ -n "$CONFIG_FILE" ]]`, so an
+    # unset one skipped it and the entry hit anyway, while the header said
+    # freshness meant newer than the config.
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+    _cc_end
+}
+
+#[test]
+it_refuses_an_entry_written_in_an_older_format() {
+    _cc_setup
+    nut_cache_write probe "$CCROOT/src.sh" 'answer'
+    local entry; entry="$(_nut_cache_path probe "$CCROOT/src.sh")"
+    # The store is shared by every nutshell on the machine. An entry from a
+    # version that meant something else by its stamp is a miss, not a lie.
+    { printf 'f1:whatever|0 0|0 0|0 0\n'; printf 'stale answer'; } > "$entry"
+    assert_fails nut_cache_hit probe "$CCROOT/src.sh"
     _cc_end
 }

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -374,6 +374,57 @@ it_takes_over_a_lock_whose_holder_died() {
 }
 
 #[test]
+it_records_the_pid_of_the_process_that_actually_holds_the_lock() {
+    # The guard runs inside a command substitution: `init` calls
+    # `extern_resolve` in `$( )`, which reaches `extern_path` and then here.
+    # `$$` in a subshell is the *parent's* pid, so the lock recorded a process
+    # that outlives the one holding it. A subshell dying mid-clone then left a
+    # lock naming a pid `kill -0` says is alive, the takeover never fired, and
+    # the next run sat out the whole ten minute clock instead.
+    #
+    # So the property is that the pid in the lock belongs to whoever wrote it.
+    _isolate
+    local fix work dir lock
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    cd "${work}/project" || return 1
+
+    dir="$(_extern_cache_root)/pretend-pid"
+    lock="${dir}.lock"
+    # The store root need not exist yet, and the guard makes it. A missing
+    # parent used to fail `mkdir "$lock"` the same way contention does, so this
+    # waited eleven minutes for a lock nobody held.
+    assert_fails test -d "$lock"
+
+    # Held long enough to read the lock while it exists, from a subshell, which
+    # is how every real caller reaches this.
+    local seen
+    seen="$( _EXTERN_LOCK_WAIT_SECONDS=3 _extern_guard "$dir" bash -c 'cat "$0/pid"' "$lock" )"
+
+    assert_ne "$seen" "" "the guard writes a pid into the lock"
+    assert_ne "$seen" "$$" "and it is not the pid of the shell that will outlive it"
+}
+
+#[test]
+it_still_waits_for_a_lock_whose_holder_is_alive() {
+    # The control for the one above. A live holder is a lock that must not be
+    # taken over, however impatient the next process is, or two clones race
+    # into one directory.
+    _isolate
+    local fix work dir lock
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    cd "${work}/project" || return 1
+
+    dir="$(_extern_cache_root)/pretend-live"
+    lock="${dir}.lock"
+    fs_mkdir "$lock"
+    printf '%s' "$$" > "${lock}/pid"
+
+    local rc=0
+    _EXTERN_LOCK_WAIT_SECONDS=2 _extern_guard "$dir" true || rc=$?
+    assert_ne "$rc" "0" "a live holder is waited for, then reported"
+}
+
+#[test]
 it_resolves_a_namespaced_module_to_a_file() {
     # What a namespaced `use` turns into. Kept separate from loading so the
     # resolution can be asked about without sourcing anything.
@@ -893,4 +944,31 @@ it_makes_no_scratch_directory_outside_its_own_root() {
     stray="$(grep -nE 'mktemp -d[)" ]|fs_temp_dir[ )"]' "${BASH_SOURCE[0]}" \
         | grep -v '_EX_TMP' | grep -v 'self-cleaned' | grep -vE '^[0-9]+: *#' || true)"
     assert_empty "$stray"
+}
+
+#[test]
+it_does_not_wait_out_the_clock_for_a_parent_that_is_merely_absent() {
+    # `mkdir "$lock"` is the lock, and it failed for two different reasons that
+    # looked identical: somebody holds it, or the directory above it is not
+    # there yet. The second waited eleven minutes for a lock nobody held, which
+    # is the whole default wait, on a store that had simply never been used.
+    _isolate
+    local fix work dir
+    fix="$(_extern_fixture)"; work="${fix%% *}"
+    cd "${work}/project" || return 1
+
+    # Deliberately several levels below anything that exists.
+    dir="$(_extern_cache_root)/never/been/here/pretend"
+    assert_fails test -d "$(dirname "$dir")"
+
+    local start end rc=0
+    start="$(date +%s)"
+    _EXTERN_LOCK_WAIT_SECONDS=30 _extern_guard "$dir" git init --quiet "$dir" || rc=$?
+    end="$(date +%s)"
+
+    assert_eq "$rc" "0"
+    # Promptly, rather than after any part of the wait. The wait is set to 30
+    # here and is 660 in production, so the old behaviour blows this by a wide
+    # margin either way.
+    assert_ok test "$(( end - start ))" -lt 5
 }

--- a/tests/priv_test.sh
+++ b/tests/priv_test.sh
@@ -491,3 +491,36 @@ it_does_not_pass_su_a_flag_only_one_su_has() {
     assert_fails grep -qx -- "-s" <<<"$out"
     assert_contains "$out" "somebody"
 }
+
+#[test]
+it_steps_down_with_doas_where_that_is_what_the_machine_has() {
+    _priv_as_root
+    # `priv_run` already elevates with doas. Without the same here, a machine
+    # that can elevate cannot step back down, which is the exact failure this
+    # function exists to prevent. OpenBSD and some Alpine installs carry doas
+    # and none of the other three.
+    _priv_stubs doas
+    local out; out="$(priv_as_user "reading" git status)"
+    _priv_stubs_end; _priv_as_root_end
+    assert_eq "$(head -1 <<<"$out")" "doas"
+    assert_contains "$out" "somebody"
+}
+
+#[test]
+it_prefers_runuser_and_sudo_over_doas() {
+    _priv_as_root
+    _priv_stubs runuser sudo doas su
+    local out; out="$(priv_as_user "reading" git status)"
+    _priv_stubs_end; _priv_as_root_end
+    assert_eq "$(head -1 <<<"$out")" "runuser"
+}
+
+#[test]
+it_names_doas_when_it_cannot_step_down_at_all() {
+    _priv_as_root
+    _priv_stubs
+    local err; err="$(priv_as_user "reading" true 2>&1 >/dev/null)"
+    _priv_stubs_end; _priv_as_root_end
+    # The message lists what it looked for, so a reader knows what to install.
+    assert_contains "$err" "doas"
+}

--- a/tests/toolchain_test.sh
+++ b/tests/toolchain_test.sh
@@ -498,3 +498,55 @@ it_refuses_to_store_a_fetch_whose_version_is_not_the_name_asked_for() {
     assert_fails test -e "$NUTSHELL_TOOLCHAINS/0.4.0-rc1"
     _tc_end
 }
+
+# --- the store root is spelled twice, and only this holds the two together ----
+
+#[test]
+it_derives_the_same_store_root_as_the_xdg_module_does() {
+    # `find-nutshell` runs before nutshell exists and cannot `use xdg`, so the
+    # platform branch is written out in both places. Its own comment says the
+    # two are "held together by a test rather than by anybody remembering",
+    # and no such test existed: `grep -rn xdg_data_home tests/` returned
+    # nothing, and the nearest one restated find-nutshell's own literals back
+    # to it without ever calling the module.
+    #
+    # This calls both and compares, so changing one and not the other fails
+    # here rather than on somebody's machine.
+    local keep_store="${NUTSHELL_STORE:-}" keep_tc="${NUTSHELL_TOOLCHAINS:-}"
+    unset NUTSHELL_STORE NUTSHELL_TOOLCHAINS
+
+    use xdg
+    xdg_set_app_name nutshell
+    local from_module; from_module="$(xdg_app_data)"
+    local from_resolver; from_resolver="$(nutshell_store_root)"
+
+    assert_ne "$from_module" ""
+    assert_eq "$from_resolver" "$from_module"
+
+    [[ -n "$keep_store" ]] && export NUTSHELL_STORE="$keep_store"
+    [[ -n "$keep_tc" ]] && export NUTSHELL_TOOLCHAINS="$keep_tc"
+    return 0
+}
+
+#[test]
+it_follows_the_data_home_override_the_same_way_the_module_does() {
+    # The branch that actually differs between platforms, exercised rather
+    # than assumed: with the variable set, both must follow it.
+    local keep_store="${NUTSHELL_STORE:-}" keep_tc="${NUTSHELL_TOOLCHAINS:-}"
+    unset NUTSHELL_STORE NUTSHELL_TOOLCHAINS
+
+    use xdg
+    local probe="/tmp/nut-xdg-probe"
+    local from_module from_resolver
+    from_module="$(XDG_DATA_HOME="$probe" bash -c '
+        . "'"$PWD"'/init" >/dev/null 2>&1
+        use xdg; xdg_set_app_name nutshell; xdg_app_data')"
+    from_resolver="$(XDG_DATA_HOME="$probe" nutshell_store_root)"
+
+    assert_contains "$from_resolver" "$probe"
+    assert_eq "$from_resolver" "$from_module"
+
+    [[ -n "$keep_store" ]] && export NUTSHELL_STORE="$keep_store"
+    [[ -n "$keep_tc" ]] && export NUTSHELL_TOOLCHAINS="$keep_tc"
+    return 0
+}

--- a/tools/assoc-array-report
+++ b/tools/assoc-array-report
@@ -12,6 +12,13 @@
 # **A report, not a gate.** There is no threshold anybody can justify here; the
 # decision it feeds is a design one.
 #
+# **Two arms are not maps and are labelled so in the table.** `slots by index`
+# and `slots by stride` are what a map becomes once the key has already been
+# resolved: the caller holds the index. They belong here because the gap
+# between them and the arms beside them prices the key lookup, which is the
+# thing a design would be trading away. They are not alternatives to
+# `declare -A` and the table must not read as though they were.
+#
 # **This is not a bench.** nutshell has no bench harness, so this is an ad-hoc
 # measurement and is called that. It does what it can without one: every arm is
 # a real alternative somebody would actually reach for, the arms run on the
@@ -343,13 +350,38 @@ arm_hand_rolled_hash() {
 # Running them
 # -----------------------------------------------------------------------------
 
-_ms() {
-    local fn="$1" start end out
+# One arm, run several times, reported as its best and its spread.
+#
+# A single timing of a 5ms arm is not a measurement. Observed on this machine,
+# four consecutive runs of the same arm at the same size: 5, 5, 35, 5. The
+# ratio column then read 160%, 160%, 25%, 180% for the arm beside it, and the
+# old control passed every time, because it only asked whether *any* arm
+# differed from the first by a millisecond across a set spanning 5ms to 3s.
+#
+# The minimum is the estimator rather than the mean: every source of noise here
+# adds time and none removes it, so the fastest run is the one least disturbed.
+# The spread is kept and printed, because a number without one cannot be
+# compared against another number.
+_REPEATS="${ASSOC_REPEATS:-7}"
+
+_time_once() {
+    local fn="$1" start end
     start="$(date +%s%N 2>/dev/null)" || return 1
-    out="$("$fn")"
+    "$fn" >/dev/null
     end="$(date +%s%N 2>/dev/null)" || return 1
-    _LAST_OUT="$out"
     printf '%s' "$(( (end - start) / 1000000 ))"
+}
+
+# Sets _ARM_BEST and _ARM_WORST.
+_measure() {
+    local fn="$1" i t
+    _ARM_BEST=""; _ARM_WORST=""
+    for (( i = 0; i < _REPEATS; i++ )); do
+        t="$(_time_once "$fn")" || return 1
+        [[ -z "$_ARM_BEST"  || "$t" -lt "$_ARM_BEST"  ]] && _ARM_BEST="$t"
+        [[ -z "$_ARM_WORST" || "$t" -gt "$_ARM_WORST" ]] && _ARM_WORST="$t"
+    done
+    return 0
 }
 
 main() {
@@ -369,25 +401,25 @@ main() {
                      "eval names, encoded in place" "one string, scanned"
                      "one file, read in shell" "one file per key"
                      "one file per key, in memory"
-                     "slots by index, caller holds it"
-                     "slots by stride, three fields"
+                     "slots by index (not a map)"
+                     "slots by stride (not a map)"
                      "hash table rolled by hand")
     # Above these sizes an arm takes long enough that running it stops being
     # worth the wait. Stated per arm rather than hidden, because which arms
     # have a ceiling at all is itself the result: the two that address a key
     # directly have none.
     local -a ceiling=(0 4000 0 800 4000 0 0 0 0 4000)
-    local -a took=()
-    local i t base=""
+    local -a best=() worst=()
+    local i t
 
     for (( i = 0; i < ${#names[@]}; i++ )); do
         if (( ceiling[i] > 0 && ENTRIES > ceiling[i] )); then
-            took+=("-")
+            best+=("-"); worst+=("-")
             continue
         fi
-        t="$(_ms "${names[$i]}")" || { printf 'no nanosecond clock here; cannot measure\n' >&2; return 1; }
-        took+=("$t")
-        [[ -z "$base" ]] && base="$t"
+        _measure "${names[$i]}" || {
+            printf 'no nanosecond clock here; cannot measure\n' >&2; return 1; }
+        best+=("$_ARM_BEST"); worst+=("$_ARM_WORST")
     done
 
     # The control that matters most: every arm has to give the same answers.
@@ -395,7 +427,7 @@ main() {
     # and an arm whose encoding collides two keys would look excellent.
     local want="" got=""
     for (( i = 0; i < ${#names[@]}; i++ )); do
-        [[ "${took[$i]}" == "-" ]] && continue
+        [[ "${best[$i]}" == "-" ]] && continue
         got="$("${names[$i]}")"
         [[ "$got" == "SKIP" ]] && continue
         if [[ -z "$want" ]]; then want="$got"; continue; fi
@@ -406,9 +438,7 @@ main() {
         fi
     done
 
-    # And that the input is distinct enough to be worth answering. An encoding
-    # that maps two real keys onto one name would pass the check above while
-    # holding half the table.
+    # And that the input is distinct enough to be worth answering.
     local -A seen=(); local n
     for (( i = 0; i < ENTRIES; i++ )); do
         n="${KEYS[$i]//[^A-Za-z0-9_]/_}"
@@ -420,32 +450,46 @@ main() {
         return 1
     fi
 
-    # The second control. Every arm answers the same question on the same
-    # input, so if they all take the same time the instrument is measuring
-    # something other than the arms and the numbers below mean nothing.
-    local spread=0
-    for (( i = 1; i < ${#took[@]}; i++ )); do
-        [[ "${took[$i]}" == "-" ]] && continue
-        (( took[i] != took[0] )) && spread=1
-    done
-    if (( spread == 0 )); then
-        printf 'every arm took the same time, so this is not measuring the arms\n' >&2
+    # The baseline has to be steady enough to divide by. This is the control
+    # the old one was missing: it compared arms to each other and never asked
+    # whether the number it divided by meant anything.
+    local base_best="${best[0]}" base_worst="${worst[0]}"
+    if [[ "$base_best" == "-" ]] || (( base_best <= 0 )); then
+        printf 'the baseline did not measure; nothing below can be a ratio\n' >&2
+        return 1
+    fi
+    if (( base_worst > base_best * 2 )); then
+        printf 'the baseline moved from %sms to %sms across %s runs.\n' \
+            "$base_best" "$base_worst" "$_REPEATS" >&2
+        printf 'this machine is too noisy right now for a ratio to mean anything.\n' >&2
+        printf 'raw times only:\n\n' >&2
+        for (( i = 0; i < ${#names[@]}; i++ )); do
+            printf '  %-34s %6s..%-6s\n' "${labels[$i]}" "${best[$i]}" "${worst[$i]}"
+        done
         return 1
     fi
 
-    printf '  %-34s %9s  %s\n' "arm" "ms" "against bash"
+    printf '  %-34s %8s %9s  %s\n' "arm" "best ms" "spread" "against bash"
     for (( i = 0; i < ${#names[@]}; i++ )); do
-        local rel="-"
-        if [[ "${took[$i]}" == "-" ]]; then
-            printf '  %-34s %9s  %s\n' "${labels[$i]}" "-" "not run at this size"
+        if [[ "${best[$i]}" == "-" ]]; then
+            printf '  %-34s %8s %9s  %s\n' "${labels[$i]}" "-" "-" "not run at this size"
             continue
         fi
         if [[ "$("${names[$i]}")" == "SKIP" ]]; then
-            printf '  %-34s %9s  %s\n' "${labels[$i]}" "-" "no memory filesystem here"
+            printf '  %-34s %8s %9s  %s\n' "${labels[$i]}" "-" "-" "no memory filesystem here"
             continue
         fi
-        (( base > 0 )) && rel="$(( took[i] * 100 / base ))%"
-        printf '  %-34s %9s  %s\n' "${labels[$i]}" "${took[$i]}" "$rel"
+        # A ratio only where the two ranges do not overlap. Where they do, the
+        # arms are not distinguishable at this size and saying so is the
+        # honest answer.
+        local rel
+        if (( best[i] > base_worst )) || (( worst[i] < base_best )); then
+            rel="$(( best[i] * 100 / base_best ))%"
+        else
+            rel="within the noise"
+        fi
+        printf '  %-34s %8s %9s  %s\n' \
+            "${labels[$i]}" "${best[$i]}" "${best[$i]}..${worst[$i]}" "$rel"
     done
 
     printf '\n'


### PR DESCRIPTION
`docs/TODO.md` opens with "Four items block a release" and three of them were
still live while a release was being cut. The rest is what a review of that
release PR turned up.

## The declared blockers

**`init` exited 0 after failing on bash 3.** Measured on 3.2.57, which is what
macOS ships at `/bin/bash`:

```
init: line 51: declare: -A: invalid option
init: line 53: declare: -A: invalid option
init: line 117: extern: unbound variable
EXIT=0
```

The `|| declare -A` fallback needs bash 4 too, so `_NUTSHELL_LOADED` was not an
associative array and the first `use` evaluated a module name as arithmetic. A
Makefile or CI read exit 0. There is a refusal in `init` and in `bin/nutshell`
now, before anything that needs the floor, and it exits 1. Spelled through
`case` on `$BASH_VERSION` so the block itself parses under bash 3 and under any
sh.

**The extern lock recorded the wrong pid.** The guard runs inside a command
substitution, so `$$` was the parent's: a subshell dying mid-clone left a lock
naming a process that is still alive, the takeover never fired, and the next
run sat out the full eleven minutes. `$BASHPID`, which is the one word the note
asks for. The test it names fed the one input the code already handled, so the
branch that is actually produced was never entered.

And a third thing fell out of writing that test: `mkdir "$lock"` is the lock,
so it must not have a second reason to fail, and a **missing parent directory
failed it exactly the way contention does**. A store that had never been used
waited eleven minutes for a lock nobody held.

## What the review found

- **the cache served stale answers as fresh.** `-nt` only sees mtime move
  forward, and `tar -x`, `rsync -a`, `cp -p` and `touch -t` all move it back.
  Reproduced: contents replaced wholesale, mtime set to 2000, and it served
  "no findings". An entry records its inputs now and every one must match,
  including the interpreter's own stamp, because a check is not one file
- **six of that cache's twelve tests could not have caught any of it.** Every
  invalidation case moved its input *forward*, which is the direction the code
  handled, and the escape test restated a substitution
- **a sourced check inherited the runner's arguments**, getting `$1` as its own
  path and `$2` as its display name. All eight built-in checks take that branch
  and it had no test coverage at all
- **the prune could delete a revision a running program was using.** Reading
  files does not move a directory's mtime, so age measured time since fetch,
  not since use. Every resolution touches now
- **the readme argued with itself**, teaching the vendored copy in ten places
  under a section headed "Do not carry a copy in the tree", and naming
  `git_is_clean`, which has never existed
- **the measurement tool's control could not fail.** Its baseline moved 5, 5,
  35, 5 across four runs while the ratio column read 160%, 160%, 25%, 180%.
  Seven repeats, best and spread, and no ratio where the ranges overlap
- **`attr` saw one of the spellings bash accepts for a definition**, so a
  `#[pub]` on `function old_style {` or `spaced_paren ()` or a hyphenated name
  was invisible. It and `srcfile` share one pattern now
- **`priv_as_user` had no `doas`** while `priv_run` does, so a machine that
  could elevate could not step back down

## Sanity

`./test` is 517, up from 494. `./check` is unchanged in verdict.

Every fix has a case that fails without it, and the ones that matter were
written by reproducing the defect first: the bash 3 exit code, the stale cache
hit, the argument leak, the deleted revision, the unstable baseline.