### PR TITLE
fix: the five the release review still wanted

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -LO https://raw.githubusercontent.com/orgrinrt/nutshell/main/find-nutshell
 HERE="${BASH_SOURCE[0]%/*}"
 . "$HERE/find-nutshell"
 nutshell_find "$HERE" dev || exit 1    # a version, or a branch
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 ```
 
 It takes what the caller named, then what is installed if that satisfies, then
@@ -134,12 +134,18 @@ resolver instead and let it find one:
 HERE="${BASH_SOURCE[0]%/*}"
 . "$HERE/find-nutshell"
 nutshell_find "$HERE" dev || exit 1
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 
 use os log
 
 log_info "hello"
 ```
+
+Both source lines end in `|| exit 1`, and that is not decoration. Sourcing
+`init` can fail: on a bash older than 4 it refuses, and a `return` inside a
+sourced file returns *to* the caller rather than stopping it. Without the
+check, a script prints the refusal and then runs its whole body with nothing
+loaded, reporting success.
 
 That second form is what a project carries when it pins a version, and
 `find-nutshell` is the only file it needs beside its own source. There is no
@@ -211,7 +217,7 @@ Each script is independent. Each one has the init line:
 ```bash
 #!/usr/bin/env bash
 # scripts/build.sh
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 
 use os log fs
 
@@ -229,7 +235,7 @@ One script bootstraps, others use the clean shebang:
 ```bash
 #!/usr/bin/env bash
 # scripts/main.sh - The entry point
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 
 # PATH is already set by init, so internal scripts can use nutshell shebang
 "${0%/*}/internal/build.sh" "$@"
@@ -516,7 +522,7 @@ happens.
 ```bash
 #!/usr/bin/env bash
 # scripts/build.sh
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 
 use os log deps fs
 
@@ -543,7 +549,7 @@ log_success "Build complete!"
 ```bash
 #!/usr/bin/env bash
 # scripts/fetch-data.sh
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 
 use log http json
 
@@ -566,7 +572,7 @@ fi
 ```bash
 #!/usr/bin/env bash
 # scripts/install.sh
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 
 use log prompt fs color
 
@@ -594,7 +600,7 @@ log_success "Installation complete!"
 Every script needs this line:
 
 ```bash
-. "$NUTSHELL_INIT"
+. "$NUTSHELL_INIT" || exit 1
 ```
 
 Breaking it down:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3,6 +3,28 @@
 ## Release blockers, from the 2026-08-14 dev-to-main readiness review
 
 Four items block a release. `./release` already refuses on the third. Findings are a reviewer's and the
+## The QA gate is fourteen seconds and op wants two
+
+Open, and recorded here because the target otherwise lives only in a state file
+that is current-only and gets overwritten.
+
+op called the gate untenable at 250 seconds and again at 37. It is 14.4 now,
+measured, on 24 files. His bar, verbatim:
+
+> We should be looking at sub 2 seconds for 24 files realistically.
+> tree-sitter based deno project can do it in milliseconds.
+
+What got it from 250 to 14 was removing forks: `lib/attr.sh` was piping every
+line of every file through `sed`, a config key was re-read per passing check
+from inside a subshell where the cache could not survive, the name-similarity
+comparison filled a whole edit-distance matrix when three rows settled it, and
+the eight checks were eight interpreter startups with eight cold caches.
+
+What is left is flat, with no hot spot, so more of the same is not the answer.
+The two candidates are `NUT_CACHE=1` being on by default once it has been
+trusted for a while, which takes a warm run to 9s, and not re-reading the same
+two dozen files in each of eight checks.
+
 two probes behind items 1 and 2 were written read-only, so **commit them alongside the fix**: until then
 these are reproducible claims rather than repo evidence.
 

--- a/init
+++ b/init
@@ -37,11 +37,14 @@ _nutshell_refuse_old_bash() {
     printf '  first on PATH, or run this under it directly.\n' >&2
 }
 
+# `return` here returns to whoever sourced this and cannot stop them, so the
+# caller has to check. Every example in the readme ends its source line in
+# `|| exit 1` for that reason, and both consumers do the same.
 case "${BASH_VERSION:-}" in
-    "")        _nutshell_refuse_old_bash; return 1 2>/dev/null || exit 1 ;;
-    1.*|2.*|3.*) _nutshell_refuse_old_bash; return 1 2>/dev/null || exit 1 ;;
+    ""|1.*|2.*|3.*)
+        _nutshell_refuse_old_bash
+        return 1 2>/dev/null || exit 1 ;;
 esac
-
 # Prevent multiple inclusion
 [[ -n "${_NUTSHELL_INIT:-}" ]] && return 0
 _NUTSHELL_INIT=1

--- a/lib/checkcache.sh
+++ b/lib/checkcache.sh
@@ -69,10 +69,18 @@ declare -g  _NUT_CACHE_BASE=""
 
 # `<mtime> <size>` for a set of paths, in one call.
 _nut_cache_stat_into() {
-    local out line path
+    local line mtime size path
     while IFS= read -r line; do
         [[ -n "$line" ]] || continue
-        _NUT_CACHE_STAMP["${line#* * }"]="${line%% * *} ${line#* }"
+        # `<mtime> <size> <path>`, split from the front. Taking the size with
+        # `${v##* }` takes the last field, which is the path, so the size was
+        # stat'd and then thrown away and a content change landing on the same
+        # mtime hit. Two `git checkout`s inside one second do that, and so does
+        # `touch -r`.
+        mtime="${line%% *}"; line="${line#* }"
+        size="${line%% *}";  path="${line#* }"
+        [[ -n "$path" ]] || continue
+        _NUT_CACHE_STAMP["$path"]="${mtime} ${size}"
     done < <(
         if stat -f '%m %z %N' "$@" 2>/dev/null; then :
         else stat -c '%Y %s %n' "$@" 2>/dev/null; fi
@@ -90,7 +98,8 @@ _nut_cache_stamp_of() {
         v="${_NUT_CACHE_STAMP[$p]:-}"
     fi
     [[ -n "$v" ]] || return 1
-    printf '%s' "${v%% *} ${v##* }"
+    # Already `<mtime> <size>`; there is nothing to re-parse out of it.
+    printf '%s' "$v"
 }
 
 # What every entry shares: the interpreter's newest file and the format.
@@ -102,12 +111,18 @@ _nut_cache_base() {
     [[ -n "$_NUT_CACHE_BASE" ]] && { printf '%s' "$_NUT_CACHE_BASE"; return 0; }
     local root="${NUTSHELL_ROOT:-}" newest=""
     if [[ -n "$root" && -d "$root/lib" ]]; then
-        newest="$(find "$root/lib" -type f -newer "$root/lib" -print 2>/dev/null | head -1)"
+        # The newest *file*, not the directory's own mtime. A directory's mtime
+        # moves when an entry is added or removed and not when a file inside it
+        # is edited, so stat'ing `lib` caught `git pull` and a new module and
+        # missed the case this exists for: editing `lib/srcfile.sh` in place
+        # changes what a check reports while touching nothing else.
+        #
+        # One `find` and one batched `stat`, per run rather than per file.
         newest="$(
-            if stat -f '%m' "$root/lib" "$root/init" 2>/dev/null; then :
-            else stat -c '%Y' "$root/lib" "$root/init" 2>/dev/null; fi
+            find "$root/lib" "$root/init" -type f -exec stat -f '%m' {} + 2>/dev/null \
+            || find "$root/lib" "$root/init" -type f -exec stat -c '%Y' {} + 2>/dev/null
         )"
-        newest="${newest//$'\n'/-}"
+        newest="$(printf '%s\n' "$newest" | sort -rn | head -1)"
     fi
     _NUT_CACHE_BASE="f${_NUT_CACHE_FORMAT}:${newest:-none}"
     printf '%s' "$_NUT_CACHE_BASE"

--- a/release
+++ b/release
@@ -43,12 +43,35 @@ main() {
         return 1
     fi
 
-    # init is the single home of the version, so the tag cannot disagree
-    # with what the library reports about itself.
-    local version="${NUTSHELL_VERSION}"
-    if git rev-parse -q --verify "refs/tags/${version}" >/dev/null; then
-        log_error "tag ${version} already exists; bump NUTSHELL_VERSION in init"
+    # The tag is the version, and it is named here rather than read out of the
+    # library.
+    #
+    # `init`'s `NUTSHELL_VERSION` is a constant somebody has to remember to
+    # bump, and `docs/TODO.md` records op's ruling that identity comes from git
+    # and that the constant goes. This script used to take the version from it
+    # and call that "the single home of the version", which would have made the
+    # constant load-bearing for the release process as well as for resolution,
+    # so deleting it later would break this too. It is interim; nothing new
+    # depends on it.
+    local version="${1:-}"
+    if [[ -z "$version" ]]; then
+        log_error "which version? pass it: release <version>"
+        log_error "the newest tag is $(git describe --tags --abbrev=0 2>/dev/null || printf 'none')"
         return 1
+    fi
+    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+        log_error "${version} is not a version"
+        return 1
+    fi
+    if git rev-parse -q --verify "refs/tags/${version}" >/dev/null; then
+        log_error "tag ${version} already exists"
+        return 1
+    fi
+    # Said rather than enforced: the constant is still what a consumer's
+    # `nutshell_at_least` compares against until the pinning work lands.
+    if [[ "${NUTSHELL_VERSION:-}" != "$version" ]]; then
+        log_warn "init says ${NUTSHELL_VERSION:-nothing} and this tags ${version}"
+        log_warn "until git carries the identity, those want to agree"
     fi
 
     # The gates. A release does not skip what a commit would not.

--- a/tests/checkcache_test.sh
+++ b/tests/checkcache_test.sh
@@ -182,29 +182,63 @@ it_forgets_when_a_file_changes_without_its_time_moving_forward() {
 }
 
 #[test]
-it_forgets_when_the_file_changes_size_but_not_its_time() {
+it_forgets_when_the_content_changes_and_the_time_does_not() {
     _cc_setup
+    # A reference whose mtime the file is restored to, so the only thing that
+    # moves is the content and its size. Two `git checkout`s inside one second
+    # do this, and so does `touch -r` and any build step that restores times.
+    #
+    # The previous version of this test moved the mtime *backward*, which is
+    # what the test above it already covers, so it passed on a key the size was
+    # not actually in. The size was stat'd and then discarded by a `${v##* }`
+    # that took the path.
+    local ref="$CCROOT/ref"; printf 'r\n' > "$ref"
+    touch -r "$ref" "$CCROOT/src.sh"
     nut_cache_write probe "$CCROOT/src.sh" 'answer'
-    local when; when="$(stat -f '%Sm' -t '%Y%m%d%H%M.%S' "$CCROOT/src.sh" 2>/dev/null                         || stat -c '%y' "$CCROOT/src.sh")"
+    assert_ok nut_cache_hit probe "$CCROOT/src.sh"
+
     printf 'a much longer line than before\n' > "$CCROOT/src.sh"
-    touch -t 200001010000 "$CCROOT/src.sh"
-    # Size alone is enough to know it moved.
+    touch -r "$ref" "$CCROOT/src.sh"
+
+    # Same mtime, different size.
     assert_fails nut_cache_hit probe "$CCROOT/src.sh"
     _cc_end
 }
 
 #[test]
-it_forgets_when_a_module_the_check_uses_changes() {
+it_forgets_when_a_module_the_check_uses_is_edited_in_place() {
     _cc_setup
     # A check is not one file. `check_trivial_wrappers` gets its behaviour from
     # `lib/srcfile.sh`, so editing that changes what it reports while touching
-    # neither the check nor the config. op's ruling is that a check gaining a
-    # step reads everything again.
+    # neither the check nor the config, and op's ruling is that a check gaining
+    # a step reads everything again.
+    #
+    # A real edit, under a scratch interpreter root. The previous version of
+    # this test hand-set `_NUT_CACHE_BASE` and asserted a miss, which restated
+    # the string comparison in `nut_cache_hit` and never entered the function
+    # that computes it. The defect it was named for survived that test: the
+    # computation stat'd the `lib` directory, whose mtime moves when an entry
+    # is added or removed and not when a file inside it is edited.
+    local fake="$CCROOT/fakenut"
+    mkdir -p "$fake/lib"
+    printf 'a module\n' > "$fake/lib/srcfile.sh"
+    printf 'an init\n' > "$fake/init"
+
+    local keep="${NUTSHELL_ROOT:-}"
+    export NUTSHELL_ROOT="$fake"
+    _NUT_CACHE_BASE=""
+
     nut_cache_write probe "$CCROOT/src.sh" 'answer'
     assert_ok nut_cache_hit probe "$CCROOT/src.sh"
-    # The interpreter's own stamp is part of the key, so moving it is a miss.
-    _NUT_CACHE_BASE="f2:something-else"
+
+    sleep 1
+    printf 'a module, with another step\n' > "$fake/lib/srcfile.sh"
+    _NUT_CACHE_BASE=""
+
     assert_fails nut_cache_hit probe "$CCROOT/src.sh"
+
+    export NUTSHELL_ROOT="$keep"
+    _NUT_CACHE_BASE=""
     _cc_end
 }
 


### PR DESCRIPTION
The review said ship after fixes and named five. These are them.

## The cache still had the defect the rewrite was centred on

`_nut_cache_base` computed the newest file with `find` and then **overwrote
that variable on the very next line** with a `stat` of the `lib` directory. A
directory's mtime moves when an entry is added or removed, not when a file
inside it is edited. So `git pull` and adding a module invalidated, and editing
`lib/srcfile.sh` in place did not, which is the exact case the header claims to
cover and the reason the cache exists.

The size was stat'd and thrown away: `${v##* }` takes the last space-delimited
field, which is the path. A content change landing on the same mtime hit, which
two `git checkout`s inside one second and any `touch -r` will produce.

Both tests were named for these properties and tested something adjacent. One
hand-set `_NUT_CACHE_BASE` and asserted a miss, restating a string comparison
and never entering the function that computes it. The other moved the mtime
backward, which the test fourteen lines above already covered, so it passed on
a key the size was not in.

## A failed source did not stop the caller

`init` refuses on bash 3, and `return` returns *to* whoever sourced it. So a
script printed the refusal and then ran its whole body with nothing loaded and
exited 0, on the platform the refusal exists for:

```
nutshell needs bash 4.0 or newer.
  this is: 3.2.57(1)-release
/tmp/shape.sh: line 4: use: command not found
carried on, foo=[set]
EXIT=0
```

Every source line in the readme ends in `|| exit 1` now, with a sentence saying
why. The three consumer call sites follow in their own repos.

## `release` made the constant load-bearing for releases too

It took the version from `NUTSHELL_VERSION` and called that "the single home of
the version". `docs/TODO.md` records the ruling that the tag is the version and
the constant goes, so that sentence would have been the one read next time
anyone tagged, and deleting the constant later would have broken the release
script as well as resolution. The version is an argument now; a mismatch with
the constant warns rather than decides.

## And the 2s bar has a durable home

It lived only in a state file that is current-only and gets overwritten.
`docs/TODO.md` carries it now with the measured 14.4s beside it, what took it
from 250s, and the two candidates left.

## Sanity

`./test` is 517. `./check` unchanged at four warnings.

Each fix has a control: the dir-stat restored, the size discarded again, and
the unguarded source. All three fail.