### PR TITLE
test: pin the bash floor, and stop three zeroes reading as passes

### DIFF
--- a/lib/checkcache.sh
+++ b/lib/checkcache.sh
@@ -66,6 +66,57 @@ declare -g _NUT_CACHE_FORMAT=2
 
 declare -gA _NUT_CACHE_STAMP=()
 declare -g  _NUT_CACHE_BASE=""
+declare -g  _NUT_CACHE_STAT=""
+
+# Which `stat` this machine has, decided once by what it prints rather than by
+# what it returns.
+#
+# BSD spells the format `-f` and GNU spells it `-c`. Choosing with
+# `stat -f ... || stat -c ...` looks right and is not: on GNU, `-f` is not a
+# format flag at all, it asks for file-system status, and it does not
+# recognise `%m`. It can therefore exit 0 having printed something that is not
+# an mtime, the `||` never fires, and every stamp on Linux is garbage that
+# compares equal to itself. Invalidation stops, silently, on the platform most
+# of this runs on.
+#
+# So the probe reads the answer back. A format is accepted when it produces a
+# line whose first field is a plain number, which neither flavour produces for
+# the other's spelling.
+#
+# Prints `-f` or `-c`, or nothing when neither works.
+_nut_cache_stat_flag() {
+    [[ -n "$_NUT_CACHE_STAT" ]] && { printf '%s' "${_NUT_CACHE_STAT#none}"; return 0; }
+
+    local probe="${NUTSHELL_ROOT:-.}/init" out
+    [[ -f "$probe" ]] || probe="${BASH_SOURCE[0]}"
+
+    local flag fmt
+    for flag in -f -c; do
+        case "$flag" in
+            -f) fmt='%m' ;;
+            -c) fmt='%Y' ;;
+        esac
+        out="$(stat "$flag" "$fmt" "$probe" 2>/dev/null)" || continue
+        out="${out%%[!0-9]*}"
+        if [[ -n "$out" ]]; then
+            _NUT_CACHE_STAT="$flag"
+            printf '%s' "$flag"
+            return 0
+        fi
+    done
+
+    _NUT_CACHE_STAT="none"
+    return 1
+}
+
+# The `<mtime> <size> <path>` format for whichever `stat` this is.
+_nut_cache_stat_fmt() {
+    case "$(_nut_cache_stat_flag)" in
+        -f) printf '%%m %%z %%N' ;;
+        -c) printf '%%Y %%s %%n' ;;
+        *)  return 1 ;;
+    esac
+}
 
 # `<mtime> <size>` for a set of paths, in one call.
 _nut_cache_stat_into() {
@@ -82,8 +133,10 @@ _nut_cache_stat_into() {
         [[ -n "$path" ]] || continue
         _NUT_CACHE_STAMP["$path"]="${mtime} ${size}"
     done < <(
-        if stat -f '%m %z %N' "$@" 2>/dev/null; then :
-        else stat -c '%Y %s %n' "$@" 2>/dev/null; fi
+        local flag fmt
+        flag="$(_nut_cache_stat_flag)" || exit 0
+        fmt="$(_nut_cache_stat_fmt)"   || exit 0
+        stat "$flag" "$fmt" "$@" 2>/dev/null
     )
     return 0
 }
@@ -118,9 +171,10 @@ _nut_cache_base() {
         # changes what a check reports while touching nothing else.
         #
         # One `find` and one batched `stat`, per run rather than per file.
-        newest="$(
-            find "$root/lib" "$root/init" -type f -exec stat -f '%m' {} + 2>/dev/null \
-            || find "$root/lib" "$root/init" -type f -exec stat -c '%Y' {} + 2>/dev/null
+        local flag fmt
+        flag="$(_nut_cache_stat_flag)" && case "$flag" in -f) fmt='%m' ;; *) fmt='%Y' ;; esac
+        [[ -n "${flag:-}" ]] && newest="$(
+            find "$root/lib" "$root/init" -type f -exec stat "$flag" "$fmt" {} + 2>/dev/null
         )"
         newest="$(printf '%s\n' "$newest" | sort -rn | head -1)"
     fi

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -201,6 +201,27 @@ test_run() {
     local name output rc
     _TEST_MARK_DIR="$(_test_mark_dir)" || return 1
 
+    # A file that yields no tests at all, counted before any filter. The same
+    # reasoning as the assert-nothing check below, one level up: a file nobody
+    # can run occupies the place a real one would be noticed missing from, and
+    # `[OK] 0 passed` reads as a pass.
+    #
+    # It is not hypothetical. Renaming `attr_find` breaks the discovery this
+    # very loop uses, so every file in the suite yields nothing and the run
+    # reports green over a library that no longer loads.
+    local found=0
+    while IFS= read -r name; do
+        [[ -n "$name" ]] && found=$(( found + 1 ))
+    done < <(attr_find "$file" test)
+
+    if [[ "$found" -eq 0 ]]; then
+        _TEST_FAILED+=1
+        _TEST_FAILURES+=("${file##*/}: no #[test] found in the file")
+        log_tagged "FAIL" red "${file##*/}"
+        log_substep "no #[test] found. An empty file reports a pass otherwise."
+        return 1
+    fi
+
     while IFS= read -r name; do
         [[ -z "$name" ]] && continue
         [[ -n "${TEST_FILTER:-}" && "$name" != *"$TEST_FILTER"* ]] && continue

--- a/tests/attr_test.sh
+++ b/tests/attr_test.sh
@@ -85,6 +85,15 @@ it_spawns_nothing_while_walking_a_file() {
     local src="${BASH_SOURCE[0]%/*}/../lib/attr.sh"
     local body
     body="$(sed -n '/^attr_on() {/,/^}/p' "$src"; sed -n '/^attr_find() {/,/^}/p' "$src")"
+
+    # The extraction has to have found something. Rename either walker and the
+    # `sed` matches nothing, the grep below finds nothing in nothing, and this
+    # reports a clean pass over a walker that forks per line. A zero out of a
+    # pipeline is a claim about the pipeline until the pipeline is shown able
+    # to produce anything else.
+    assert_ne "$body" ""
+    assert_contains "$body" "while IFS= read -r line"
+
     # No `$(...)` inside either walker. `$(( ))` is arithmetic and is not one.
     local subs; subs="$(grep -n '\$(' <<<"$body" | grep -v '\$((' || true)"
     assert_empty "$subs"

--- a/tests/checkcache_test.sh
+++ b/tests/checkcache_test.sh
@@ -265,3 +265,135 @@ it_refuses_an_entry_written_in_an_older_format() {
     assert_fails nut_cache_hit probe "$CCROOT/src.sh"
     _cc_end
 }
+
+# --- which stat this machine has ---------------------------------------------
+#
+# The flavour is decided by what `stat` prints, not by what it returns, and
+# the difference only shows on the platform this was not developed on.
+#
+# BSD spells the format `-f`. GNU spells it `-c`, and its own `-f` asks for
+# file-system status and does not know `%m`. A chooser written as
+# `stat -f … || stat -c …` therefore reads the wrong thing on Linux while
+# exiting 0, so the fallback never fires and every stamp is garbage that
+# compares equal to itself. Invalidation stops with nothing to show for it.
+#
+# GNU is unavailable here, so it is planted: a `stat` that owns the whole PATH
+# and behaves the way GNU's does. Prepending would let the machine's real one
+# answer, which is how a stub test comes to prove nothing.
+
+_stat_stub() {
+    local dir="$1" kind="$2"
+    mkdir -p "$dir"
+    case "$kind" in
+        gnu)
+            # `-c` works. `-f` exits 0 and prints filesystem noise, which is
+            # the whole hazard.
+            cat > "$dir/stat" <<'STUB'
+#!/bin/sh
+if [ "$1" = "-c" ]; then
+    shift; fmt="$1"; shift
+    for f do
+        m=$(/usr/bin/stat -f '%m' "$f" 2>/dev/null) || exit 1
+        z=$(/usr/bin/stat -f '%z' "$f" 2>/dev/null) || exit 1
+        case "$fmt" in
+            '%Y %s %n') printf '%s %s %s\n' "$m" "$z" "$f" ;;
+            '%Y')       printf '%s\n' "$m" ;;
+            *)          printf '?\n' ;;
+        esac
+    done
+    exit 0
+fi
+if [ "$1" = "-f" ]; then
+    shift; shift
+    for f do printf 'Blocks: Total: 1000 Free: 500\n'; done
+    exit 0
+fi
+exit 1
+STUB
+            ;;
+        bsd)
+            cat > "$dir/stat" <<'STUB'
+#!/bin/sh
+[ "$1" = "-f" ] || exit 1
+shift; fmt="$1"; shift
+exec /usr/bin/stat -f "$fmt" "$@"
+STUB
+            ;;
+        none)
+            printf '#!/bin/sh\nexit 127\n' > "$dir/stat"
+            ;;
+    esac
+    chmod +x "$dir/stat"
+
+    # The stub owns the whole PATH. Prepending leaves the real one reachable
+    # by anything that resolves a second time, and then the test is about the
+    # machine rather than about the stub.
+    for t in find sort head printf mktemp rm cat chmod sh; do
+        [[ -e "$dir/$t" ]] && continue
+        local real; real="$(command -v "$t" 2>/dev/null)" || continue
+        ln -sf "$real" "$dir/$t"
+    done
+}
+
+_stat_flag_under() {
+    local dir="$1"
+    bash -c '
+        PATH="$1"; export PATH
+        . "$2"/init || exit 1
+        use checkcache
+        _nut_cache_stat_flag || printf "NONE"
+    ' _ "$dir" "$NUTSHELL_ROOT" 2>/dev/null
+}
+
+#[test]
+it_picks_the_format_a_gnu_stat_understands() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")"
+    _stat_stub "$d" gnu
+    assert_eq "$(_stat_flag_under "$d")" "-c"
+    rm -rf "$d"
+}
+
+#[test]
+it_picks_the_format_a_bsd_stat_understands() {
+    # The control. A probe that always answered `-c` would pass the one above
+    # and be just as wrong, in the other direction.
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")"
+    _stat_stub "$d" bsd
+    assert_eq "$(_stat_flag_under "$d")" "-f"
+    rm -rf "$d"
+}
+
+#[test]
+it_says_so_rather_than_guessing_when_there_is_no_stat() {
+    # A machine with neither has no stamps, and no stamps has to mean every
+    # entry misses. Answering with a flag that does not work would mean every
+    # entry hits on a stamp that never changes.
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")"
+    _stat_stub "$d" none
+    assert_eq "$(_stat_flag_under "$d")" "NONE"
+    rm -rf "$d"
+}
+
+#[test]
+it_reads_a_real_mtime_and_size_through_whichever_stat_it_picked() {
+    # The flag being right is not the claim. The claim is that the numbers
+    # coming back are this file's mtime and size, and a probe that accepted a
+    # format printing `?` would satisfy the three above and fail this.
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")"
+    _stat_stub "$d" gnu
+    printf '0123456789' > "$d/probe.txt"
+
+    local got
+    got="$(bash -c '
+        PATH="$1"; export PATH
+        . "$2"/init || exit 1
+        use checkcache
+        _nut_cache_stat_into "$3"
+        printf "%s" "${_NUT_CACHE_STAMP[$3]:-}"
+    ' _ "$d" "$NUTSHELL_ROOT" "$d/probe.txt" 2>/dev/null)"
+
+    assert_ne "$got" ""
+    assert_eq "${got#* }" "10"
+    [[ "${got%% *}" =~ ^[0-9]+$ ]] || _test_failed "mtime is not a number: [${got%% *}]"
+    rm -rf "$d"
+}

--- a/tests/fixtures/no_tests_at_all_test.sh
+++ b/tests/fixtures/no_tests_at_all_test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# A test file with no #[test] in it, which the harness must refuse.
+#
+# The shape is not somebody forgetting to write tests. It is what every file
+# in the suite becomes when discovery itself breaks: `attr_find` is what finds
+# the tests, and `attr_find` is in the library under test.
+
+use test
+
+# Marked with something else, so the file is not empty and the attribute
+# reader is definitely running. It just finds nothing it was asked for.
+#[helper]
+it_looks_like_a_test_but_is_not_marked_as_one() {
+    assert_eq "1" "1"
+}

--- a/tests/harness_test.sh
+++ b/tests/harness_test.sh
@@ -88,3 +88,28 @@ it_does_not_charge_one_test_with_another_s_failure() {
     assert_contains "$out" "[PASS] it_forks_a_child_that_fails_late"
     assert_contains "$out" "[PASS] it_is_the_innocent_one_after_the_fork"
 }
+
+#[test]
+it_fails_a_file_that_yields_no_tests() {
+    # The same reasoning as the assert-nothing check, one level up. `0 passed`
+    # is not a pass, and the harness used to print `[OK] 0 passed` and exit 0
+    # for it.
+    #
+    # Found by mutation rather than by reading: renaming `attr_find` breaks the
+    # discovery `test_run` itself uses, so the whole suite yielded nothing and
+    # reported green over a library that no longer loaded.
+    local out
+    out="$(_harness_run "${FIXTURES}/no_tests_at_all_test.sh")"
+    assert_contains "$out" "FAIL"
+    assert_contains "$out" "no #[test] found"
+}
+
+#[test]
+it_does_not_call_a_filtered_run_empty() {
+    # The control. A filter matching nothing yields no tests for a reason that
+    # is not a defect, and refusing it would make `TEST_FILTER` unusable. The
+    # count that decides is taken before the filter.
+    local out
+    out="$(TEST_FILTER=zzz_matches_nothing _harness_run "${FIXTURES}/first_assertion_fails_test.sh")"
+    assert_eq "${out#*FAIL}" "$out"
+}

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Tests for the bash floor.
+#
+# `init` uses `declare -A`, which bash 3 does not have, so it refuses to load
+# on anything below 4. macOS ships 3.2 at /bin/bash and this is a tool reached
+# for when a machine is already broken, so the refusal has to be readable
+# rather than a syntax error two hundred lines further down.
+#
+# The refusal had no test at all. It was written wrong twice while being
+# reviewed, and both times it was caught by hand rather than by anything that
+# runs again.
+#
+# The version is faked rather than the shell. `BASH_VERSION` is an ordinary
+# assignable variable, so the guard can be driven through every branch under
+# the bash that is already running, which is what makes the table below cheap
+# enough to be exhaustive.
+
+use test
+
+INIT="${BASH_SOURCE[0]%/*}/../init"
+NUT="${BASH_SOURCE[0]%/*}/../bin/nutshell"
+
+# The pattern the guard actually uses, read out of the file rather than copied
+# here. Copying it would make this a test of the copy: edit `init` to accept
+# bash 2 and the copy would keep reporting a refusal.
+# The `case` label the guard actually uses, read out of the file rather than
+# copied here. Copying it would make the table a test of the copy: edit `init`
+# to accept bash 2 and the copy would keep reporting a refusal.
+#
+# Anchored on the `case` line rather than on the message, because the two
+# entry points spell the message differently: `init` calls a function and the
+# binary writes it inline, since it has no library to call into yet.
+_guard_pattern() {
+    local f="${1:-$INIT}" n
+    n="$(grep -n 'case "\${BASH_VERSION' "$f" | head -1)"
+    [[ -n "$n" ]] || return 1
+    n="${n%%:*}"
+    sed -n "$(( n + 1 ))p" "$f" | sed 's/^[[:space:]]*//; s/)[[:space:]]*$//'
+}
+
+# Bash sets `BASH_VERSION` itself at startup, so handing it in the environment
+# does nothing: the new shell overwrites it before reading a line. It is an
+# ordinary assignable variable once that shell is running, so every driver
+# below assigns it inside the shell under test rather than in front of it.
+#
+# This was written the other way first. All four tests using it failed, which
+# is the only reason it is written down here instead of being a thing that
+# quietly reported a pass.
+_as_bash3() {
+    local body="$1"; shift
+    bash -c "BASH_VERSION='3.2.57(1)-release'; $body" _ "$@"
+}
+
+#[test]
+it_reads_its_own_guard_out_of_init() {
+    # The control for the table below. If the extraction stops finding the
+    # label, every row falls through to `allow` and the table reports a clean
+    # pass over a guard that is not there.
+    local pat; pat="$(_guard_pattern)"
+    assert_ne "$pat" ""
+    assert_contains "$pat" '3.*'
+}
+
+#[test]
+it_carries_the_same_floor_in_both_entry_points() {
+    # `bin/nutshell` has its own copy, because it is a script rather than a
+    # sourced file and has no `init` to ask yet. A copy is a thing that drifts,
+    # so the two labels are compared rather than assumed equal.
+    assert_eq "$(_guard_pattern "$NUT")" "$(_guard_pattern "$INIT")"
+}
+
+#[test]
+it_refuses_every_bash_below_four_and_no_others() {
+    local pat; pat="$(_guard_pattern)"
+    local v want got
+
+    # Each row is a version string and what the guard owes it. The interesting
+    # ones are the ends: an empty `BASH_VERSION` means the file is being read
+    # by something that is not bash at all, and `10.0.0` is the row that says
+    # `1.*` is a prefix of `1.` rather than of `1`.
+    for v in '' 1.14.7 2.05b '3.2.57(1)-release' 3.0 4.0 '4.0.0-beta' \
+             '4.4.20(1)-release' 5.2.15 5.3 10.0.0 11.2.3; do
+        case "$v" in ''|1.*|2.*|3.*) want=refuse ;; *) want=allow ;; esac
+
+        got=allow
+        eval "case \"\$v\" in $pat) got=refuse ;; esac"
+
+        assert_eq "$got" "$want" "BASH_VERSION=[$v]"
+    done
+}
+
+#[test]
+it_says_what_is_wrong_and_where_a_newer_one_comes_from() {
+    # A refusal nobody can act on is a crash with better manners. The message
+    # has to carry the version it found and the reason macOS specifically hits
+    # this, because macOS is where it happens.
+    local out
+    out="$(_as_bash3 '. "$1" 2>&1 >/dev/null' "$INIT")"
+
+    assert_contains "$out" "bash 4.0 or newer"
+    assert_contains "$out" "3.2.57"
+    assert_contains "$out" "macOS"
+    assert_contains "$out" "PATH"
+}
+
+#[test]
+it_loads_nothing_when_it_refuses() {
+    # The refusal has to stop the load, not merely complain about it. A file
+    # that prints the message and then defines half a library is worse than
+    # one that fails outright, because the caller carries on.
+    local out
+    out="$(_as_bash3 '
+        . "$1" >/dev/null 2>&1
+        declare -F nut_once >/dev/null && echo LOADED
+        printf "%s" "${_NUTSHELL_INIT:-unset}"
+    ' "$INIT")"
+
+    assert_eq "$out" "unset"
+}
+
+#[test]
+it_loads_normally_on_the_bash_running_this() {
+    # The control for the two above. The guard refusing everything would pass
+    # both of them, and a floor that refuses every bash is not a floor.
+    local out
+    out="$(bash -c '. "$1" >/dev/null 2>&1 || exit 1; printf "%s" "${_NUTSHELL_INIT:-unset}"' _ "$INIT")"
+    assert_eq "$out" "1"
+}
+
+#[test]
+it_stops_a_caller_that_checks_the_source_line() {
+    # `return` inside a sourced file returns to whoever sourced it. It cannot
+    # stop them, which is why every example in the readme ends its source line
+    # in `|| exit 1`. This pins that the guarded form does stop.
+    local script; script="$(mktemp)"
+    cat > "$script" <<'INNER'
+BASH_VERSION='3.2.57(1)-release'
+. "$1" || exit 1
+echo REACHED_THE_BODY
+INNER
+
+    local out rc=0
+    out="$(bash "$script" "$INIT" 2>/dev/null)" || rc=$?
+    rm -f "$script"
+
+    assert_eq "$out" ""
+    assert_ne "$rc" "0"
+}
+
+#[test]
+it_does_not_stop_a_caller_that_does_not_check() {
+    # The residue, recorded rather than wished away. An unguarded source line
+    # gets the message and carries on with nothing loaded, and the only fix
+    # available to `init` is the one above, on the caller's side.
+    local script; script="$(mktemp)"
+    cat > "$script" <<'INNER'
+BASH_VERSION='3.2.57(1)-release'
+. "$1"
+echo REACHED_THE_BODY
+INNER
+
+    local out
+    out="$(bash "$script" "$INIT" 2>/dev/null)"
+    rm -f "$script"
+
+    assert_eq "$out" "REACHED_THE_BODY"
+}
+
+#[test]
+it_puts_the_binarys_floor_above_anything_bash_three_cannot_parse() {
+    # A guard below the first `declare -A` or `[[ ]]` is a guard the shell
+    # never reaches: bash 3 fails parsing the file before running any of it,
+    # and the reader gets a syntax error instead of the message.
+    #
+    # Faking the version cannot catch this, because the running bash parses
+    # the file fine. So the check is positional, and `bash --posix -n` is the
+    # cheapest reader that objects to the same constructs.
+    local guard_line body_line
+    guard_line="$(grep -n 'case "\${BASH_VERSION' "$NUT" | head -1)"
+    guard_line="${guard_line%%:*}"
+    assert_ne "$guard_line" ""
+
+    # The first line using something bash 3 does not have, or the first
+    # line of the body, whichever comes first.
+    body_line="$(grep -n 'declare -A\|set -uo pipefail' "$NUT" | head -1)"
+    body_line="${body_line%%:*}"
+    assert_ne "$body_line" ""
+
+    [[ "$guard_line" -lt "$body_line" ]] \
+        || _test_failed "guard at line $guard_line sits below line $body_line"
+}
+
+#[test]
+it_writes_the_refusal_where_a_terminal_will_show_it() {
+    # stderr, so a caller piping stdout somewhere still sees why nothing came
+    # out of it. The message going to stdout would land in whatever file the
+    # caller was redirecting into.
+    local on_out on_err
+    on_out="$(_as_bash3 '. "$1" 2>/dev/null' "$INIT")"
+    on_err="$(_as_bash3 '. "$1" 2>&1 >/dev/null' "$INIT")"
+
+    assert_empty "$on_out"
+    assert_contains "$on_err" "bash 4.0 or newer"
+}


### PR DESCRIPTION
Review of the release branch mutated each shipped mechanism and asked which named test dies. Three did not die, and all three are the same shape: a zero coming out of a pipeline being read as a pass.

## What was not tested

`init`'s bash 4 floor had no test at all. Deleting the whole `case` killed nothing in 517. That is the fix for a declared release blocker, and it was written wrong twice while being reviewed, both times caught by hand rather than by anything that runs again.

`tests/init_test.sh` drives it through every branch by assigning `BASH_VERSION` inside the shell under test. That is the only way that works, and it cost four failing tests to find out: bash sets `BASH_VERSION` itself at startup, so handing it in the environment does exactly nothing. The `10.0.0` row in the table is the one worth having, since `1.*` is a prefix of `1.` rather than of `1` and nothing pinned it. The pattern is read out of `init` rather than copied into the test, so widening the floor cannot leave the test still reporting a refusal, and the two entry points are compared to each other because `bin/nutshell` carries its own copy and a copy drifts.

## What was tested and could not fail

`it_spawns_nothing_while_walking_a_file` pulled the two walkers out by name with `sed` and grepped the result. Rename either one and the `sed` matches nothing, the grep finds nothing in nothing, and it reports a clean pass over a walker that forks per line. It now asserts the extraction found something before it looks at what it found.

The harness printed `[OK] 0 passed` and exited 0 for a file that yields no tests. Not hypothetical: `attr_find` is what discovery uses and `attr_find` is in the library under test, so renaming it makes every file in the suite yield nothing and the run report green over a library that no longer loads. This is the same reasoning as the assert-nothing check that was already there, one level up. The count is taken before `TEST_FILTER`, so a filter matching nothing stays legal, and there is a control for that.

## What could not be tested here at all

`stat`'s flavour is now decided by what it prints, not by what it returns.

BSD spells the format `-f`. GNU's `-f` asks for file-system status and does not know `%m`, so it can exit `0` having printed something that is not an mtime. Written as `stat -f … || stat -c …`, the `||` never fires on Linux, every stamp is garbage that compares equal to itself, and invalidation quietly stops on the platform most of this runs on.

Neither branch was reachable on this machine, so the tests plant a `stat` that owns the whole `PATH`: GNU-shaped, BSD-shaped, and absent. Prepending would have let the machine's real one answer, which is how a stub test comes to prove nothing.

## Sanity

533 pass, was 517. Gate is 13.8s with the same four warnings.

Each mutation kills exactly its own test, which is the thing being bought here:

| mutation | dies |
|---|---|
| delete `init`'s guard | seven, all of them named for it |
| `1.*` becomes `1*` | the table and the drift check, nothing else |
| binary guard moved below `set -uo pipefail` | the positional test only |
| binary floor drifts to `3.*` | the drift check only |
| rename both `attr` walkers behind wrappers | `it_spawns_nothing_while_walking_a_file` only |
| drop the zero-tests refusal | `it_fails_a_file_that_yields_no_tests` only |
| count tests after the filter instead of before | `it_does_not_call_a_filtered_run_empty` only |
| the old exit-status `stat` chooser | the GNU pick and the real-numbers check |
| always answer `-c` | the BSD control, plus five that need real stamps |

A lot of the older tests in here are probably still for show. These ones are not, and I checked rather than read, because reading is what missed all three the first two times.