### PR TITLE
fix: catch a docblock that documents the function below the one it sits on

### DIFF
--- a/examples/checks/check_public_api_docs.sh
+++ b/examples/checks/check_public_api_docs.sh
@@ -26,6 +26,7 @@ set -uo pipefail
 
 # Load the check-runner framework (provides cfg_*, log_*, etc.)
 use check-runner
+use attr
 
 # =============================================================================
 # CONFIG-DRIVEN PARAMETERS
@@ -97,8 +98,14 @@ _pad_load() {
         # Where each function is defined, recorded on the one pass rather than
         # searched for per lookup. Searching was 440 functions times 376 lines
         # of regex per file, which is the same shape as the greps it replaced.
-        if [[ "$line" =~ ^[[:space:]]*(function[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]*\( ]]; then
-            local n="${BASH_REMATCH[2]}"
+        # `ATTR_DEFINES_PATTERN`, so this agrees with `attr` and `srcfile`
+        # about what a definition is. The pattern here was its own, and it
+        # required parentheses, so `function name {` was invisible to it: a
+        # `#[pub]` on one of those was never looked up at all and the check
+        # passed over it in silence. That is the same drift the shared pattern
+        # was made to end, in a third reader nobody moved across.
+        if [[ "$line" =~ $ATTR_DEFINES_PATTERN ]]; then
+            local n="${BASH_REMATCH[2]:-${BASH_REMATCH[3]}}"
             [[ -n "${_PAD_AT["${file}:${n}"]:-}" ]] || _PAD_AT["${file}:${n}"]=$((i + 1))
         fi
     done
@@ -164,6 +171,52 @@ docblock_has_element() {
     # read as its own, so the needle is lowered and compared as text.
     local hay="${docblock,,}" needle="${element,,}"
     [[ "$hay" == *"$needle"* ]]
+}
+
+# Whether a docblock belongs to the function it landed on.
+#
+# Attributes attach downward, so a `#[pub]` block sitting above a private
+# helper documents the helper. Where a docblock's `Usage:` names some other
+# function that is defined *later in the same file*, the block was written for
+# that one and something got inserted between them.
+#
+# Two things go wrong at once and neither is visible on its own. The named
+# function ends up undocumented, and the helper ends up marked public. Both
+# read as fine, because each of the two lines involved is correct where it sits.
+#
+# Only a `Usage:` whose first token is a bare name counts. `Usage: exit
+# "$(doctor_exit)"` is an invocation example and names `exit`, which defines
+# nothing, so it is not a mismatch.
+#
+# Prints the name the block was written for, and returns 0, when it is orphaned.
+docblock_orphaned_from() {
+    local file="$1" landed_on="$2" docblock="$3"
+    local line named at_named at_landed
+    local -a mentions=()
+
+    # Collected first, because a block may carry several `Usage:` lines and one
+    # of them naming this definition settles it. Deciding on the first line
+    # that did not match would call a two-form block an orphan of its own
+    # alternative spelling.
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*#[[:space:]]*Usage:[[:space:]]*([a-zA-Z_][a-zA-Z0-9_-]*)([[:space:]]|$) ]] \
+            || continue
+        named="${BASH_REMATCH[1]}"
+        [[ "$named" == "$landed_on" ]] && return 1
+        mentions+=("$named")
+    done <<< "$docblock"
+
+    for named in ${mentions[@]+"${mentions[@]}"}; do
+        at_named="$(_pad_defined_at "$file" "$named")" || continue
+        at_landed="$(_pad_defined_at "$file" "$landed_on")" || continue
+        # Later in the file, so the block was passed over on its way down.
+        # Earlier means the block refers back to something, which is prose.
+        [[ "$at_named" -gt "$at_landed" ]] || continue
+
+        printf '%s' "$named"
+        return 0
+    done
+    return 1
 }
 
 # Count comment lines in docblock
@@ -261,12 +314,22 @@ test_public_api_docs() {
             local has_warn=0
             local missing_required=""
             local missing_recommended=""
-            
+
+            # A block that documents a different function is worse than a
+            # missing one, because it reads as present from either end.
+            local orphan_of=""
+            if orphan_of="$(docblock_orphaned_from "$file" "$func_name" "$docblock")"; then
+                has_error=1
+                missing_required="the docblock is written for ${orphan_of}(), which is defined below this"
+            fi
+
             # Check minimum doc lines
             local doc_lines
             doc_lines=$(count_doc_lines "$docblock")
             
-            if [[ $doc_lines -lt $MIN_DOC_LINES ]]; then
+            if [[ -n "$orphan_of" ]]; then
+                : # already reported, and the count below would overwrite why
+            elif [[ $doc_lines -lt $MIN_DOC_LINES ]]; then
                 has_error=1
                 missing_required="insufficient documentation ($doc_lines lines, need $MIN_DOC_LINES)"
             else
@@ -394,6 +457,10 @@ main() {
     exit_with_status
 }
 
+# `NUT_CHECK_LOAD_ONLY` is the one way in for a test that wants the docblock
+# readers without a whole run over a repository, the same door
+# `check_function_duplication.sh` carries for the same reason.
+#
 # A check script is an entry point, so it runs.
 #
 # This used to be guarded by `[[ "${BASH_SOURCE[0]}" == "${0}" ]]`, the ordinary
@@ -403,4 +470,4 @@ main() {
 # the interpreter and `BASH_SOURCE[0]` is this file, and `main` was never
 # called. Six of the eight built-in checks exited 0 having done nothing, and
 # `./check` read that as a pass and printed one.
-main "$@"
+[[ -n "${NUT_CHECK_LOAD_ONLY:-}" ]] || main "$@"

--- a/lib/check-runner.sh
+++ b/lib/check-runner.sh
@@ -555,9 +555,6 @@ get_script_files() {
 # ANNOTATION CHECKING
 # =============================================================================
 
-# Check if a function has a specific annotation
-#[pub]
-# Usage: has_annotation "file" "func_name" "annotation_pattern" -> returns 0/1
 # attr_name_of <annotation>
 #
 # The attribute name inside a configured marker: `#[pub]` gives `pub`. Prints
@@ -593,6 +590,9 @@ attr_name_of() {
 # The window was a second, quieter bug: ten lines is enough for a terse
 # function and not for a documented one, so whether an annotation was seen
 # depended on how much prose sat under it.
+#
+#[pub]
+# Usage: has_annotation "file" "func_name" "annotation_pattern" -> returns 0/1
 has_annotation() {
     local file="$1" func_name="$2" annotation="$3"
 

--- a/tests/check_docblock_owner_test.sh
+++ b/tests/check_docblock_owner_test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Tests for whether a docblock belongs to the function it landed on.
+#
+# Attributes attach downward, to the next definition. So a `#[pub]` block and
+# its `Usage:` line, with a second function inserted underneath them, document
+# that second function instead. Two things break at once and neither shows:
+# the function the block was written for goes undocumented, and a private
+# helper gets marked public.
+#
+# It was in every repository this gate runs on, four times, and the existing
+# docs check reported the helper as documented because it was, by the block
+# meant for somebody else.
+
+use test
+
+NUT_CHECK_LOAD_ONLY=1 . "${BASH_SOURCE[0]%/*}/../examples/checks/check_public_api_docs.sh"
+
+# A file on disk, since the readers work over one, plus the docblock the check
+# would have extracted for a given definition.
+_dbo_file() {
+    local f; f="$(mktemp "${TMPDIR:-/tmp}/nutshell-dbo.XXXXXX")"
+    printf '%s' "$1" > "$f"
+    printf '%s' "$f"
+}
+
+# Whether the block above <func> in <file> is orphaned, and from whom.
+_orphan_of() {
+    local file="$1" func="$2" block
+    _pad_load "$file" || return 1
+    get_function_docblock "$file" "$func" >/dev/null
+    block="$PAD_DOCBLOCK"
+    docblock_orphaned_from "$file" "$func" "$block"
+}
+
+#[test]
+it_catches_a_block_the_next_definition_stole() {
+    # The case that was actually shipped, four times, reduced.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+#[pub]
+# What the public one does.
+# Usage: the_public_one -> prints a thing
+# A private helper that got inserted underneath.
+_the_helper() {
+    printf helper
+}
+
+the_public_one() {
+    _the_helper
+}
+')"
+    assert_eq "$(_orphan_of "$f" "_the_helper")" "the_public_one"
+    rm -f "$f"
+}
+
+#[test]
+it_leaves_a_block_that_names_its_own_function_alone() {
+    # The control. A detector that answered yes always would pass the test
+    # above and fail every real file in the tree.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+#[pub]
+# What it does.
+# Usage: the_public_one -> prints a thing
+the_public_one() {
+    printf thing
+}
+
+_the_helper() {
+    printf helper
+}
+')"
+    assert_fails _orphan_of "$f" "the_public_one"
+    rm -f "$f"
+}
+
+#[test]
+it_does_not_mistake_an_invocation_example_for_a_name() {
+    # `Usage: exit "$(doctor_exit)"` names `exit`, which defines nothing here.
+    # A detector matching the first token without checking it is defined
+    # reports every such block, and this shape is all over the tree.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+#[pub]
+# An exit status for the whole run.
+# Usage: exit "$(doctor_exit)"
+doctor_exit() {
+    printf 0
+}
+')"
+    assert_fails _orphan_of "$f" "doctor_exit"
+    rm -f "$f"
+}
+
+#[test]
+it_does_not_flag_a_block_referring_back_to_something_above_it() {
+    # Naming a function defined *earlier* is prose about a relationship, not a
+    # block that slid down past its own definition. Only later counts.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+first_one() {
+    printf first
+}
+
+#[pub]
+# Does the same as first_one, for the other shape.
+# Usage: first_one
+second_one() {
+    printf second
+}
+')"
+    assert_fails _orphan_of "$f" "second_one"
+    rm -f "$f"
+}
+
+#[test]
+it_does_not_flag_a_name_that_is_defined_nowhere() {
+    # A `Usage:` naming something from another module is a cross reference. It
+    # cannot be an orphan here, because there is nothing here to be orphaned
+    # from.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+#[pub]
+# Wraps the thing from the other module.
+# Usage: some_other_modules_function
+the_wrapper() {
+    printf wrapped
+}
+')"
+    assert_fails _orphan_of "$f" "the_wrapper"
+    rm -f "$f"
+}
+
+#[test]
+it_reads_a_hyphenated_and_a_function_keyword_definition() {
+    # Both spellings bash accepts. A detector that only knew `name()` would
+    # report the block below as an orphan of a function it could not see was
+    # defined.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+#[pub]
+# Usage: the_public_one -> prints a thing
+_the_helper() {
+    printf helper
+}
+
+function the_public_one {
+    _the_helper
+}
+')"
+    assert_eq "$(_orphan_of "$f" "_the_helper")" "the_public_one"
+    rm -f "$f"
+}
+
+#[test]
+it_finds_the_orphan_when_a_later_usage_line_is_the_right_one() {
+    # A block can carry more than one `Usage:`. One matching the definition it
+    # sits above means the block belongs here, whatever else it mentions.
+    local f; f="$(_dbo_file '#!/usr/bin/env bash
+
+#[pub]
+# Usage: the_public_one -> the other form
+# Usage: _the_helper -> this form
+_the_helper() {
+    printf helper
+}
+
+the_public_one() {
+    _the_helper
+}
+')"
+    assert_fails _orphan_of "$f" "_the_helper"
+    rm -f "$f"
+}


### PR DESCRIPTION
Attributes attach downward, to the next definition. Put a second function between a `#[pub]` block and the one it was written for, and the block documents the second one instead.

Two things break at once and neither of them shows. The function it was written for goes undocumented, and a private helper gets marked public. The docs check reported the helper as documented, which was correct: it was documented, by somebody else's block.

## How many

Four, across every repository this gate runs on, found by grepping for a `Usage:` line naming a function defined later in the same file. One of them is `has_annotation` in this repo's own `check-runner`, which is fixed here; the other three land in their own repos.

## Where it goes

Into the check that already extracts docblocks, rather than a new check, because it is the same question that check exists to ask. It fires only when the named function is defined **later in the same file**, which is what keeps the ordinary shapes out of it:

- `Usage: exit "$(doctor_exit)"` names `exit`, which defines nothing, so it stays an invocation example.
- A block naming something defined above it is prose about a relationship, not a block that slid down past its own definition.
- A name from another module is a cross reference, and there is nothing here for it to be orphaned from.

`NUT_CHECK_LOAD_ONLY` is added to this check, the same door `check_function_duplication.sh` already carries, so the tests reach the readers without a whole run over a repository.

## Two things I got wrong first

Both found by the tests rather than by reading them, which is the whole argument for writing them.

`_pad_load` rolled its own idea of what a definition looks like, and required parentheses. So `function name {` was invisible to it and a `#[pub]` on one of those was never looked up at all. That is exactly the drift `ATTR_DEFINES_PATTERN` was made to end, sitting in a third reader nobody moved across. It uses the shared pattern now, so `attr`, `srcfile` and this check agree about what a definition is.

And the first version decided on the first `Usage:` line that did not match the definition below it, which calls a block carrying two spellings an orphan of its own alternative form. The mentions get collected before anything is decided.

## Sanity

540 pass, was 533. Gate is the same four warnings.

Seven tests, and the five that are not the positive case are the point:

| planted | expected |
|---|---|
| a helper inserted under a `#[pub]` block | orphan, names the function below |
| a block naming its own function | not an orphan |
| `Usage: exit "$(doctor_exit)"` | not an orphan |
| a block naming something defined above | not an orphan |
| a name defined nowhere in the file | not an orphan |
| `function name {` as the real owner | orphan, and this one failed first |
| two `Usage:` lines, one of them matching | not an orphan, and this one failed first |