### PR TITLE
fix: a gate that examined nothing was reporting a pass

### DIFF
--- a/check
+++ b/check
@@ -21,7 +21,14 @@
 set -uo pipefail
 
 # Bootstrap nutshell (this is an entry point script)
-. "${BASH_SOURCE[0]%/*}/init"
+#
+# `|| exit 1`, because `init` refuses to load on a bash older than 4 and its
+# `return` returns to whoever sourced it: it cannot stop them. Unchecked, this
+# printed the refusal, ran its whole body with no modules loaded, found no
+# checks to run, and reported PASSED. On macOS, under `/bin/bash`, which is the
+# machine the refusal exists for. `release` gates on this command.
+# shellcheck source=/dev/null
+. "${BASH_SOURCE[0]%/*}/init" || exit 1
 
 # Load nutshell modules
 use os log string validate toml fs
@@ -348,7 +355,17 @@ _run_custom_checks() {
 _print_summary() {
     echo ""
     echo -e "${BOLD}────────────────────────────────────────${NC}"
-    
+
+    # Zero checks is not a pass. The same reasoning as `lib/test.sh` refusing a
+    # file that yields no tests: a run that examined nothing has established
+    # nothing, and "All 0 checks passed" is the sentence a broken bootstrap
+    # prints on its way to exit 0.
+    if [[ $TOTAL_CHECKS -eq 0 ]]; then
+        echo -e "${RED}${BOLD}FAILED${NC} - no checks ran at all"
+        echo "  nothing was found to run. A gate that examined nothing has not passed."
+        return 1
+    fi
+
     if [[ $FAILED_CHECKS -gt 0 ]]; then
         echo -e "${RED}${BOLD}FAILED${NC} - $FAILED_CHECKS of $TOTAL_CHECKS checks failed"
         return 1

--- a/lib/checkcache.sh
+++ b/lib/checkcache.sh
@@ -79,34 +79,43 @@ declare -g  _NUT_CACHE_STAT=""
 # compares equal to itself. Invalidation stops, silently, on the platform most
 # of this runs on.
 #
-# So the probe reads the answer back. A format is accepted when it produces a
-# line whose first field is a plain number, which neither flavour produces for
-# the other's spelling.
+# So the probe reads the answer back, against a file whose size it already
+# knows. Requiring only "starts with a digit" would rest on a premise nothing
+# here can check: that no `stat` ever leads its wrong-flag output with a
+# number. GNU prints the literal `%m` and a stub might print a block count, and
+# the difference decides whether Linux gets working invalidation.
+#
+# A written file of known length removes the premise. A format is accepted when
+# it returns that exact length, which only the right spelling can do.
 #
 # Prints `-f` or `-c`, or nothing when neither works.
 _nut_cache_stat_flag() {
     [[ -n "$_NUT_CACHE_STAT" ]] && { printf '%s' "${_NUT_CACHE_STAT#none}"; return 0; }
 
-    local probe="${NUTSHELL_ROOT:-.}/init" out
-    [[ -f "$probe" ]] || probe="${BASH_SOURCE[0]}"
+    local probe out flag fmt rc=1
+    probe="$(mktemp "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")" || { _NUT_CACHE_STAT="none"; return 1; }
+    # Ten bytes, no trailing newline, so the size is known exactly.
+    printf '0123456789' > "$probe"
 
-    local flag fmt
     for flag in -f -c; do
         case "$flag" in
-            -f) fmt='%m' ;;
-            -c) fmt='%Y' ;;
+            -f) fmt='%m %z' ;;
+            -c) fmt='%Y %s' ;;
         esac
         out="$(stat "$flag" "$fmt" "$probe" 2>/dev/null)" || continue
-        out="${out%%[!0-9]*}"
-        if [[ -n "$out" ]]; then
-            _NUT_CACHE_STAT="$flag"
-            printf '%s' "$flag"
-            return 0
-        fi
+        # `<mtime> <size>`, and the size has to be the one just written.
+        [[ "$out" == *' '* ]] || continue
+        [[ "${out%% *}" =~ ^[0-9]+$ ]] || continue
+        [[ "${out##* }" == "10" ]] || continue
+        _NUT_CACHE_STAT="$flag"
+        rc=0
+        break
     done
 
-    _NUT_CACHE_STAT="none"
-    return 1
+    rm -f "$probe"
+    [[ "$rc" -eq 0 ]] || { _NUT_CACHE_STAT="none"; return 1; }
+    printf '%s' "$_NUT_CACHE_STAT"
+    return 0
 }
 
 # The `<mtime> <size> <path>` format for whichever `stat` this is.

--- a/test
+++ b/test
@@ -12,7 +12,10 @@
 # =============================================================================
 
 set -uo pipefail
-. "${BASH_SOURCE[0]%/*}/init"
+# `|| exit 1` for the reason every example in the readme carries it: `init`
+# refuses below bash 4 with a `return`, and a `return` cannot stop its caller.
+# shellcheck source=/dev/null
+. "${BASH_SOURCE[0]%/*}/init" || exit 1
 
 use test log
 

--- a/tests/attr_test.sh
+++ b/tests/attr_test.sh
@@ -86,13 +86,17 @@ it_spawns_nothing_while_walking_a_file() {
     local body
     body="$(sed -n '/^attr_on() {/,/^}/p' "$src"; sed -n '/^attr_find() {/,/^}/p' "$src")"
 
-    # The extraction has to have found something. Rename either walker and the
-    # `sed` matches nothing, the grep below finds nothing in nothing, and this
-    # reports a clean pass over a walker that forks per line. A zero out of a
-    # pipeline is a claim about the pipeline until the pipeline is shown able
-    # to produce anything else.
+    # Both walkers, counted. The first guard here asserted the extraction was
+    # non-empty, which closes the case where both are renamed and leaves the
+    # one that matters: rename `attr_on` alone, keep a wrapper, and put a fork
+    # in its loop, and `attr_find`'s text alone satisfies "non-empty" and
+    # "contains a read loop" while the forking walker is never looked at.
+    #
+    # A zero out of a pipeline is a claim about the pipeline, and so is a one
+    # where two were meant.
     assert_ne "$body" ""
-    assert_contains "$body" "while IFS= read -r line"
+    local loops; loops="$(grep -c 'while IFS= read -r line' <<<"$body")"
+    assert_eq "$loops" "2" "both walkers have to be in the extraction"
 
     # No `$(...)` inside either walker. `$(( ))` is arithmetic and is not one.
     local subs; subs="$(grep -n '\$(' <<<"$body" | grep -v '\$((' || true)"

--- a/tests/check_reporting_test.sh
+++ b/tests/check_reporting_test.sh
@@ -179,3 +179,92 @@ exit_with_status')"
     local out; out="$(_crp_run "$d")"
     assert_contains "$out" "⚠"
 }
+
+# --- a gate that examined nothing has not passed -----------------------------
+#
+# `./check` sourced `init` unchecked. `init` refuses below bash 4 with a
+# `return`, and a `return` returns to whoever sourced it: it cannot stop them.
+# So on macOS under `/bin/bash` the gate printed the refusal, ran its whole
+# body with no modules loaded, found nothing to run, and reported
+# `PASSED - All 0 checks passed` with exit 0. `release` gates on that command.
+#
+# Two independent guards, because either alone leaves a hole. The source line
+# stops this particular cause; the zero-check refusal stops every other way a
+# run can end up examining nothing.
+
+# A nutshell whose `init` refuses, and this repo's `check` beside it.
+_crp_refusing_nutshell() {
+    local d="$_CRP_TMP/refusing"
+    rm -rf "$d"; mkdir -p "$d"
+    cp -R "$_CRP_NUT/lib" "$_CRP_NUT/examples" "$d/" 2>/dev/null
+    cp "$_CRP_NUT/check" "$d/check"
+    # `init` that says no, the way it does on bash 3.
+    {
+        printf 'printf "nutshell needs bash 4.0 or newer.\\n" >&2\n'
+        printf 'return 1 2>/dev/null || exit 1\n'
+    } > "$d/init"
+    chmod +x "$d/check"
+    printf '%s' "$d"
+}
+
+#[test]
+it_refuses_rather_than_passing_when_nutshell_will_not_load() {
+    local d; d="$(_crp_refusing_nutshell)"
+    local out rc=0
+    out="$( (cd "$d" && ./check) 2>&1 )" || rc=$?
+
+    assert_ne "$rc" "0"
+    # And it must not have said the word that made this dangerous.
+    assert_eq "${out#*All 0 checks passed}" "$out"
+}
+
+#[test]
+it_fails_with_the_reason_rather_than_shell_noise() {
+    # The source guard on its own, and what it is actually worth.
+    #
+    # The zero-check refusal below turns this scenario into a failure too, and
+    # `set -u` often kills the unguarded run on an unbound variable before it
+    # gets anywhere, so "did it fail" cannot separate them. What separates them
+    # is *what the reader is told*.
+    #
+    # Guarded, the source line is the last thing that runs and the refusal is
+    # the whole output. Unguarded, the body runs on with no modules loaded and
+    # the reader gets `use: command not found` and `NUTSHELL_ROOT: unbound
+    # variable` on top of it, or, where nothing happens to be unbound, a
+    # summary saying everything passed.
+    local d; d="$(_crp_refusing_nutshell)"
+    local out
+    out="$( (cd "$d" && ./check) 2>&1 )" || true
+
+    assert_contains "$out" "bash 4.0 or newer"
+    assert_eq "${out#*unbound variable}" "$out" "it kept going with nothing loaded"
+    assert_eq "${out#*command not found}" "$out" "it kept going with nothing loaded"
+    assert_eq "${out#*checks passed}" "$out" "it reached a verdict with nothing loaded"
+}
+
+#[test]
+it_says_no_checks_ran_rather_than_all_of_them_passing() {
+    # The second guard on its own. A project that names no checks and runs no
+    # builtins reaches the summary with a working nutshell and nothing done.
+    local d="$_CRP_TMP/nothing-to-run"
+    mkdir -p "$d"
+    printf '[qa]\ncustom_checks = []\nrun_builtins = false\n' > "$d/nut.toml"
+
+    local out rc=0
+    out="$(_crp_run "$d")" || rc=$?
+
+    assert_ne "$rc" "0"
+    assert_contains "$out" "no checks ran"
+}
+
+#[test]
+it_still_passes_a_project_that_has_a_check_and_it_succeeds() {
+    # The control for both. A refusal that fired on every run would satisfy the
+    # two above and make the gate useless.
+    local d; d="$(_crp_project ok-run 'exit 0')"
+    local out rc=0
+    out="$(_crp_run "$d")" || rc=$?
+
+    assert_eq "$rc" "0"
+    assert_contains "$out" "PASSED"
+}

--- a/tests/checkcache_test.sh
+++ b/tests/checkcache_test.sh
@@ -286,8 +286,10 @@ _stat_stub() {
     mkdir -p "$dir"
     case "$kind" in
         gnu)
-            # `-c` works. `-f` exits 0 and prints filesystem noise, which is
-            # the whole hazard.
+            # `-c` works and expands directives the way GNU does. `-f` exits 0
+            # and prints filesystem noise, which is the whole hazard: written
+            # against exit status, the chooser picks `-f` here and every stamp
+            # on Linux is garbage that compares equal to itself.
             cat > "$dir/stat" <<'STUB'
 #!/bin/sh
 if [ "$1" = "-c" ]; then
@@ -295,11 +297,9 @@ if [ "$1" = "-c" ]; then
     for f do
         m=$(/usr/bin/stat -f '%m' "$f" 2>/dev/null) || exit 1
         z=$(/usr/bin/stat -f '%z' "$f" 2>/dev/null) || exit 1
-        case "$fmt" in
-            '%Y %s %n') printf '%s %s %s\n' "$m" "$z" "$f" ;;
-            '%Y')       printf '%s\n' "$m" ;;
-            *)          printf '?\n' ;;
-        esac
+        out=$fmt
+        out=$(printf '%s' "$out" | sed -e "s|%Y|$m|g" -e "s|%s|$z|g" -e "s|%n|$f|g")
+        printf '%s\n' "$out"
     done
     exit 0
 fi
@@ -319,6 +319,32 @@ shift; fmt="$1"; shift
 exec /usr/bin/stat -f "$fmt" "$@"
 STUB
             ;;
+        gnu-numeric)
+            # The premise the digit test rested on, denied. A `stat` whose
+            # wrong-flag output *starts with a number* passes any "first field
+            # looks numeric" probe, and the chooser then picks `-f` on a
+            # machine where `-f` is not a format flag at all. Nothing here can
+            # rule such a `stat` out, so the detection stops depending on it.
+            cat > "$dir/stat" <<'STUB'
+#!/bin/sh
+if [ "$1" = "-c" ]; then
+    shift; fmt="$1"; shift
+    for f do
+        m=$(/usr/bin/stat -f '%m' "$f" 2>/dev/null) || exit 1
+        z=$(/usr/bin/stat -f '%z' "$f" 2>/dev/null) || exit 1
+        out=$(printf '%s' "$fmt" | sed -e "s|%Y|$m|g" -e "s|%s|$z|g" -e "s|%n|$f|g")
+        printf '%s\n' "$out"
+    done
+    exit 0
+fi
+if [ "$1" = "-f" ]; then
+    shift; shift
+    for f do printf '4096 1000000 500000\n'; done
+    exit 0
+fi
+exit 1
+STUB
+            ;;
         none)
             printf '#!/bin/sh\nexit 127\n' > "$dir/stat"
             ;;
@@ -328,7 +354,7 @@ STUB
     # The stub owns the whole PATH. Prepending leaves the real one reachable
     # by anything that resolves a second time, and then the test is about the
     # machine rather than about the stub.
-    for t in find sort head printf mktemp rm cat chmod sh; do
+    for t in find sort head printf mktemp rm cat chmod sh sed grep; do
         [[ -e "$dir/$t" ]] && continue
         local real; real="$(command -v "$t" 2>/dev/null)" || continue
         ln -sf "$real" "$dir/$t"
@@ -395,5 +421,20 @@ it_reads_a_real_mtime_and_size_through_whichever_stat_it_picked() {
     assert_ne "$got" ""
     assert_eq "${got#* }" "10"
     [[ "${got%% *}" =~ ^[0-9]+$ ]] || _test_failed "mtime is not a number: [${got%% *}]"
+    rm -rf "$d"
+}
+
+#[test]
+it_is_not_fooled_by_a_stat_whose_wrong_flag_prints_numbers() {
+    # The control for the two picks above, and the reason the detection writes
+    # a file of known size rather than looking for a leading digit.
+    #
+    # This `stat` is GNU: `-c` is the format flag and `-f` asks about the file
+    # system. Its `-f` output happens to begin with a block size. A probe that
+    # accepted "the first field is a number" picks `-f` here and is wrong about
+    # every stamp afterwards, on the platform where it matters.
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")"
+    _stat_stub "$d" gnu-numeric
+    assert_eq "$(_stat_flag_under "$d")" "-c"
     rm -rf "$d"
 }


### PR DESCRIPTION
`./check` sourced `init` unchecked. `init` refuses on a bash older than 4 with a `return`, and a `return` returns to whoever sourced it: it cannot stop them. So the gate printed the refusal, carried on with no modules loaded, found nothing to run, and reported `PASSED - All 0 checks passed` with exit 0.

On macOS, under `/bin/bash`, which is the exact machine the refusal exists for. And `release` gates on that command.

This is embarrassing twice over. It is the class already fixed one level down in `lib/test.sh`, in the other runner, in the same session. And it is the unchecked-source pattern applied carefully to eight readme examples and not to this repository's own two entry points.

## Two guards, because either alone leaves a hole

`check` and `test` both carry `|| exit 1` on the bootstrap. `_print_summary` refuses `TOTAL_CHECKS -eq 0` the way `test_run` refuses a file that yields no tests. The first stops this cause; the second stops every other way a run ends up having examined nothing.

Their observables differ, which is what took a few goes to get right. The zero-check refusal is about the verdict. The source guard is about what the reader is told: guarded, the refusal is the whole output; unguarded, they get `use: command not found` and `NUTSHELL_ROOT: unbound variable` on top of it, or a verdict. Writing the second test against "did it fail" made it pass under either, since `set -u` often kills the unguarded run anyway.

## Two more from the same round

Both places where a guard was written against a premise instead of against the thing it was for.

`it_spawns_nothing_while_walking_a_file` closed the case where both `attr` walkers are renamed and left the one that matters. Rename `attr_on` alone, keep a wrapper, put a fork in its read loop: `attr_find`'s text on its own satisfies both "non-empty" and "contains a read loop", and the forking walker is never looked at. It counts two loops now.

The `stat` flavour probe accepted a first field that looked numeric. That rests on no `stat` anywhere leading its wrong-flag output with a number, and nothing here can check that: GNU prints the literal `%m`, but a version that led with a block count would be picked as `-f` on Linux with everything downstream wrong. It writes ten bytes and requires the size back as ten, which only the right spelling can do, and a fourth stub whose `-f` prints `4096 1000000 500000` is the control.

## Sanity

545 pass, was 540. Gate is the same four warnings, and it is now a gate that says so rather than one that would have said PASSED with nothing loaded.

Each guard dies to its own test and to no other:

| mutation | dies |
|---|---|
| drop `\|\| exit 1` from `check`'s bootstrap | `it_fails_with_the_reason_rather_than_shell_noise` |
| drop the zero-check refusal | `it_says_no_checks_ran_rather_than_all_of_them_passing` |
| refuse always | `it_still_passes_a_project_that_has_a_check_and_it_succeeds` |
| rename `attr_on` only, wrapper, fork in its loop | `it_spawns_nothing_while_walking_a_file` |
| `stat` detection back to the leading digit | `it_is_not_fooled_by_a_stat_whose_wrong_flag_prints_numbers` |