### PR TITLE
fix: a store entry that is not the release it is named for

### DIFF
--- a/find-nutshell
+++ b/find-nutshell
@@ -404,6 +404,12 @@ nutshell_toolchains() {
         name="${d%/}"; name="${name##*/}"
         v="$(_nutshell_version_of "${d}init")" || continue
         [[ "$v" == "$name" ]] || continue
+        # And it has to say where it came from. An entry without the record
+        # was written by a nutshell that did not keep one, or by hand, and
+        # there is no way to tell whether it is the release it is named for.
+        # Skipping it means the next request refetches, which is the cheap and
+        # correct answer; keeping it means trusting a name.
+        [[ -f "${d}.fetched" ]] || continue
         printf '%s\n' "$v"
     done | _nutshell_sort_versions
 }
@@ -546,6 +552,35 @@ _nutshell_fetch() {
         printf 'nutshell: %s in %s reports itself as %s\n' "$want" "$remote" "${got:-nothing}" >&2
         _nutshell_remember_failure "$want"
         return 1
+    fi
+
+    # What this actually is, written before it is adopted, so the record moves
+    # into place with the content in one rename.
+    #
+    # A version string is not a content hash. Anything reporting `0.4.0` fills
+    # a `0.4.0` directory, and the tree on `dev` reports the next version for
+    # the whole stretch before that version is tagged. So a fetch during that
+    # stretch, or from a branch whose name shadows a tag, lands content that is
+    # not the release and passes every check afterwards, because the directory
+    # and the interpreter inside it agree.
+    #
+    # Observed: a `toolchains/0.4.0` holding a tree from before the tag, which
+    # nothing detected and which the store would have kept forever, since a
+    # directory that exists is adopted rather than replaced.
+    {
+        printf 'ref %s\n' "$want"
+        printf 'remote %s\n' "$remote"
+        printf 'commit %s\n' "$(git -C "$tmp" rev-parse HEAD 2>/dev/null)"
+    } > "${tmp}/.fetched" 2>/dev/null
+
+    # An entry already sitting there without a record cannot be trusted and
+    # cannot simply be adopted, because adoption keeps whoever got there first.
+    # It is moved aside rather than removed: something may be sourcing out of
+    # it right now, and a rename leaves an open file alone where a delete does
+    # not. What is left behind is invisible to `nutshell_toolchains`, since its
+    # name is not a version.
+    if [[ -d "$dir" && ! -f "${dir}/.fetched" ]]; then
+        mv "$dir" "${dir}.unrecorded.$$" 2>/dev/null || rm -rf "$tmp"
     fi
 
     _nutshell_adopt "$tmp" "$dir" || return 1

--- a/tests/toolchain_test.sh
+++ b/tests/toolchain_test.sh
@@ -42,6 +42,19 @@ _tc_store() {
     mkdir -p "$NUTSHELL_TOOLCHAINS/$name"
     printf 'export NUTSHELL_VERSION="%s"\n' "$v" \
         > "$NUTSHELL_TOOLCHAINS/$name/init"
+    # What a fetch leaves behind. An entry without it is not trusted, since a
+    # version string is not a content hash and a directory named for a release
+    # can hold something else that also calls itself that.
+    printf 'ref %s\nremote test\ncommit 0000000\n' "$v" \
+        > "$NUTSHELL_TOOLCHAINS/$name/.fetched"
+}
+
+# The same, minus the record: what an older nutshell left, or a hand-made
+# directory.
+_tc_store_unrecorded() {
+    local v="$1" name="${2:-$1}"
+    _tc_store "$v" "$name"
+    rm -f "$NUTSHELL_TOOLCHAINS/$name/.fetched"
 }
 
 # A remote holding one tagged version, so a fetch has somewhere real to go.
@@ -359,11 +372,40 @@ it_adopts_the_copy_that_got_there_first_instead_of_deleting_it() {
     # A fetch that deletes and replaces loses the mark; one that adopts what is
     # there keeps it, and both answers are the same version, which is the whole
     # reason adopting is allowed.
-    mkdir -p "$NUTSHELL_TOOLCHAINS/0.4.0"
-    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$NUTSHELL_TOOLCHAINS/0.4.0/init"
+    #
+    # Recorded, because that is what the loser of a real race finds: the winner
+    # writes its record into the scratch copy before the rename, so the two
+    # arrive together. An unrecorded directory is a different situation and is
+    # the test below.
+    _tc_store 0.4.0
     printf 'in use\n' > "$NUTSHELL_TOOLCHAINS/0.4.0/marker"
     assert_ok _nutshell_fetch 0.4.0 >/dev/null 2>&1
     assert_ok test -f "$NUTSHELL_TOOLCHAINS/0.4.0/marker"
+    _tc_end
+}
+
+#[test]
+it_moves_an_unrecorded_entry_aside_rather_than_adopting_it() {
+    _tc_setup
+    _tc_remote 0.4.0
+    _tc_store_unrecorded 0.4.0
+    printf 'not the release\n' > "$NUTSHELL_TOOLCHAINS/0.4.0/marker"
+
+    assert_ok _nutshell_fetch 0.4.0 >/dev/null 2>&1
+    # The fetched copy is in place, so the marker is gone from the name.
+    assert_fails test -f "$NUTSHELL_TOOLCHAINS/0.4.0/marker"
+    assert_ok test -f "$NUTSHELL_TOOLCHAINS/0.4.0/.fetched"
+
+    # Moved, not deleted. Something may be sourcing out of it, and a rename
+    # leaves an open file alone where a delete does not.
+    local aside=0 d
+    for d in "$NUTSHELL_TOOLCHAINS"/0.4.0.unrecorded.*; do
+        [[ -f "$d/marker" ]] && aside=1
+    done
+    assert_eq "$aside" "1" "the old directory should still be on disk"
+
+    # And what is left behind is invisible, because its name is not a version.
+    assert_eq "$(nutshell_toolchains)" "0.4.0"
     _tc_end
 }
 
@@ -549,4 +591,55 @@ it_follows_the_data_home_override_the_same_way_the_module_does() {
     [[ -n "$keep_store" ]] && export NUTSHELL_STORE="$keep_store"
     [[ -n "$keep_tc" ]] && export NUTSHELL_TOOLCHAINS="$keep_tc"
     return 0
+}
+
+# --- an entry that cannot say where it came from -----------------------------
+#
+# A version string is not a content hash. Everything reporting `0.4.0` fits a
+# `0.4.0` directory, and the tree on `dev` reports the next version for the
+# whole stretch before that version is tagged, so a fetch during that stretch
+# lands content that is not the release and then passes every check: the
+# directory and the interpreter inside it agree with each other perfectly.
+#
+# This was not hypothetical. A `toolchains/0.4.0` written before the 0.4.0 tag
+# existed sat in the real store on this machine, held a tree from before the
+# bash floor was added, and would have been handed to every consumer pinning
+# the release. Nothing detected it, and nothing would have replaced it, because
+# a directory that exists is adopted rather than overwritten.
+
+#[test]
+it_skips_an_entry_that_does_not_say_what_it_is() {
+    _tc_setup
+    _tc_store 0.4.0
+    _tc_store_unrecorded 0.5.0
+    # 0.5.0 agrees with its own name and is still not trusted, because nothing
+    # in it says it is the 0.5.0 release rather than something that said so.
+    assert_eq "$(nutshell_toolchains)" "0.4.0"
+    _tc_end
+}
+
+#[test]
+it_refetches_rather_than_handing_out_an_unrecorded_entry() {
+    _tc_setup
+    _tc_remote 0.4.0
+    _tc_store_unrecorded 0.4.0
+
+    assert_ok nutshell_find "" 0.4.0 2>/dev/null
+    # `fetched` and not `toolchain`, which is the whole claim: the directory
+    # was sitting there, agreed with its own name, and was not handed back.
+    assert_eq "$NUTSHELL_FROM" "fetched"
+    assert_ok test -f "$NUTSHELL_TOOLCHAINS/0.4.0/.fetched"
+    _tc_end
+}
+
+#[test]
+it_still_takes_a_recorded_entry_without_fetching() {
+    # The control for both. Requiring a fresh fetch on every lookup would make
+    # the store pointless, and no remote is configured here, so a fetch would
+    # fail loudly rather than quietly succeed.
+    _tc_setup
+    _tc_store 0.4.0
+    assert_ok nutshell_find "" 0.4.0
+    assert_eq "$NUTSHELL_FROM" "toolchain"
+    _tc_end
 }


### PR DESCRIPTION
A version string is not a content hash. Everything reporting `0.4.0` fits a `0.4.0` directory, and the tree on `dev` reports the next version for the whole stretch before that version is tagged. So a fetch during that stretch, or from a branch whose name shadows a tag, lands content that is not the release, and then passes every check afterwards, because the directory and the interpreter inside it agree with each other perfectly.

Found by tagging `0.4.0` and watching the resolver hand back a tree from before the bash floor existed. The store on this machine held a `toolchains/0.4.0` written the previous evening, matching no commit on any branch, and it would have gone to every consumer pinning the release. Nothing detected it, and refetching would not have replaced it: a directory that exists is adopted rather than overwritten, which is right for two processes racing on the same version and wrong here.

## What a fetch leaves behind now

`ref`, `remote` and `commit`, written into the scratch copy before the rename, so the record arrives with the content in one step rather than as a second thing that can be missing.

An entry without one is not listed. Nothing in it says it is the release it is named for, so the next request refetches instead of trusting a name. Everything an older nutshell already wrote falls into this, which is the intended cost: one refetch per version, once.

An unrecorded entry already in place is moved aside rather than removed. Something may be sourcing out of it, and a rename leaves an open file alone where a delete does not. What is left behind is invisible to `nutshell_toolchains` because its name is no longer a version.

## One existing test changed rather than worked around

`it_adopts_the_copy_that_got_there_first_instead_of_deleting_it` built its incumbent by hand with no record, which is now a different situation entirely. A real race always leaves a recorded one, since the winner writes the record before the rename. Its fixture uses `_tc_store` now, and the unrecorded case gets its own test beside it.

## Sanity

549 pass, was 545. Gate is the same four warnings.

| mutation | dies |
|---|---|
| stop writing the record | the fetch test and both unrecorded tests |
| trust an entry with no record | `it_skips_an_entry_that_does_not_say_what_it_is`, `it_refetches_...` |
| adopt the unrecorded one anyway | `it_moves_an_unrecorded_entry_aside_...`, `it_refetches_...` |
| delete it instead of moving it | `it_moves_an_unrecorded_entry_aside_...` alone |

The resolver copies in `the-whole-shebang` and `hulilupteri` go with it; each repo's drift test is what says so.