### PR TITLE
chore: 0.4.1

### DIFF
--- a/bin/nutshell
+++ b/bin/nutshell
@@ -79,7 +79,7 @@ use extern log
 # scalar. Same shape mockspace.toml uses for the same job, because it is the
 # same job and a reader should not have to learn two spellings:
 #
-#     nutshell_version = "0.4.0"     the released form
+#     nutshell_version = "0.4.1"     the released form
 #     nutshell_branch  = "dev"       when there is no release yet
 #
 # Root level, before any [table] header. A bare key written after one belongs

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -462,7 +462,7 @@ for, not a requirement to copy either.
 It was not how it worked. Externs were already central and content-addressed;
 the interpreter was the exception, resolved by picking from what the machine
 happened to have and never fetching. That is the whole of the version trouble:
-`0.4.0` exists only on `dev`, nothing has tagged it, so no amount of resolving
+`0.4.0` existed only on `dev` with nothing tagged, so no amount of resolving
 could find it and the fallback to the vendored copy fired every run.
 
 Settled by this work: a toolchain store keyed by version, a fetch when the
@@ -564,9 +564,10 @@ itself in a file.
 Named before what it enables, because a closed gap reads as progress while a
 falsified claim announces nothing.
 
-- **`init:29`'s `NUTSHELL_VERSION`.** A constant somebody has to remember to
-  bump, which is why `main` says 0.2.0, `dev` says 0.4.0, and neither is a fact
-  about the code. It goes.
+- **`init`'s `NUTSHELL_VERSION`.** A constant somebody has to remember to bump,
+  so for the whole stretch between a bump and the tag that matches it, `dev`
+  reports a version that does not exist yet. That is what let a pre-release
+  tree fill a store directory named for a release. It goes.
 - **`find-nutshell:_nutshell_version_of`.** Reads that constant out of `init`
   without sourcing it. The whole function exists to serve the constant.
 - **The store's name-equals-contents invariant.** `nutshell_toolchains` skips a

--- a/init
+++ b/init
@@ -58,7 +58,7 @@ _NUTSHELL_ROOT="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 
 # Export for use by modules
 export NUTSHELL_ROOT="${_NUTSHELL_ROOT}"
-export NUTSHELL_VERSION="0.4.0"
+export NUTSHELL_VERSION="0.4.1"
 
 # Script identity belongs to the interpreter invocation, not to ancestry. The
 # interpreter exports NUTSHELL_SCRIPT and NUTSHELL_SCRIPT_DIR after this file


### PR DESCRIPTION
The store fix landed after `0.4.0` was tagged, and a published tag is not moved. So the release that carries it is a patch on top.

`docs/TODO.md` also said the version constant's trouble was that `main` and `dev` disagree. That is a symptom rather than the thing. The trouble is that `dev` reports a version which does not exist yet, for the whole stretch between a bump and the tag that matches it, and that is exactly what let a pre-release tree fill a store directory named for a release.

## Sanity

549 pass. `bin/nutshell`'s example pin says `0.4.1` so the documented form is one that resolves.