### PR TITLE
release: 0.4.1, a store entry that lied about which release it was

### DIFF
--- a/bin/nutshell
+++ b/bin/nutshell
@@ -79,7 +79,7 @@ use extern log
 # scalar. Same shape mockspace.toml uses for the same job, because it is the
 # same job and a reader should not have to learn two spellings:
 #
-#     nutshell_version = "0.4.0"     the released form
+#     nutshell_version = "0.4.1"     the released form
 #     nutshell_branch  = "dev"       when there is no release yet
 #
 # Root level, before any [table] header. A bare key written after one belongs

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -462,7 +462,7 @@ for, not a requirement to copy either.
 It was not how it worked. Externs were already central and content-addressed;
 the interpreter was the exception, resolved by picking from what the machine
 happened to have and never fetching. That is the whole of the version trouble:
-`0.4.0` exists only on `dev`, nothing has tagged it, so no amount of resolving
+`0.4.0` existed only on `dev` with nothing tagged, so no amount of resolving
 could find it and the fallback to the vendored copy fired every run.
 
 Settled by this work: a toolchain store keyed by version, a fetch when the
@@ -564,9 +564,10 @@ itself in a file.
 Named before what it enables, because a closed gap reads as progress while a
 falsified claim announces nothing.
 
-- **`init:29`'s `NUTSHELL_VERSION`.** A constant somebody has to remember to
-  bump, which is why `main` says 0.2.0, `dev` says 0.4.0, and neither is a fact
-  about the code. It goes.
+- **`init`'s `NUTSHELL_VERSION`.** A constant somebody has to remember to bump,
+  so for the whole stretch between a bump and the tag that matches it, `dev`
+  reports a version that does not exist yet. That is what let a pre-release
+  tree fill a store directory named for a release. It goes.
 - **`find-nutshell:_nutshell_version_of`.** Reads that constant out of `init`
   without sourcing it. The whole function exists to serve the constant.
 - **The store's name-equals-contents invariant.** `nutshell_toolchains` skips a

--- a/find-nutshell
+++ b/find-nutshell
@@ -404,6 +404,12 @@ nutshell_toolchains() {
         name="${d%/}"; name="${name##*/}"
         v="$(_nutshell_version_of "${d}init")" || continue
         [[ "$v" == "$name" ]] || continue
+        # And it has to say where it came from. An entry without the record
+        # was written by a nutshell that did not keep one, or by hand, and
+        # there is no way to tell whether it is the release it is named for.
+        # Skipping it means the next request refetches, which is the cheap and
+        # correct answer; keeping it means trusting a name.
+        [[ -f "${d}.fetched" ]] || continue
         printf '%s\n' "$v"
     done | _nutshell_sort_versions
 }
@@ -546,6 +552,35 @@ _nutshell_fetch() {
         printf 'nutshell: %s in %s reports itself as %s\n' "$want" "$remote" "${got:-nothing}" >&2
         _nutshell_remember_failure "$want"
         return 1
+    fi
+
+    # What this actually is, written before it is adopted, so the record moves
+    # into place with the content in one rename.
+    #
+    # A version string is not a content hash. Anything reporting `0.4.0` fills
+    # a `0.4.0` directory, and the tree on `dev` reports the next version for
+    # the whole stretch before that version is tagged. So a fetch during that
+    # stretch, or from a branch whose name shadows a tag, lands content that is
+    # not the release and passes every check afterwards, because the directory
+    # and the interpreter inside it agree.
+    #
+    # Observed: a `toolchains/0.4.0` holding a tree from before the tag, which
+    # nothing detected and which the store would have kept forever, since a
+    # directory that exists is adopted rather than replaced.
+    {
+        printf 'ref %s\n' "$want"
+        printf 'remote %s\n' "$remote"
+        printf 'commit %s\n' "$(git -C "$tmp" rev-parse HEAD 2>/dev/null)"
+    } > "${tmp}/.fetched" 2>/dev/null
+
+    # An entry already sitting there without a record cannot be trusted and
+    # cannot simply be adopted, because adoption keeps whoever got there first.
+    # It is moved aside rather than removed: something may be sourcing out of
+    # it right now, and a rename leaves an open file alone where a delete does
+    # not. What is left behind is invisible to `nutshell_toolchains`, since its
+    # name is not a version.
+    if [[ -d "$dir" && ! -f "${dir}/.fetched" ]]; then
+        mv "$dir" "${dir}.unrecorded.$$" 2>/dev/null || rm -rf "$tmp"
     fi
 
     _nutshell_adopt "$tmp" "$dir" || return 1

--- a/init
+++ b/init
@@ -58,7 +58,7 @@ _NUTSHELL_ROOT="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 
 # Export for use by modules
 export NUTSHELL_ROOT="${_NUTSHELL_ROOT}"
-export NUTSHELL_VERSION="0.4.0"
+export NUTSHELL_VERSION="0.4.1"
 
 # Script identity belongs to the interpreter invocation, not to ancestry. The
 # interpreter exports NUTSHELL_SCRIPT and NUTSHELL_SCRIPT_DIR after this file

--- a/tests/toolchain_test.sh
+++ b/tests/toolchain_test.sh
@@ -42,6 +42,19 @@ _tc_store() {
     mkdir -p "$NUTSHELL_TOOLCHAINS/$name"
     printf 'export NUTSHELL_VERSION="%s"\n' "$v" \
         > "$NUTSHELL_TOOLCHAINS/$name/init"
+    # What a fetch leaves behind. An entry without it is not trusted, since a
+    # version string is not a content hash and a directory named for a release
+    # can hold something else that also calls itself that.
+    printf 'ref %s\nremote test\ncommit 0000000\n' "$v" \
+        > "$NUTSHELL_TOOLCHAINS/$name/.fetched"
+}
+
+# The same, minus the record: what an older nutshell left, or a hand-made
+# directory.
+_tc_store_unrecorded() {
+    local v="$1" name="${2:-$1}"
+    _tc_store "$v" "$name"
+    rm -f "$NUTSHELL_TOOLCHAINS/$name/.fetched"
 }
 
 # A remote holding one tagged version, so a fetch has somewhere real to go.
@@ -359,11 +372,40 @@ it_adopts_the_copy_that_got_there_first_instead_of_deleting_it() {
     # A fetch that deletes and replaces loses the mark; one that adopts what is
     # there keeps it, and both answers are the same version, which is the whole
     # reason adopting is allowed.
-    mkdir -p "$NUTSHELL_TOOLCHAINS/0.4.0"
-    printf 'export NUTSHELL_VERSION="0.4.0"\n' > "$NUTSHELL_TOOLCHAINS/0.4.0/init"
+    #
+    # Recorded, because that is what the loser of a real race finds: the winner
+    # writes its record into the scratch copy before the rename, so the two
+    # arrive together. An unrecorded directory is a different situation and is
+    # the test below.
+    _tc_store 0.4.0
     printf 'in use\n' > "$NUTSHELL_TOOLCHAINS/0.4.0/marker"
     assert_ok _nutshell_fetch 0.4.0 >/dev/null 2>&1
     assert_ok test -f "$NUTSHELL_TOOLCHAINS/0.4.0/marker"
+    _tc_end
+}
+
+#[test]
+it_moves_an_unrecorded_entry_aside_rather_than_adopting_it() {
+    _tc_setup
+    _tc_remote 0.4.0
+    _tc_store_unrecorded 0.4.0
+    printf 'not the release\n' > "$NUTSHELL_TOOLCHAINS/0.4.0/marker"
+
+    assert_ok _nutshell_fetch 0.4.0 >/dev/null 2>&1
+    # The fetched copy is in place, so the marker is gone from the name.
+    assert_fails test -f "$NUTSHELL_TOOLCHAINS/0.4.0/marker"
+    assert_ok test -f "$NUTSHELL_TOOLCHAINS/0.4.0/.fetched"
+
+    # Moved, not deleted. Something may be sourcing out of it, and a rename
+    # leaves an open file alone where a delete does not.
+    local aside=0 d
+    for d in "$NUTSHELL_TOOLCHAINS"/0.4.0.unrecorded.*; do
+        [[ -f "$d/marker" ]] && aside=1
+    done
+    assert_eq "$aside" "1" "the old directory should still be on disk"
+
+    # And what is left behind is invisible, because its name is not a version.
+    assert_eq "$(nutshell_toolchains)" "0.4.0"
     _tc_end
 }
 
@@ -549,4 +591,55 @@ it_follows_the_data_home_override_the_same_way_the_module_does() {
     [[ -n "$keep_store" ]] && export NUTSHELL_STORE="$keep_store"
     [[ -n "$keep_tc" ]] && export NUTSHELL_TOOLCHAINS="$keep_tc"
     return 0
+}
+
+# --- an entry that cannot say where it came from -----------------------------
+#
+# A version string is not a content hash. Everything reporting `0.4.0` fits a
+# `0.4.0` directory, and the tree on `dev` reports the next version for the
+# whole stretch before that version is tagged, so a fetch during that stretch
+# lands content that is not the release and then passes every check: the
+# directory and the interpreter inside it agree with each other perfectly.
+#
+# This was not hypothetical. A `toolchains/0.4.0` written before the 0.4.0 tag
+# existed sat in the real store on this machine, held a tree from before the
+# bash floor was added, and would have been handed to every consumer pinning
+# the release. Nothing detected it, and nothing would have replaced it, because
+# a directory that exists is adopted rather than overwritten.
+
+#[test]
+it_skips_an_entry_that_does_not_say_what_it_is() {
+    _tc_setup
+    _tc_store 0.4.0
+    _tc_store_unrecorded 0.5.0
+    # 0.5.0 agrees with its own name and is still not trusted, because nothing
+    # in it says it is the 0.5.0 release rather than something that said so.
+    assert_eq "$(nutshell_toolchains)" "0.4.0"
+    _tc_end
+}
+
+#[test]
+it_refetches_rather_than_handing_out_an_unrecorded_entry() {
+    _tc_setup
+    _tc_remote 0.4.0
+    _tc_store_unrecorded 0.4.0
+
+    assert_ok nutshell_find "" 0.4.0 2>/dev/null
+    # `fetched` and not `toolchain`, which is the whole claim: the directory
+    # was sitting there, agreed with its own name, and was not handed back.
+    assert_eq "$NUTSHELL_FROM" "fetched"
+    assert_ok test -f "$NUTSHELL_TOOLCHAINS/0.4.0/.fetched"
+    _tc_end
+}
+
+#[test]
+it_still_takes_a_recorded_entry_without_fetching() {
+    # The control for both. Requiring a fresh fetch on every lookup would make
+    # the store pointless, and no remote is configured here, so a fetch would
+    # fail loudly rather than quietly succeed.
+    _tc_setup
+    _tc_store 0.4.0
+    assert_ok nutshell_find "" 0.4.0
+    assert_eq "$NUTSHELL_FROM" "toolchain"
+    _tc_end
 }


### PR DESCRIPTION
A patch on `0.4.0`, released the same night, because the defect it fixes was found by tagging `0.4.0` and watching the resolver hand back the wrong thing.

## The store could hold something that was not the release

A version string is not a content hash. Everything reporting `0.4.0` fits a `0.4.0` directory, and the tree on `dev` reports the next version for the whole stretch before that version is tagged. So a fetch during that stretch lands content that is not the release and passes every check afterwards, because the directory and the interpreter inside it agree with each other perfectly.

The store on the machine that cut this release held exactly that: a `toolchains/0.4.0` written the previous evening, matching no commit on any branch, holding a tree from before the bash floor existed. It would have gone to every consumer pinning the release, and refetching would not have replaced it, since a directory that exists is adopted rather than overwritten.

A fetch records `ref`, `remote` and `commit` now, written before the rename so the record arrives with the content. An entry without one is not listed and the next request refetches. An unrecorded entry already in place is moved aside rather than removed, because something may be sourcing out of it and a rename leaves an open file alone where a delete does not.

## What this costs you

One refetch per version, once. Everything an older nutshell wrote into the store has no record, so the first run on `0.4.1` fetches it again and then settles.

Nothing else in the api moved. If you have not yet moved to `0.4.0`, its release notes are the ones to read; everything in them still applies.

## Sanity

549 pass. `./check` is `PASSED WITH WARNINGS` with four.

Each of the four mechanisms dies to its own test: dropping the record, trusting an entry without one, adopting an unrecorded entry anyway, and deleting it instead of moving it aside.