### PR TITLE
fix: a lock that recorded the tag rather than the commit it points at

### DIFF
--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -465,6 +465,17 @@ _extern_remote_ref() {
 
     # `^{}` is the commit an annotated tag points at, and it is the one to
     # build from; the bare line is the tag object itself.
+    #
+    # Asked for with a trailing `*`, because the exact pattern does not return
+    # the peeled line at all. `git ls-remote <url> refs/tags/0.1.0` gives one
+    # row and it is the tag object; the `^{}` row only appears under a glob.
+    # So this read the tag object every time, the `peeled` branch below never
+    # ran, and a lockfile pinning an annotated tag recorded a sha that is not
+    # a commit and can never equal any checkout's `HEAD`.
+    #
+    # Two exact patterns rather than a glob, so nothing but those two rows
+    # can come back and the `case` below has nothing to filter out. A glob
+    # would also return `0.1.0-rc1`, which is a door with no reason to open.
     local peeled="" plain=""
     while IFS= read -r line; do
         sha="${line%%[[:space:]]*}"
@@ -472,7 +483,7 @@ _extern_remote_ref() {
             *"refs/tags/${ref}^{}") peeled="$sha" ;;
             *"refs/tags/${ref}")    plain="$sha"  ;;
         esac
-    done < <(git ls-remote "$url" "refs/tags/${ref}" 2>/dev/null)
+    done < <(git ls-remote "$url" "refs/tags/${ref}" "refs/tags/${ref}^{}" 2>/dev/null)
     [[ -n "$peeled" ]] && { printf 'tags %s' "$peeled"; return 0; }
     [[ -n "$plain" ]]  && { printf 'tags %s' "$plain";  return 0; }
     return 1

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -972,3 +972,74 @@ it_does_not_wait_out_the_clock_for_a_parent_that_is_merely_absent() {
     # margin either way.
     assert_ok test "$(( end - start ))" -lt 5
 }
+
+# --- what a tag resolves to --------------------------------------------------
+#
+# An annotated tag is two objects: the tag, and the commit it points at.
+# `git ls-remote <url> refs/tags/x` returns only the first, and the peeled
+# `refs/tags/x^{}` row appears only when the pattern lets it. So a resolver
+# that asks for the exact ref and then handles `^{}` has code for a case it
+# never sees, which is what this had.
+#
+# The consequence is quiet. A lockfile pinning an annotated tag recorded the
+# tag object's sha, which is not a commit and can never equal any checkout's
+# `HEAD`, so nothing that compares them can ever agree. Found by tagging
+# the-whole-shebang `0.1.0` and reading the lock it produced.
+
+_ex_tagged_repo() {
+    local kind="$1"
+    local d; d="$(_ex_tmp tagrepo)"
+    git -C "$d" init -q -b main
+    git -C "$d" config user.email t@example.invalid
+    git -C "$d" config user.name  t
+    printf 'one\n' > "$d/f"
+    git -C "$d" add f
+    git -C "$d" commit -q -m one
+    case "$kind" in
+        annotated) git -C "$d" tag -a v1 -m "release v1" ;;
+        # Written as a ref rather than through `git tag`, which is what a
+        # lightweight tag is. This machine's config forces annotation, so
+        # `git tag v1` asks for a message and makes the other kind.
+        light)     git -C "$d" update-ref refs/tags/v1 "$(git -C "$d" rev-parse HEAD)" ;;
+    esac
+    printf '%s' "$d"
+}
+
+#[test]
+it_resolves_an_annotated_tag_to_the_commit_and_not_to_the_tag() {
+    local d; d="$(_ex_tagged_repo annotated)"
+    local want; want="$(git -C "$d" rev-parse 'v1^{}')"
+    local tagobj; tagobj="$(git -C "$d" rev-parse v1)"
+
+    # The control for the test itself: an annotated tag has to have two
+    # different shas, or this proves nothing about which one came back.
+    assert_ne "$tagobj" "$want"
+
+    local got; got="$(_extern_remote_ref "$d" v1)"
+    assert_eq "$got" "tags ${want}"
+}
+
+#[test]
+it_resolves_a_lightweight_tag_to_the_same_commit() {
+    # The control. A lightweight tag is the commit, so both readings agree and
+    # a resolver that always took the bare row would pass this. It is here so
+    # the fix above cannot be a change that only works for one shape.
+    local d; d="$(_ex_tagged_repo light)"
+    local want; want="$(git -C "$d" rev-parse 'v1^{}')"
+    assert_eq "$(git -C "$d" rev-parse v1)" "$want"
+    assert_eq "$(_extern_remote_ref "$d" v1)" "tags ${want}"
+}
+
+#[test]
+it_prefers_a_branch_over_a_tag_of_the_same_name() {
+    # Unchanged behaviour, pinned because the glob above widened what the tag
+    # query returns and this is the neighbouring decision.
+    local d; d="$(_ex_tagged_repo annotated)"
+    git -C "$d" checkout -q -b v1 2>/dev/null
+    printf 'two\n' > "$d/f"; git -C "$d" add f; git -C "$d" commit -q -m two
+    # By its full ref, because a branch and a tag of the same name make the
+    # short name ambiguous and git resolves it to the tag.
+    local head; head="$(git -C "$d" rev-parse refs/heads/v1)"
+
+    assert_eq "$(_extern_remote_ref "$d" v1)" "heads ${head}"
+}


### PR DESCRIPTION
An annotated tag is two objects, the tag and the commit under it, and `git ls-remote <url> refs/tags/x` returns only the first. The peeled `refs/tags/x^{}` row appears only when the pattern asks for it.

So the resolver here had a branch for `^{}` and never saw one. Every annotated tag resolved to the tag object, which is not a commit and can never equal any checkout's `HEAD`, so a lockfile pinning one recorded a sha that nothing can be compared against. The code reads as if it handles this, which is why it lasted.

Found by tagging `the-whole-shebang 0.1.0` and reading the lock hulilupteri then wrote: `f22ab18` where the commit is `2039130`.

```
$ git ls-remote <url> refs/tags/0.1.0
f22ab18…  refs/tags/0.1.0

$ git ls-remote <url> refs/tags/0.1.0 'refs/tags/0.1.0^{}'
f22ab18…  refs/tags/0.1.0
2039130…  refs/tags/0.1.0^{}
```

Two exact patterns rather than a glob. A glob returns the peeled row too and also returns `0.1.0-rc1`, which is a door with no reason to open.

## Sanity

552 pass. Gate unchanged at four warnings.

Three tests, and the second is what makes the first mean anything: a lightweight tag resolves to the same commit either way, so a fix that only worked for one shape would pass the annotated case on its own. The third pins that a branch still beats a tag of the same name, which is the neighbouring decision.

| mutation | dies |
|---|---|
| back to the exact single pattern | the annotated test |
| prefer the tag object over the commit | the annotated test |
| drop the branch-first lookup | three, including the branch-beats-tag one |

A fourth test was written and then deleted rather than kept. It asserted that a longer tag starting the same way is not taken, against a query that cannot return one, so no mutation could make it fail. Its own comment claimed the query was a glob, which it had been for about a minute while I was writing it.