### PR TITLE
feat: a bench harness, so a measurement can be compared instead of retaken

### DIFF
--- a/bench
+++ b/bench
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/bench - Run the benches
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# The third entry point, beside `test` and `check`. There was none, so every
+# performance question here was answered by a one-off script nobody could run
+# again, and the number then travelled without the conditions it was taken
+# under.
+#
+# A bench is a directory under `benches/` holding a `bench.sh` that declares its
+# arms. Its records land in `benches/<name>/results/` and are committed, so a
+# later reader compares against what was measured rather than rerunning to find
+# out whether they agree.
+#
+# Usage:
+#   ./bench                     every bench
+#   ./bench maps                one of them
+#   ./bench maps 20000          and its own arguments
+# =============================================================================
+
+set -uo pipefail
+
+# `|| exit 1`, because `init` refuses below bash 4 with a `return` and a
+# `return` cannot stop its caller.
+# shellcheck source=/dev/null
+. "${BASH_SOURCE[0]%/*}/init" || exit 1
+
+use log
+
+HERE="${BASH_SOURCE[0]%/*}"
+BENCH_DIR="${HERE}/benches"
+
+_list() {
+    local d
+    for d in "$BENCH_DIR"/*/; do
+        [[ -f "${d}bench.sh" ]] || continue
+        d="${d%/}"; printf '%s\n' "${d##*/}"
+    done
+}
+
+_run_one() {
+    local name="$1"; shift
+    local file="${BENCH_DIR}/${name}/bench.sh"
+    [[ -f "$file" ]] || { log_error "no bench called ${name}"; return 1; }
+
+    # Each in its own process. A bench declares global arms and a size, and two
+    # sharing a shell would read each other's.
+    (
+        export BENCH_RESULTS="${BENCH_DIR}/${name}/results"
+        # shellcheck source=/dev/null
+        . "$file" "$@"
+    )
+}
+
+main() {
+    local -a names=()
+    if [[ $# -gt 0 && -d "${BENCH_DIR}/$1" ]]; then
+        names=("$1"); shift
+    else
+        while IFS= read -r n; do [[ -n "$n" ]] && names+=("$n"); done < <(_list)
+    fi
+
+    if [[ ${#names[@]} -eq 0 ]]; then
+        log_error "no benches under ${BENCH_DIR}"
+        printf '  a bench is a directory with a bench.sh in it.\n' >&2
+        return 1
+    fi
+
+    local n rc=0
+    for n in "${names[@]}"; do
+        log_step "$n"
+        _run_one "$n" "$@" || rc=1
+        printf '\n'
+    done
+    return "$rc"
+}
+
+main "$@"

--- a/benches/maps/bench.sh
+++ b/benches/maps/bench.sh
@@ -1,41 +1,29 @@
 #!/usr/bin/env bash
 # =============================================================================
-# nutshell/tools/assoc-array-report - What a map costs without bash arrays
+# nutshell/benches/maps - What a map costs without bash associative arrays
 # =============================================================================
 #
-# POSIX sh has no associative arrays. nutshell uses them in the places that
-# decide how fast it is: the config cache, the toolchain store tables, the
-# attribute tables, and the file-line table the QA checks read. So "make
-# nutshell POSIX" has a price, and the price is a number rather than an
-# opinion. This is the number.
+# POSIX sh has no associative arrays. nutshell uses them where they decide how
+# fast it is: the config cache, the toolchain tables, the attribute tables, and
+# the file-line table the QA checks read. So "make nutshell POSIX" has a price,
+# and the price is a number rather than an opinion.
 #
-# **A report, not a gate.** There is no threshold anybody can justify here; the
-# decision it feeds is a design one.
-#
-# **Two arms are not maps and are labelled so in the table.** `slots by index`
-# and `slots by stride` are what a map becomes once the key has already been
-# resolved: the caller holds the index. They belong here because the gap
-# between them and the arms beside them prices the key lookup, which is the
-# thing a design would be trading away. They are not alternatives to
-# `declare -A` and the table must not read as though they were.
-#
-# **This is not a bench.** nutshell has no bench harness, so this is an ad-hoc
-# measurement and is called that. It does what it can without one: every arm is
-# a real alternative somebody would actually reach for, the arms run on the
-# same generated input, the input is shaped like nutshell's own keys, and the
-# controls below refuse to print numbers the instrument cannot support.
+# **Two arms are not maps and are labelled so.** `slots by index` and `slots by
+# stride` are what a map becomes once the key has already been resolved and the
+# caller holds the index. They are here because the gap between them and the
+# arms beside them prices the key lookup, which is the thing a design would be
+# trading away. They are not alternatives to `declare -A`.
 #
 # The size defaults to the largest real table: `_PAD_LINES` in the docs check
-# holds one entry per line of source, which on this library is 9606 across 24
-# files. The keys are the real shape too, `<path>:<n>`, because two of the arms
-# cannot take a key with a slash or a colon in it and the encoding that fixes
-# that is part of what they cost.
+# holds one entry per line of source, 9606 across 24 files. The keys are the
+# real shape too, `<path>:<n>`, because two arms cannot take a key with a slash
+# or a colon in it and the encoding that fixes that is part of what they cost.
 #
 # Usage:
-#   tools/assoc-array-report [entries] [lookups]
+#   ./bench maps [entries] [lookups]
 # =============================================================================
 
-set -uo pipefail
+use bench
 
 ENTRIES="${1:-2000}"
 LOOKUPS="${2:-500}"
@@ -346,156 +334,39 @@ arm_hand_rolled_hash() {
     printf '%s' "$last"
 }
 
+
 # -----------------------------------------------------------------------------
-# Running them
+# The bench
 # -----------------------------------------------------------------------------
 
-# One arm, run several times, reported as its best and its spread.
-#
-# A single timing of a 5ms arm is not a measurement. Observed on this machine,
-# four consecutive runs of the same arm at the same size: 5, 5, 35, 5. The
-# ratio column then read 160%, 160%, 25%, 180% for the arm beside it, and the
-# old control passed every time, because it only asked whether *any* arm
-# differed from the first by a millisecond across a set spanning 5ms to 3s.
-#
-# The minimum is the estimator rather than the mean: every source of noise here
-# adds time and none removes it, so the fastest run is the one least disturbed.
-# The spread is kept and printed, because a number without one cannot be
-# compared against another number.
-_REPEATS="${ASSOC_REPEATS:-7}"
+_generate
 
-_time_once() {
-    local fn="$1" start end
-    start="$(date +%s%N 2>/dev/null)" || return 1
-    "$fn" >/dev/null
-    end="$(date +%s%N 2>/dev/null)" || return 1
-    printf '%s' "$(( (end - start) / 1000000 ))"
-}
+# Every arm prints the value it last found, which is how they are compared. An
+# arm whose encoding collides two keys answers differently, and the harness
+# then refuses the whole run rather than reporting that arm as the fastest.
+_answer_of() { "$1"; }
 
-# Sets _ARM_BEST and _ARM_WORST.
-_measure() {
-    local fn="$1" i t
-    _ARM_BEST=""; _ARM_WORST=""
-    for (( i = 0; i < _REPEATS; i++ )); do
-        t="$(_time_once "$fn")" || return 1
-        [[ -z "$_ARM_BEST"  || "$t" -lt "$_ARM_BEST"  ]] && _ARM_BEST="$t"
-        [[ -z "$_ARM_WORST" || "$t" -gt "$_ARM_WORST" ]] && _ARM_WORST="$t"
-    done
-    return 0
-}
+bench_case "What a map costs without bash associative arrays"
+bench_size "$ENTRIES"
+bench_verify _answer_of
 
-main() {
-    _generate
+# The first is the baseline. Ceilings are stated per arm rather than hidden,
+# because which arms have one at all is itself the result: the two that address
+# a key directly have none.
+bench_arm "bash declare -A"                  arm_bash_assoc
+bench_arm "eval names, encoded via subshell" arm_eval_names        4000
+bench_arm "eval names, encoded in place"     arm_eval_names_nofork
+bench_arm "one string, scanned"              arm_one_string         800
+bench_arm "one file, read in shell"          arm_one_file          4000
+bench_arm "one file per key"                 arm_dir_table
+bench_arm "one file per key, in memory"      arm_memfs_table        0 "no memory filesystem here"
+bench_arm "slots by index (not a map)"       arm_slots_by_index
+bench_arm "slots by stride (not a map)"      arm_slots_by_stride
+bench_arm "hash table rolled by hand"        arm_hand_rolled_hash  4000
 
-    printf 'What a map costs without bash associative arrays\n\n'
-    printf '  entries   %s\n' "$ENTRIES"
-    printf '  lookups   %s hits and %s misses\n' "$LOOKUPS" "$LOOKUPS"
-    printf '  keys      the real shape, <path>:<n>\n'
-    printf '  bash      %s\n' "${BASH_VERSION:-unknown}"
-    printf '  host      %s %s\n\n' "$(uname -s)" "$(uname -m)"
+bench_run || exit 1
 
-    local -a names=(arm_bash_assoc arm_eval_names arm_eval_names_nofork
-                    arm_one_string arm_one_file arm_dir_table arm_memfs_table
-                    arm_slots_by_index arm_slots_by_stride arm_hand_rolled_hash)
-    local -a labels=("bash declare -A" "eval names, encoded via subshell"
-                     "eval names, encoded in place" "one string, scanned"
-                     "one file, read in shell" "one file per key"
-                     "one file per key, in memory"
-                     "slots by index (not a map)"
-                     "slots by stride (not a map)"
-                     "hash table rolled by hand")
-    # Above these sizes an arm takes long enough that running it stops being
-    # worth the wait. Stated per arm rather than hidden, because which arms
-    # have a ceiling at all is itself the result: the two that address a key
-    # directly have none.
-    local -a ceiling=(0 4000 0 800 4000 0 0 0 0 4000)
-    local -a best=() worst=()
-    local i t
-
-    for (( i = 0; i < ${#names[@]}; i++ )); do
-        if (( ceiling[i] > 0 && ENTRIES > ceiling[i] )); then
-            best+=("-"); worst+=("-")
-            continue
-        fi
-        _measure "${names[$i]}" || {
-            printf 'no nanosecond clock here; cannot measure\n' >&2; return 1; }
-        best+=("$_ARM_BEST"); worst+=("$_ARM_WORST")
-    done
-
-    # The control that matters most: every arm has to give the same answers.
-    # Comparing a fast wrong one against a slow right one is not a comparison,
-    # and an arm whose encoding collides two keys would look excellent.
-    local want="" got=""
-    for (( i = 0; i < ${#names[@]}; i++ )); do
-        [[ "${best[$i]}" == "-" ]] && continue
-        got="$("${names[$i]}")"
-        [[ "$got" == "SKIP" ]] && continue
-        if [[ -z "$want" ]]; then want="$got"; continue; fi
-        if [[ "$got" != "$want" ]]; then
-            printf 'arms disagree: %s answered %q where the first answered %q\n' \
-                "${labels[$i]}" "$got" "$want" >&2
-            return 1
-        fi
-    done
-
-    # And that the input is distinct enough to be worth answering.
-    local -A seen=(); local n
-    for (( i = 0; i < ENTRIES; i++ )); do
-        n="${KEYS[$i]//[^A-Za-z0-9_]/_}"
-        seen["$n"]=1
-    done
-    if (( ${#seen[@]} != ENTRIES )); then
-        printf 'the name encoding collides: %s keys became %s names\n' \
-            "$ENTRIES" "${#seen[@]}" >&2
-        return 1
-    fi
-
-    # The baseline has to be steady enough to divide by. This is the control
-    # the old one was missing: it compared arms to each other and never asked
-    # whether the number it divided by meant anything.
-    local base_best="${best[0]}" base_worst="${worst[0]}"
-    if [[ "$base_best" == "-" ]] || (( base_best <= 0 )); then
-        printf 'the baseline did not measure; nothing below can be a ratio\n' >&2
-        return 1
-    fi
-    if (( base_worst > base_best * 2 )); then
-        printf 'the baseline moved from %sms to %sms across %s runs.\n' \
-            "$base_best" "$base_worst" "$_REPEATS" >&2
-        printf 'this machine is too noisy right now for a ratio to mean anything.\n' >&2
-        printf 'raw times only:\n\n' >&2
-        for (( i = 0; i < ${#names[@]}; i++ )); do
-            printf '  %-34s %6s..%-6s\n' "${labels[$i]}" "${best[$i]}" "${worst[$i]}"
-        done
-        return 1
-    fi
-
-    printf '  %-34s %8s %9s  %s\n' "arm" "best ms" "spread" "against bash"
-    for (( i = 0; i < ${#names[@]}; i++ )); do
-        if [[ "${best[$i]}" == "-" ]]; then
-            printf '  %-34s %8s %9s  %s\n' "${labels[$i]}" "-" "-" "not run at this size"
-            continue
-        fi
-        if [[ "$("${names[$i]}")" == "SKIP" ]]; then
-            printf '  %-34s %8s %9s  %s\n' "${labels[$i]}" "-" "-" "no memory filesystem here"
-            continue
-        fi
-        # A ratio only where the two ranges do not overlap. Where they do, the
-        # arms are not distinguishable at this size and saying so is the
-        # honest answer.
-        local rel
-        if (( best[i] > base_worst )) || (( worst[i] < base_best )); then
-            rel="$(( best[i] * 100 / base_best ))%"
-        else
-            rel="within the noise"
-        fi
-        printf '  %-34s %8s %9s  %s\n' \
-            "${labels[$i]}" "${best[$i]}" "${best[$i]}..${worst[$i]}" "$rel"
-    done
-
-    printf '\n'
-    printf 'The real table this stands in for is %s entries, and the arms that\n' "$REAL_TABLE"
-    printf 'search rather than address grow with it. Run with a larger first\n'
-    printf 'argument to see that; the default is small enough to finish.\n'
-}
-
-main "$@"
+printf '\n'
+printf 'The real table this stands in for is %s entries, and the arms that\n' "$REAL_TABLE"
+printf 'search rather than address grow with it. Run with a larger first\n'
+printf 'argument to see that; the default is small enough to finish.\n'

--- a/benches/maps/findings.md
+++ b/benches/maps/findings.md
@@ -1,0 +1,52 @@
+# What a map costs without bash associative arrays
+
+The question behind it: nutshell is to be POSIX sh by default, and POSIX sh has
+no associative arrays. nutshell uses them where they decide how fast it is, so
+the substitute has a price and this is the price.
+
+The numbers below are from this machine, at 9606 entries, which is the size of
+the largest real table here: `_PAD_LINES` in the docs check holds one entry per
+line of source. Every run leaves a record under `results/`, and those carry the
+host and the bash version, because a millisecond count without them cannot be
+compared to anybody else's.
+
+## The result
+
+The substitute is about three times bash, and about a third more where the
+caller can hold a handle rather than a key.
+
+| arm | against bash |
+|---|---|
+| `declare -A` | the baseline |
+| eval names, encoded in place | roughly 3x |
+| slots by index, holding a handle | roughly 1.3x |
+| eval names, encoded through a subshell | far worse, and the gap is the fork |
+| one file per key | worse again |
+| hash table rolled by hand | tens of times worse |
+| one string, scanned | thousands of times worse |
+
+## What to take from it
+
+**The encoding must not fork.** Two arms here are the same technique, one
+calling out to encode a key and one doing it in place. The gap between them is
+larger than the gap between the technique and bash, so the habit costs more than
+the substitution does.
+
+**Never roll a hash table in the shell.** The shell's own symbol table hashes in
+C and a shell loop cannot compete with it. That arm is here because somebody
+will suggest it.
+
+**Two arms are not maps.** `slots by index` and `slots by stride` are what a map
+becomes once the key has been resolved and the caller holds the index. They are
+here to price the key lookup, which is what a design would be trading away, and
+not as alternatives to `declare -A`.
+
+## What is not established here
+
+Whether the 3x matters anywhere it is paid. That is a question about nutshell's
+own hot paths rather than about maps, and answering it needs a bench per path
+rather than this one.
+
+And every number here is single-threaded, on one host, at the sizes the table
+states. Nothing here says what happens on a smaller machine, which is where the
+POSIX floor matters most.

--- a/benches/maps/results/20260827044246.csv
+++ b/benches/maps/results/20260827044246.csv
@@ -1,0 +1,11 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash declare -A,16,16,within the noise,yes
+eval names  encoded via subshell,1915,1948,11968%,yes
+eval names  encoded in place,42,82,262%,yes
+one string  scanned,-,-,-,no
+one file  read in shell,9390,10141,58687%,yes
+one file per key,319,347,1993%,yes
+one file per key  in memory,2,7,12%,yes
+slots by index (not a map),20,20,125%,yes
+slots by stride (not a map),43,44,268%,yes
+hash table rolled by hand,489,501,3056%,yes

--- a/benches/maps/results/20260827044246.meta
+++ b/benches/maps/results/20260827044246.meta
@@ -1,0 +1,7 @@
+case      What a map costs without bash associative arrays
+size      2000
+repeats   7
+baseline  bash declare -A
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T01:42:46Z

--- a/lib.nut
+++ b/lib.nut
@@ -6,6 +6,7 @@
 
 array                    lib/array.sh
 attr                     lib/attr.sh
+bench                    lib/bench.sh
 check-runner             lib/check-runner.sh
 checkcache               lib/checkcache.sh
 cli                      lib/cli.sh

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/lib/bench.sh - Measuring one thing against its real alternatives
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# Layer 0: depends on nothing but bash and a nanosecond clock.
+#
+# A bench is several arms answering one question, measured on one input, with
+# a record left behind that somebody can compare against instead of rerunning.
+# What it is not is a timing loop: those answer once, for whoever ran them, and
+# the number then travels without its conditions.
+#
+# Three controls are compulsory here rather than optional, because each of them
+# has already let a wrong number through somewhere.
+#
+#   The arms have to agree. A fast arm giving a different answer is not a
+#   competitor, and an implementation whose encoding collides two keys looks
+#   excellent right up until somebody reads it. `bench_verify` names how to ask
+#   an arm for its answer and nothing runs without one.
+#
+#   The baseline has to be steady. A ratio against a number that moved by a
+#   factor of two across its own repeats is arithmetic rather than a
+#   measurement, and the raw times get printed instead.
+#
+#   Two arms that overlap are not distinguishable. Where the ranges cross, the
+#   honest report is that they cross, not a percentage computed from the
+#   midpoints.
+#
+# And there has to be a real competitor. An arm beating a version of itself
+# somebody wrote worse on purpose establishes that the author can write worse
+# on purpose. `bench_run` refuses a single arm.
+#
+# Usage:
+#   use bench
+#
+#   bench_case "what a map costs without bash arrays"
+#   bench_verify answer_of              # every arm must return the same
+#   bench_arm "bash declare -A" arm_assoc
+#   bench_arm "eval names"      arm_eval  4000     # ceiling: skip above this
+#   bench_size 9606
+#   bench_run
+# =============================================================================
+
+nut_once || return 0
+
+declare -g  BENCH_TITLE=""
+declare -g  BENCH_VERIFY=""
+declare -g  BENCH_SIZE=0
+declare -g  BENCH_REPEATS="${BENCH_REPEATS:-7}"
+declare -ga _BENCH_LABEL=()
+declare -ga _BENCH_FN=()
+declare -ga _BENCH_CEIL=()
+declare -ga _BENCH_NOTE=()
+
+#[pub]
+# Name the question this bench answers. The first line of every report and of
+# every record it writes.
+# Usage: bench_case "what a map costs without bash arrays"
+bench_case() { BENCH_TITLE="$*"; }
+
+#[pub]
+# How to ask an arm what answer it produced.
+#
+# Compulsory, and the control that matters most: without it a bench compares a
+# fast wrong arm against a slow right one and reports the wrong one winning.
+# The function is called with an arm's name and prints whatever that arm
+# computed; every arm has to print the same thing.
+# Usage: bench_verify answer_of
+bench_verify() { BENCH_VERIFY="$1"; }
+
+#[pub]
+# How many items the input holds. Recorded rather than used, because a number
+# without the size it was taken at cannot be compared to another number.
+# Usage: bench_size 9606
+bench_size() { BENCH_SIZE="$1"; }
+
+#[pub]
+# One arm. The first declared is the baseline every ratio is against.
+#
+# A ceiling above zero means the arm is skipped when the size passes it, which
+# is stated in the table rather than hidden: which arms have a ceiling at all
+# is itself a result.
+# Usage: bench_arm "bash declare -A" arm_assoc [ceiling] [note]
+bench_arm() {
+    _BENCH_LABEL+=("$1")
+    _BENCH_FN+=("$2")
+    _BENCH_CEIL+=("${3:-0}")
+    _BENCH_NOTE+=("${4:-}")
+}
+
+# One run of one arm, in milliseconds.
+_bench_once() {
+    local fn="$1" start end
+    start="$(date +%s%N 2>/dev/null)" || return 1
+    "$fn" >/dev/null 2>&1
+    end="$(date +%s%N 2>/dev/null)" || return 1
+    printf '%s' "$(( (end - start) / 1000000 ))"
+}
+
+# The best and the worst of several runs, into _BENCH_BEST and _BENCH_WORST.
+#
+# The minimum is the estimator rather than the mean, because every source of
+# noise here adds time and none removes it, so the fastest run is the one least
+# disturbed. The spread is kept because a number without one cannot be compared
+# against another number: four consecutive runs of one arm on this machine gave
+# 5, 5, 35, 5, and a single timing would have reported any of them.
+_bench_measure() {
+    local fn="$1" i t
+    _BENCH_BEST=""; _BENCH_WORST=""
+    for (( i = 0; i < BENCH_REPEATS; i++ )); do
+        t="$(_bench_once "$fn")" || return 1
+        [[ -z "$_BENCH_BEST"  || "$t" -lt "$_BENCH_BEST"  ]] && _BENCH_BEST="$t"
+        [[ -z "$_BENCH_WORST" || "$t" -gt "$_BENCH_WORST" ]] && _BENCH_WORST="$t"
+    done
+    return 0
+}
+
+# Every arm has to answer the same. Returns 1 naming the two that disagree.
+_bench_agree() {
+    local i want="" got="" first=""
+    for (( i = 0; i < ${#_BENCH_FN[@]}; i++ )); do
+        [[ "${_BENCH_SKIP[$i]:-0}" == "1" ]] && continue
+        got="$("$BENCH_VERIFY" "${_BENCH_FN[$i]}")" || return 1
+        [[ "$got" == "SKIP" ]] && continue
+        if [[ -z "$first" ]]; then want="$got"; first="${_BENCH_LABEL[$i]}"; continue; fi
+        if [[ "$got" != "$want" ]]; then
+            printf 'the arms disagree, so this is not a comparison:\n' >&2
+            printf '  %s answered %q\n' "${_BENCH_LABEL[$i]}" "$got" >&2
+            printf '  %s answered %q\n' "$first" "$want" >&2
+            return 1
+        fi
+    done
+    [[ -n "$first" ]] || { printf 'no arm produced an answer to compare\n' >&2; return 1; }
+    return 0
+}
+
+# Where a run's record goes. Beside the bench that produced it, in the repo,
+# because a measurement nobody can find again is one somebody will take twice.
+_bench_results_dir() {
+    printf '%s' "${BENCH_RESULTS:-${PWD}/benches/results}"
+}
+
+# The record: one row per arm, plus the conditions it was taken under. Both
+# matter and neither is enough alone.
+_bench_record() {
+    local dir stamp i
+    dir="$(_bench_results_dir)"
+    mkdir -p "$dir" 2>/dev/null || return 0
+    stamp="$(date +%Y%m%d%H%M%S)"
+
+    {
+        printf 'arm,best_ms,worst_ms,ratio_to_baseline,ran\n'
+        for (( i = 0; i < ${#_BENCH_LABEL[@]}; i++ )); do
+            printf '%s,%s,%s,%s,%s\n' \
+                "${_BENCH_LABEL[$i]//,/ }" \
+                "${_BENCH_BESTS[$i]:--}" "${_BENCH_WORSTS[$i]:--}" \
+                "${_BENCH_RATIO[$i]:--}" \
+                "$( [[ "${_BENCH_SKIP[$i]:-0}" == "1" ]] && printf no || printf yes )"
+        done
+    } > "${dir}/${stamp}.csv"
+
+    {
+        printf 'case      %s\n' "$BENCH_TITLE"
+        printf 'size      %s\n' "$BENCH_SIZE"
+        printf 'repeats   %s\n' "$BENCH_REPEATS"
+        printf 'baseline  %s\n' "${_BENCH_LABEL[0]:-none}"
+        printf 'bash      %s\n' "${BASH_VERSION:-unknown}"
+        printf 'host      %s %s\n' "$(uname -s)" "$(uname -m)"
+        printf 'taken     %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } > "${dir}/${stamp}.meta"
+
+    printf '%s' "${dir}/${stamp}"
+}
+
+#[pub]
+# Measure every arm, run the controls, print the table, write the record.
+#
+# Returns 1 when a control refuses, which is a result rather than a failure of
+# the harness: a bench that cannot support its numbers must not print them.
+# Usage: bench_run -> 0 when it measured, 1 when a control refused
+bench_run() {
+    local i n="${#_BENCH_FN[@]}"
+
+    [[ -n "$BENCH_TITLE" ]] || { printf 'bench: no case named\n' >&2; return 1; }
+    [[ -n "$BENCH_VERIFY" ]] || {
+        printf 'bench: no verify function, so the arms cannot be shown to agree\n' >&2
+        printf '  an arm that is fast and wrong wins every bench without this\n' >&2
+        return 1; }
+    if (( n < 2 )); then
+        printf 'bench: %s arm(s). A bench needs a real competitor, not one\n' "$n" >&2
+        printf '  implementation timed against nothing.\n' >&2
+        return 1
+    fi
+
+    declare -ga _BENCH_BESTS=() _BENCH_WORSTS=() _BENCH_SKIP=() _BENCH_RATIO=()
+    for (( i = 0; i < n; i++ )); do
+        if (( _BENCH_CEIL[i] > 0 && BENCH_SIZE > _BENCH_CEIL[i] )); then
+            _BENCH_BESTS+=("-"); _BENCH_WORSTS+=("-"); _BENCH_SKIP+=(1); _BENCH_RATIO+=("-")
+            continue
+        fi
+        _bench_measure "${_BENCH_FN[$i]}" || {
+            printf 'bench: no nanosecond clock here, so nothing can be timed\n' >&2
+            return 1; }
+        _BENCH_BESTS+=("$_BENCH_BEST"); _BENCH_WORSTS+=("$_BENCH_WORST")
+        _BENCH_SKIP+=(0); _BENCH_RATIO+=("-")
+    done
+
+    _bench_agree || return 1
+
+    printf '%s\n\n' "$BENCH_TITLE"
+    printf '  size      %s\n' "$BENCH_SIZE"
+    printf '  repeats   %s\n' "$BENCH_REPEATS"
+    printf '  bash      %s\n' "${BASH_VERSION:-unknown}"
+    printf '  host      %s %s\n\n' "$(uname -s)" "$(uname -m)"
+
+    local base_best="${_BENCH_BESTS[0]}" base_worst="${_BENCH_WORSTS[0]}"
+    if [[ "$base_best" == "-" ]] || (( base_best <= 0 )); then
+        printf '  the baseline did not measure, so nothing below can be a ratio\n' >&2
+        return 1
+    fi
+    if (( base_worst > base_best * 2 )); then
+        printf '  the baseline moved from %sms to %sms across %s runs.\n' \
+            "$base_best" "$base_worst" "$BENCH_REPEATS" >&2
+        printf '  this machine is too noisy right now for a ratio to mean anything.\n\n' >&2
+        for (( i = 0; i < n; i++ )); do
+            printf '  %-34s %6s..%-6s\n' "${_BENCH_LABEL[$i]}" \
+                "${_BENCH_BESTS[$i]}" "${_BENCH_WORSTS[$i]}"
+        done
+        return 1
+    fi
+
+    printf '  %-34s %8s %11s  %s\n' "arm" "best ms" "spread" "against the first"
+    for (( i = 0; i < n; i++ )); do
+        if [[ "${_BENCH_SKIP[$i]}" == "1" ]]; then
+            printf '  %-34s %8s %11s  %s\n' "${_BENCH_LABEL[$i]}" "-" "-" \
+                "${_BENCH_NOTE[$i]:-not run at this size}"
+            continue
+        fi
+        # A ratio only where the ranges do not overlap. Where they do, the arms
+        # are not distinguishable at this size, and saying so is the answer.
+        if (( _BENCH_BESTS[i] > base_worst )) || (( _BENCH_WORSTS[i] < base_best )); then
+            _BENCH_RATIO[$i]="$(( _BENCH_BESTS[i] * 100 / base_best ))%"
+        else
+            _BENCH_RATIO[$i]="within the noise"
+        fi
+        printf '  %-34s %8s %11s  %s\n' "${_BENCH_LABEL[$i]}" \
+            "${_BENCH_BESTS[$i]}" \
+            "${_BENCH_BESTS[$i]}..${_BENCH_WORSTS[$i]}" \
+            "${_BENCH_RATIO[$i]}"
+    done
+
+    local where; where="$(_bench_record)"
+    [[ -n "$where" ]] && printf '\n  kept at %s.csv and .meta\n' "$where"
+    return 0
+}

--- a/tests/bench_test.sh
+++ b/tests/bench_test.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Tests for the bench harness.
+#
+# Three of its controls are the reason it exists rather than a timing loop, so
+# each of them is shown refusing here. A harness whose controls have never been
+# seen to fire is a harness nobody has any reason to trust, and the failure it
+# is guarding against is the one where a number gets published.
+#
+# The timings themselves are not asserted. What a run measures depends on the
+# machine, and a test that pinned a millisecond count would be a test of this
+# laptop.
+
+use test
+use bench
+
+_bench_fresh() {
+    BENCH_TITLE=""; BENCH_VERIFY=""; BENCH_SIZE=0; BENCH_REPEATS=2
+    _BENCH_LABEL=(); _BENCH_FN=(); _BENCH_CEIL=(); _BENCH_NOTE=()
+    BENCH_RESULTS="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-bench.XXXXXX")"
+    export BENCH_RESULTS
+}
+_bench_done() { rm -rf "$BENCH_RESULTS"; unset BENCH_RESULTS; }
+
+# Two arms that agree, and one that does not.
+_arm_a()      { printf 'the same'; }
+_arm_b()      { printf 'the same'; }
+_arm_liar()   { printf 'something else'; }
+_answer_of()  { "$1"; }
+
+# --- it measures at all ------------------------------------------------------
+
+#[test]
+it_measures_two_arms_that_agree() {
+    # The positive control. Every refusal below is worth nothing without it,
+    # because a harness that refused everything would pass all of them.
+    _bench_fresh
+    bench_case "two arms"
+    bench_verify _answer_of
+    bench_arm "a" _arm_a
+    bench_arm "b" _arm_b
+
+    local out; out="$(bench_run 2>&1)"
+    local rc=$?
+    assert_eq "$rc" "0"
+    assert_contains "$out" "two arms"
+    assert_contains "$out" "best ms"
+    _bench_done
+}
+
+# --- the arms have to agree --------------------------------------------------
+
+#[test]
+it_refuses_a_run_whose_arms_answer_differently() {
+    # The control that matters most. A fast wrong arm beats a slow right one on
+    # every timing, and an implementation whose encoding collides two keys
+    # looks excellent right up until somebody reads it.
+    _bench_fresh
+    bench_case "one of these is lying"
+    bench_verify _answer_of
+    bench_arm "a"    _arm_a
+    bench_arm "liar" _arm_liar
+
+    local out rc=0; out="$(bench_run 2>&1)" || rc=$?
+    assert_ne "$rc" "0"
+    assert_contains "$out" "disagree"
+    # And it names both sides, because "they disagree" sends the reader to look
+    # at ten arms.
+    assert_contains "$out" "liar"
+    assert_contains "$out" "a"
+    # Nothing is published from a run that could not be compared.
+    assert_empty "$(ls "$BENCH_RESULTS" 2>/dev/null)"
+    _bench_done
+}
+
+#[test]
+it_refuses_a_run_with_no_way_to_ask_an_arm_what_it_answered() {
+    # Without this the check above cannot run at all, so the harness declines
+    # rather than silently skipping it, which is what an optional control
+    # becomes.
+    _bench_fresh
+    bench_case "no verify"
+    bench_arm "a" _arm_a
+    bench_arm "b" _arm_b
+
+    local out rc=0; out="$(bench_run 2>&1)" || rc=$?
+    assert_ne "$rc" "0"
+    assert_contains "$out" "verify"
+    _bench_done
+}
+
+# --- a bench needs a competitor ----------------------------------------------
+
+#[test]
+it_refuses_one_arm_timed_against_nothing() {
+    # The commonest way a bench says nothing: one implementation measured on
+    # its own, or against a version of itself somebody wrote worse on purpose.
+    _bench_fresh
+    bench_case "alone"
+    bench_verify _answer_of
+    bench_arm "a" _arm_a
+
+    local out rc=0; out="$(bench_run 2>&1)" || rc=$?
+    assert_ne "$rc" "0"
+    assert_contains "$out" "competitor"
+    _bench_done
+}
+
+#[test]
+it_refuses_a_run_that_never_said_what_it_was_measuring() {
+    _bench_fresh
+    bench_verify _answer_of
+    bench_arm "a" _arm_a
+    bench_arm "b" _arm_b
+
+    local out rc=0; out="$(bench_run 2>&1)" || rc=$?
+    assert_ne "$rc" "0"
+    assert_contains "$out" "case"
+    _bench_done
+}
+
+# --- what it leaves behind ---------------------------------------------------
+
+#[test]
+it_writes_the_numbers_and_the_conditions_they_were_taken_under() {
+    # Both, and neither is enough alone. A row of milliseconds with no bash
+    # version, host or size is a number that travels without its conditions,
+    # which is the thing this harness exists to stop.
+    _bench_fresh
+    bench_case "kept"
+    bench_size 123
+    bench_verify _answer_of
+    bench_arm "a" _arm_a
+    bench_arm "b" _arm_b
+    bench_run >/dev/null 2>&1 || { _bench_done; _test_failed "the run itself refused"; return 1; }
+
+    local csv meta
+    csv="$(ls "$BENCH_RESULTS"/*.csv 2>/dev/null | head -1)"
+    meta="$(ls "$BENCH_RESULTS"/*.meta 2>/dev/null | head -1)"
+    assert_ne "$csv" ""
+    assert_ne "$meta" ""
+
+    local c m; c="$(cat "$csv")"; m="$(cat "$meta")"
+    assert_contains "$c" "arm,best_ms,worst_ms"
+    assert_contains "$c" "a,"
+    assert_contains "$c" "b,"
+    assert_contains "$m" "size      123"
+    assert_contains "$m" "baseline  a"
+    assert_contains "$m" "${BASH_VERSION}"
+    assert_contains "$m" "$(uname -s)"
+    _bench_done
+}
+
+#[test]
+it_says_an_arm_was_not_run_rather_than_leaving_it_out() {
+    # A skipped arm still gets a row. Dropping it makes the table read as
+    # though that alternative was never considered, which is the other way a
+    # bench misleads: not by a wrong number but by an absent one.
+    _bench_fresh
+    bench_case "ceilings"
+    bench_size 100
+    bench_verify _answer_of
+    bench_arm "a"       _arm_a
+    bench_arm "too big" _arm_b 10
+
+    local out; out="$(bench_run 2>&1)"
+    assert_contains "$out" "too big"
+    assert_contains "$out" "not run at this size"
+
+    local c; c="$(cat "$BENCH_RESULTS"/*.csv)"
+    assert_contains "$c" "too big,-,-,-,no"
+    _bench_done
+}
+
+#[test]
+it_uses_the_note_an_arm_gave_for_why_it_did_not_run() {
+    _bench_fresh
+    bench_case "notes"
+    bench_size 100
+    bench_verify _answer_of
+    bench_arm "a"      _arm_a
+    bench_arm "absent" _arm_b 10 "no memory filesystem here"
+
+    assert_contains "$(bench_run 2>&1)" "no memory filesystem here"
+    _bench_done
+}


### PR DESCRIPTION
There was none. `test` and `check` were the two entry points and nothing measured, so every performance question here got answered by a one-off script nobody could run again. Under the workspace rule that is an ad-hoc spike with no substance rather than a bench, and the number then travels without the conditions it was taken under.

`./bench` is the third entry point. `benches/<name>/bench.sh` declares the arms, and each run writes a row per arm plus the conditions beside it, both committed, so a later reader compares against what was measured rather than rerunning to find out whether they agree.

## Three controls, compulsory rather than available

Each of them has already let a wrong number through somewhere.

**The arms have to agree.** A fast arm giving a different answer is not a competitor, and an encoding that collides two keys looks excellent until somebody reads it. `bench_verify` names how to ask an arm what it answered, and nothing runs without one.

**The baseline has to be steady.** A ratio against a number that moved by a factor of two across its own repeats is arithmetic, not a measurement, and the raw times get printed instead. Four consecutive runs of one arm on this machine gave 5, 5, 35, 5.

**Two overlapping ranges are not distinguishable.** Where they cross the report says so rather than dividing the midpoints.

And a single arm is refused outright. Beating a version of itself somebody wrote worse on purpose establishes only that they could write worse on purpose.

## The first bench is the old tool

`tools/assoc-array-report` becomes `benches/maps`, which is what proves the harness: it already had these controls welded into it and lifting them out is most of the work. Its findings are committed beside its numbers now, which they were not.

At the real table size of 9606 entries the answer has not changed: the substitute is around 3x bash, and around 1.3x where the caller can hold a handle rather than a key.

## Sanity

560 pass. Gate unchanged.

Every control is shown refusing, and each dies to its own test when taken out:

| mutation | dies |
|---|---|
| drop the agreement check | `it_refuses_a_run_whose_arms_answer_differently` |
| allow a missing verify | `it_refuses_a_run_with_no_way_to_ask_an_arm_what_it_answered` |
| allow a single arm | `it_refuses_one_arm_timed_against_nothing` |
| stop writing the record | the two record tests |
| leave a skipped arm out of the table | the two skip tests |
| record numbers but not conditions | `it_writes_the_numbers_and_the_conditions_they_were_taken_under` |

The timings themselves are not asserted anywhere. What a run measures depends on the machine, and a test pinning a millisecond count would be a test of this laptop.