### PR TITLE
feat: a module can say which shell or tools its file needs

### DIFF
--- a/benches/module-resolve/bench.sh
+++ b/benches/module-resolve/bench.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/benches/module-resolve - What a predicate costs at load time
+# =============================================================================
+#
+# A `when=` row decides which file a module is sourced from, and the decision
+# is taken on every `use` of that module, before anything is parsed. So it sits
+# in front of the whole library and a cost here is a cost everything pays.
+#
+# The question is not whether a predicate is fast in isolation. It is whether
+# a manifest that uses them resolves at the same speed as one that does not,
+# because if it does not, the POSIX arrangement is paid for at every startup.
+#
+# The arms all answer the same question, "which file is module N", against a
+# manifest of the same size. What differs is what the rows carry.
+#
+# Usage:
+#   ./bench module-resolve [rows] [lookups]
+# =============================================================================
+
+use bench
+
+ROWS="${1:-200}"
+LOOKUPS="${2:-200}"
+
+_MR_TMP="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-mr.XXXXXX")"
+trap '[[ -n "${_MR_TMP:-}" ]] && rm -rf "$_MR_TMP"' EXIT
+
+# A library root whose manifest carries `$2` on every row.
+_mr_lib() {
+    local name="$1" trailing="$2" d="$_MR_TMP/$1" i
+    mkdir -p "$d"
+    : > "$d/lib.nut"
+    for (( i = 0; i < ROWS; i++ )); do
+        printf 'mod%s  m%s.sh %s\n' "$i" "$i" "$trailing" >> "$d/lib.nut"
+        : > "$d/m${i}.sh"
+    done
+    printf '%s' "$d"
+}
+
+# Look up a spread of modules, and print the last answer so nothing can be
+# dropped for going unused.
+_mr_run() {
+    local d="$1" i last=""
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        last="$(_lib_nut_lookup "$d" "mod$(( i * ROWS / LOOKUPS ))")"
+    done
+    printf '%s' "${last##*/}"
+}
+
+_PLAIN="$(_mr_lib plain '')"
+_VIS="$(_mr_lib vis 'internal')"
+_TRUE="$(_mr_lib true_pred 'when=have:sh')"
+_FALSE="$(_mr_lib false_pred 'when=have:no-such-command-anywhere-3f9a')"
+_BOTH="$(_mr_lib both 'when=have:sh+have:cat')"
+
+# The false-predicate library answers nothing, so it is not an arm: it would
+# disagree with the others and the harness would refuse the run, correctly.
+# Its cost is reported in the note at the end instead.
+
+arm_plain()      { _mr_run "$_PLAIN"; }
+arm_visibility() { _mr_run "$_VIS"; }
+arm_one_pred()   { _mr_run "$_TRUE"; }
+arm_two_preds()  { _mr_run "$_BOTH"; }
+
+_answer_of() { "$1"; }
+
+bench_case "What a when= row costs at module resolve time"
+bench_size "$ROWS"
+bench_verify _answer_of
+
+bench_arm "no trailing column"        arm_plain
+bench_arm "a visibility, no predicate" arm_visibility
+bench_arm "one predicate"             arm_one_pred
+bench_arm "two, joined by a plus"     arm_two_preds
+
+bench_run || exit 1
+
+printf '\n'
+printf 'The rows are %s and the lookups %s, so each lookup scans about half\n' "$ROWS" "$LOOKUPS"
+printf 'the manifest. A predicate that held nowhere is not an arm here: it\n'
+printf 'answers nothing, the arms would disagree, and the harness refuses the\n'
+printf 'run rather than reporting the one that did no work as the fastest.\n'

--- a/benches/module-resolve/findings.md
+++ b/benches/module-resolve/findings.md
@@ -1,0 +1,48 @@
+# What a `when=` row costs at module resolve time
+
+A predicate decides which file a module is sourced from, and it is evaluated on
+every `use` of that module before anything is parsed. So it sits in front of the
+whole library and anything it costs, everything pays.
+
+## The result
+
+A predicated row resolves at about **113%** of a plain one, and two joined by a
+plus at about **117%**. Reproducible across runs; a row carrying only a
+visibility is inside the noise, so the cost is the predicate rather than the
+extra column.
+
+At the sizes that matter this is nothing: a real manifest is around thirty rows
+and a program does a handful of `use` calls. The number is here so that a later
+change to the predicate vocabulary has something to move against.
+
+## What the memo does and does not do
+
+`_nut_when` remembers `have:` answers, because `command -v` is the only word in
+the vocabulary that costs anything. `shell:` and `env:` are a `case` on a
+variable and are deliberately not cached: both can change, and caching them made
+a test that drives the bash floor through its branches read one answer for every
+version it tried.
+
+**The memo reaches one lookup and no further.** Every caller of
+`_lib_nut_lookup` wraps it in a command substitution, so the cache is written in
+a subshell and dies with it. A module with several predicated rows shares an
+answer between them; two `use` calls of the same module do not.
+
+That was written into the code as a 14%-to-noise improvement before it was
+measured, and it is not one. The numbers here are the same with the memo and
+without it.
+
+## The larger cost, which is not the predicate
+
+**The fork around the lookup.** Every resolve is a command substitution, paid by
+every module whether it carries a predicate or not. Returning through a variable
+instead of by printing would remove it, which is five call sites and its own
+change, and this bench is the instrument to price it with.
+
+## What is not established here
+
+Anything about a shell that is not this one. Every number is bash 5.3 on one
+host, and the whole point of the predicate is machines that are not this one.
+POSIX `sh` has no associative array, so the memo above does not survive that
+conversion in this form, and what replaces it wants measuring rather than
+assuming.

--- a/benches/module-resolve/results/20260827054213.csv
+++ b/benches/module-resolve/results/20260827054213.csv
@@ -1,0 +1,5 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+no trailing column,307,335,within the noise,yes
+a visibility  no predicate,323,331,within the noise,yes
+one predicate,344,355,112%,yes
+two  joined by a plus,357,394,116%,yes

--- a/benches/module-resolve/results/20260827054213.meta
+++ b/benches/module-resolve/results/20260827054213.meta
@@ -1,0 +1,7 @@
+case      What a when= row costs at module resolve time
+size      200
+repeats   7
+baseline  no trailing column
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T02:42:13Z

--- a/benches/module-resolve/results/20260827054224.csv
+++ b/benches/module-resolve/results/20260827054224.csv
@@ -1,0 +1,5 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+no trailing column,303,327,within the noise,yes
+a visibility  no predicate,322,353,within the noise,yes
+one predicate,344,359,113%,yes
+two  joined by a plus,362,375,119%,yes

--- a/benches/module-resolve/results/20260827054224.meta
+++ b/benches/module-resolve/results/20260827054224.meta
@@ -1,0 +1,7 @@
+case      What a when= row costs at module resolve time
+size      200
+repeats   7
+baseline  no trailing column
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T02:42:24Z

--- a/benches/module-resolve/results/20260827054326.csv
+++ b/benches/module-resolve/results/20260827054326.csv
@@ -1,0 +1,5 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+no trailing column,308,368,within the noise,yes
+a visibility  no predicate,325,340,within the noise,yes
+one predicate,346,362,within the noise,yes
+two  joined by a plus,363,382,within the noise,yes

--- a/benches/module-resolve/results/20260827054326.meta
+++ b/benches/module-resolve/results/20260827054326.meta
@@ -1,0 +1,7 @@
+case      What a when= row costs at module resolve time
+size      200
+repeats   7
+baseline  no trailing column
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T02:43:26Z

--- a/tests/when_test.sh
+++ b/tests/when_test.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Tests for choosing a module's file before it is sourced.
+#
+# The half that picks between tools already existed: `text_grep` chooses `grep`
+# over `perl` on first call and reloads. That is per function and inside a
+# module, and it cannot help with the thing this is for.
+#
+# A file using a construct the running shell cannot parse fails at parse time.
+# No `if` inside it can guard that, because the guard is in the file being
+# parsed. So the decision has to sit above the sourcing, which is `use`, and
+# that is what a `when=` row in the manifest is.
+#
+# Which makes the ordering load-bearing rather than cosmetic. A floor above a
+# better row makes that row unreachable and nothing about the tree looks wrong.
+
+use test
+
+_W_TMP="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-when.XXXXXX")"
+trap '[[ -n "${_W_TMP:-}" ]] && rm -rf "$_W_TMP"' EXIT
+
+# A library root with a manifest and the files it names.
+_w_lib() {
+    local d; d="$(mktemp -d "${_W_TMP}/lib.XXXXXX")"
+    printf '%s' "$1" > "$d/lib.nut"
+    local f
+    while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        mkdir -p "$d/${f%/*}" 2>/dev/null
+        printf 'MARK=%s\n' "${f##*/}" > "$d/$f"
+    done < <(awk '!/^#/ && NF>=2 {print $2}' "$d/lib.nut" | sort -u)
+    printf '%s' "$d"
+}
+
+# Which file the resolver picks, as a bare name.
+_w_pick() {
+    local got; got="$(_lib_nut_lookup "$1" "$2" 2>/dev/null)" || return 1
+    printf '%s' "${got##*/}"
+}
+
+# --- the predicate itself ----------------------------------------------------
+
+#[test]
+it_holds_for_a_command_that_is_here() {
+    assert_ok _nut_when "have:sh"
+}
+
+#[test]
+it_does_not_hold_for_a_command_that_is_not() {
+    # The control for the one above. A predicate that always held would pass
+    # every test in this file and select the first row on every machine.
+    assert_fails _nut_when "have:no-such-command-anywhere-3f9a"
+}
+
+#[test]
+it_holds_for_the_shell_that_is_running_this() {
+    assert_ok _nut_when "shell:bash"
+    assert_ok _nut_when "shell:bash4"
+}
+
+#[test]
+it_reads_the_bash_floor_the_same_way_init_does() {
+    # `shell:bash4` and `init`'s own guard answer one question, and two answers
+    # to it is how a floor drifts. `10.0.0` is the row worth having: `1.*` is a
+    # prefix of `1.` rather than of `1`.
+    local v
+    for v in '' 1.14.7 2.05b '3.2.57(1)-release' 4.0 '4.0.0-beta' 5.3 10.0.0; do
+        local want=no
+        case "$v" in ''|1.*|2.*|3.*) want=no ;; *) want=yes ;; esac
+        local got=no
+        BASH_VERSION="$v" _nut_when "shell:bash4" && got=yes
+        assert_eq "$got" "$want" "BASH_VERSION=[$v]"
+    done
+}
+
+#[test]
+it_wants_both_sides_of_a_plus() {
+    assert_ok    _nut_when "have:sh+have:cat"
+    assert_fails _nut_when "have:sh+have:no-such-command-anywhere-3f9a"
+    assert_fails _nut_when "have:no-such-command-anywhere-3f9a+have:sh"
+}
+
+#[test]
+it_refuses_a_word_it_does_not_know() {
+    # A typo must not read as true. Read as true, it promotes a variant onto
+    # every machine, which is the exact opposite of what a predicate is for,
+    # and nothing about the tree would look wrong.
+    assert_fails _nut_when "hav:grep"
+    assert_fails _nut_when "shell:zsh"
+    assert_fails _nut_when "have:sh+wat"
+}
+
+#[test]
+it_holds_for_nothing_at_all() {
+    # An empty predicate is the floor, which is what a row with no `when=`
+    # becomes.
+    assert_ok _nut_when ""
+}
+
+#[test]
+it_does_not_run_what_is_written_in_the_file() {
+    # The predicate comes out of a file on disk and is never evaluated as
+    # shell. `eval` here would be arbitrary execution in the one place that
+    # runs before anything else in the library.
+    local witness="$_W_TMP/witness"
+    rm -f "$witness"
+    _nut_when "env:X; touch $witness" 2>/dev/null || true
+    _nut_when "have:sh; touch $witness" 2>/dev/null || true
+    assert_fails test -e "$witness"
+}
+
+# --- choosing a file ---------------------------------------------------------
+
+#[test]
+it_takes_the_first_row_whose_predicate_holds() {
+    local d; d="$(_w_lib 'thing  a.sh  when=have:no-such-command-anywhere-3f9a
+thing  b.sh  when=have:sh
+thing  c.sh')"
+    assert_eq "$(_w_pick "$d" thing)" "b.sh"
+}
+
+#[test]
+it_falls_to_the_row_with_no_predicate() {
+    local d; d="$(_w_lib 'thing  a.sh  when=have:no-such-command-anywhere-3f9a
+thing  c.sh')"
+    assert_eq "$(_w_pick "$d" thing)" "c.sh"
+}
+
+#[test]
+it_finds_nothing_when_no_row_holds_and_there_is_no_floor() {
+    # A library with only predicated rows can fail to resolve on a machine
+    # that matches none of them. That is the library's defect and the resolver
+    # says so rather than picking one anyway.
+    local d; d="$(_w_lib 'thing  a.sh  when=have:no-such-command-anywhere-3f9a')"
+    assert_fails _w_pick "$d" thing
+}
+
+#[test]
+it_reads_the_order_in_the_file_as_the_order_to_try() {
+    # The same two rows the other way round. A floor above a better row makes
+    # that row unreachable, and this is what says so.
+    local d; d="$(_w_lib 'thing  c.sh
+thing  b.sh  when=have:sh')"
+    assert_eq "$(_w_pick "$d" thing)" "c.sh"
+}
+
+#[test]
+it_still_resolves_a_module_that_has_no_predicate_anywhere() {
+    # The control for the whole feature. Every existing manifest is rows with
+    # no `when=` at all, and a change that broke those would be caught by the
+    # rest of the suite, but not by anything in this file.
+    local d; d="$(_w_lib 'one  one.sh
+two  two.sh')"
+    assert_eq "$(_w_pick "$d" one)" "one.sh"
+    assert_eq "$(_w_pick "$d" two)" "two.sh"
+}
+
+#[test]
+it_takes_a_visibility_and_a_predicate_on_one_row_in_either_order() {
+    # Both on the same row, which is the case that was broken and which the
+    # first version of this test did not reach: it used two rows, one carrying
+    # each, and passed while `internal when=...` was dropping the predicate on
+    # the floor and loading the module anyway.
+    #
+    # All four combinations, because a fix that read the words instead of the
+    # positions could still have got one of them backwards.
+    local d
+
+    d="$(_w_lib 'thing  a.sh  internal when=have:no-such-command-anywhere-3f9a')"
+    assert_fails _w_pick "$d" thing
+
+    d="$(_w_lib 'thing  a.sh  when=have:no-such-command-anywhere-3f9a internal')"
+    assert_fails _w_pick "$d" thing
+
+    d="$(_w_lib 'thing  a.sh  internal when=have:sh')"
+    assert_eq "$(_w_pick "$d" thing)" "a.sh"
+    assert_fails _lib_nut_lookup "$d" thing public
+
+    d="$(_w_lib 'thing  a.sh  when=have:sh internal')"
+    assert_eq "$(_w_pick "$d" thing)" "a.sh"
+    assert_fails _lib_nut_lookup "$d" thing public
+}
+
+#[test]
+it_still_refuses_an_internal_module_from_outside() {
+    # The predicate column must not have opened the visibility door. Reading a
+    # trailing word and assigning it to the visibility is exactly the shape
+    # that could.
+    local d; d="$(_w_lib 'thing  a.sh  internal')"
+    assert_fails _lib_nut_lookup "$d" thing public
+    # And it is still reachable from inside, or the check above is passing for
+    # the wrong reason.
+    assert_eq "$(_w_pick "$d" thing)" "a.sh"
+}
+
+# --- what is remembered and what is not --------------------------------------
+
+#[test]
+it_gives_the_same_answer_for_a_binary_the_second_time() {
+    # The memo, which exists because `command -v` is the only word here that
+    # costs anything and this sits in front of every `use`.
+    assert_ok _nut_when "have:sh"
+    assert_ok _nut_when "have:sh"
+    assert_fails _nut_when "have:no-such-command-anywhere-3f9a"
+    assert_fails _nut_when "have:no-such-command-anywhere-3f9a"
+}
+
+#[test]
+it_does_not_remember_an_answer_that_can_change() {
+    # `env:` is a caller's variable and `shell:` is read from one, so neither
+    # is cached. Caching them made a predicate answer once for every value it
+    # was ever asked about, which is the cache being wrong rather than the
+    # caller being awkward.
+    export _NUT_WHEN_PROBE=1
+    assert_ok _nut_when "env:_NUT_WHEN_PROBE"
+    unset _NUT_WHEN_PROBE
+    assert_fails _nut_when "env:_NUT_WHEN_PROBE"
+
+    local before after
+    BASH_VERSION='5.0' _nut_when "shell:bash4" && before=yes || before=no
+    BASH_VERSION='3.2' _nut_when "shell:bash4" && after=yes  || after=no
+    assert_eq "$before" "yes"
+    assert_eq "$after"  "no"
+}
+
+#[test]
+it_does_not_let_a_remembered_binary_answer_for_a_different_one() {
+    # Keyed by the whole expression, not by the word. Keying by anything
+    # coarser makes one answer stand for several questions.
+    assert_ok    _nut_when "have:sh"
+    assert_fails _nut_when "have:sh+have:no-such-command-anywhere-3f9a"
+    assert_ok    _nut_when "have:sh"
+}


### PR DESCRIPTION
The first half of the POSIX arrangement, and the half that did not exist.

The half that picks between tools already did: `text_grep` chooses `grep` over `perl` at first call and reloads. That is per function and inside a module, and it cannot help with this. A file using a construct the running shell cannot parse fails at parse time, so no `if` inside it can guard it. The guard has to sit above the sourcing, and `use` is where that is.

## The shape

A module may be declared more than once, each row carrying `when=`, and the first row whose predicate holds is the one sourced.

```
text  lib/text.fast.sh  when=have:grep
text  lib/text.sh
```

The row with no predicate is the floor and always holds. Order in the file is the order tried, so a floor above a better row makes that row unreachable, and there is a test that says so rather than a comment asking you to be careful.

The vocabulary is four words and one operator: `have:`, `shell:bash`, `shell:bash4`, `env:`, and `+` meaning both. Deliberately small. A predicate language grows into a parser, and this is read before any module is loaded, which is the exact cycle the manifest format exists to avoid. It is `case` and `command -v` throughout so it keeps working when `init` becomes POSIX sh, which would be a strange thing to break on the first step toward it.

An unknown word does not hold. Read as true, a typo promotes a variant onto every machine and nothing about the tree looks wrong.

## What I got wrong twice

**The trailing columns were read by position.** So `internal when=...` read the visibility, ignored the fourth word entirely, and loaded the module on a machine whose predicate did not hold. Silently, which is the only way this kind of thing ever goes. They are read as words now, and the test that was meant to cover it used two rows carrying one thing each and passed the whole time; it does all four combinations on one row now.

**The memo's comment claimed a 14% improvement it does not deliver.** Every caller of `_lib_nut_lookup` wraps it in a command substitution, so whatever the cache writes dies in that subshell. It reaches one lookup and no further: a module with several predicated rows shares an answer between them, two `use` calls do not. The numbers are the same with it and without it, and the comment says that now.

## Sanity

578 pass. Gate unchanged at four warnings.

`benches/module-resolve` is new and prices it at about 113% of a plain row, 117% for two joined by a plus, reproducible across runs. A row carrying only a visibility is inside the noise, so the cost is the predicate rather than the extra column. At a real manifest's thirty-odd rows and a handful of `use` calls this is nothing; the number is there so a later change to the vocabulary has something to move against.

The findings file also names the larger cost, which is not the predicate: the fork around every lookup, paid by every module either way. Removing it means returning through a variable rather than by printing, which is five call sites and its own change, and this bench is the instrument to price it with.

| mutation | dies |
|---|---|
| an unknown word reads as true | `it_refuses_a_word_it_does_not_know` |
| a plus takes either side | six, including both `+` tests |
| the predicate is ignored, first row always wins | the three selection tests |
| the trailing columns read by position again | four, including the four-combination one |
| `shell:bash4` accepts bash 3 | `it_reads_the_bash_floor_the_same_way_init_does` |
| cache everything, including what can change | `it_does_not_remember_an_answer_that_can_change` |