### PR TITLE
feat: a check that says how much of this a POSIX shell can read

### DIFF
--- a/examples/checks/check_posix_floor.sh
+++ b/examples/checks/check_posix_floor.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env nutshell
+# =============================================================================
+# check_posix_floor.sh - How much of this library a POSIX shell can read
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# The floor is meant to be POSIX sh, with a predicate selecting a better file
+# where a tool or a modern shell earns it. That is a direction rather than a
+# state, so it needs a number that moves rather than an opinion that does not.
+#
+# **What this can and cannot see.** It parses each file with a real POSIX
+# shell and reports what will not parse. A parse failure is fatal in a way a
+# runtime failure is not: the shell rejects the whole file before running a
+# line of it, so no guard inside the file can help and the only fix is to not
+# source that file on that shell. That is exactly what a `when=` row is for.
+#
+# It cannot see a construct that parses and then misbehaves. `declare -A` is
+# the standing example: dash parses it as a command and fails at runtime. So a
+# clean report here means readable, not portable, and the check says so rather
+# than letting a green be read as more than it is.
+#
+# **It needs a real POSIX shell and refuses without one.** `sh` on macOS is
+# bash in POSIX mode and accepts `[[`, arrays and here-strings, so a check
+# written against `sh` reports a clean floor on a library that has none. That
+# is not hypothetical: the first measurement here was taken that way and was
+# worthless.
+#
+# Usage: ./examples/checks/check_posix_floor.sh
+#
+# Exit codes:
+#   0 - within the configured budget
+#   1 - over it, or no POSIX shell to check with
+# =============================================================================
+
+set -uo pipefail
+
+use check-runner
+
+POSIX_SHELL=""
+POSIX_MAX_UNREADABLE=-1
+declare -a POSIX_EXEMPT=()
+
+load_config() {
+    if ! cfg_is_true "tests.posix_floor"; then
+        log_info "POSIX floor test is disabled in config"
+        exit 0
+    fi
+    POSIX_SHELL="$(cfg_get_or "tests.posix_floor.shell" "")"
+    POSIX_MAX_UNREADABLE="$(cfg_get_or "tests.posix_floor.max_unreadable" "-1")"
+    cfg_get_array "tests.posix_floor.exempt" POSIX_EXEMPT || POSIX_EXEMPT=()
+}
+
+# A shell that is actually POSIX, or nothing.
+#
+# Verified rather than trusted, because the whole check is worthless run
+# against a shell that accepts what it is looking for. The probe is an array
+# assignment: POSIX has no arrays, so a shell that parses one is not the
+# instrument this needs.
+_posix_shell() {
+    local cand probe rc
+    probe="$(mktemp "${TMPDIR:-/tmp}/nutshell-posix.XXXXXX")" || return 1
+    printf 'a=(1 2)\n' > "$probe"
+
+    for cand in ${POSIX_SHELL:+$POSIX_SHELL} dash ash yash posh busybox-sh sh; do
+        command -v "$cand" >/dev/null 2>&1 || continue
+        "$cand" -n "$probe" >/dev/null 2>&1 && continue   # accepted it: not POSIX enough
+        rc=0
+        # And it has to accept ordinary POSIX, or it rejects everything and
+        # reports a library that cannot be read at all.
+        printf 'x=1\necho "${x:-}"\n' > "$probe"
+        "$cand" -n "$probe" >/dev/null 2>&1 || rc=1
+        printf 'a=(1 2)\n' > "$probe"
+        [[ "$rc" -eq 0 ]] && { rm -f "$probe"; printf '%s' "$cand"; return 0; }
+    done
+    rm -f "$probe"
+    return 1
+}
+
+_is_exempt() {
+    local f="$1" p
+    for p in ${POSIX_EXEMPT[@]+"${POSIX_EXEMPT[@]}"}; do
+        [[ "$f" == $p ]] && return 0
+    done
+    return 1
+}
+
+test_posix_floor() {
+    log_header "POSIX floor"
+
+    local sh
+    if ! sh="$(_posix_shell)"; then
+        log_fail "no POSIX shell here to check with"
+        printf '  dash, ash, yash, posh or busybox. `sh` on macOS is bash in\n'
+        printf '  POSIX mode and accepts arrays, so it cannot answer this.\n'
+        TESTS_RUN=1; TESTS_FAILED=1
+        FAILED_TESTS=("no POSIX shell available")
+        return 1
+    fi
+    log_info "checking with ${sh}"
+
+    local files file rel total=0 unreadable=0 exempt=0 why
+    declare -a bad=()
+    files="$(get_script_files)"
+
+    while IFS= read -r file; do
+        [[ -z "$file" || ! -f "$file" ]] && continue
+        rel="${file#$REPO_ROOT/}"
+        total=$(( total + 1 ))
+        if _is_exempt "$rel"; then exempt=$(( exempt + 1 )); continue; fi
+
+        why="$("$sh" -n "$file" 2>&1 | head -1)"
+        if [[ -n "$why" ]]; then
+            unreadable=$(( unreadable + 1 ))
+            why="${why##*: }"
+            bad+=("${rel}: ${why}")
+            log_test_warn "${rel} - ${why}"
+        fi
+    done <<< "$files"
+
+    echo ""
+    log_info "${unreadable} of $(( total - exempt )) cannot be read by ${sh}"
+    [[ "$exempt" -gt 0 ]] && log_info "${exempt} exempt by config"
+
+    TESTS_RUN=$(( total - exempt ))
+    TESTS_PASSED=$(( total - exempt - unreadable ))
+    TESTS_WARNED=$unreadable
+    WARNED_TESTS=("${bad[@]}")
+
+    # A budget, when one is configured. Without one this reports and never
+    # blocks, which is right while the number is still large: a gate that
+    # fails every run is one people stop reading.
+    if [[ "$POSIX_MAX_UNREADABLE" -ge 0 && "$unreadable" -gt "$POSIX_MAX_UNREADABLE" ]]; then
+        TESTS_FAILED=$(( unreadable - POSIX_MAX_UNREADABLE ))
+        FAILED_TESTS=("${bad[@]}")
+        printf '  over the budget of %s\n' "$POSIX_MAX_UNREADABLE" >&2
+        return 1
+    fi
+    return 0
+}
+
+main() {
+    # Refuse rather than grade the wrong repository.
+    #
+    # Through the `#!/usr/bin/env nutshell` shebang, `check-runner` resolves
+    # its root from the interpreter's own checkout, so a check run on its own
+    # reads the config and the files of whichever nutshell is on PATH. Run
+    # standalone here that was somebody else's clone, and it reported warnings
+    # about their files under this project's name.
+    #
+    # That is `check-runner`'s to fix and it is the same class it fixed at
+    # 0.4.0, in the one path that does not go through its walk. What this can
+    # do is not pretend: `./check` sets the root correctly and everything works
+    # there, and anywhere else this says so instead of answering.
+    if [[ -f "${PWD}/nut.toml" && -n "${REPO_ROOT:-}" && "${REPO_ROOT}" != "${PWD}" ]]; then
+        log_fail "this would read ${REPO_ROOT}, not ${PWD}"
+        printf '  run it through `./check`, which resolves the root from the\n' >&2
+        printf '  project rather than from the interpreter on PATH.\n' >&2
+        TESTS_RUN=1; TESTS_FAILED=1
+        FAILED_TESTS=("would have checked the wrong repository")
+        print_summary "POSIX floor"
+        exit_with_status
+    fi
+    load_config
+    test_posix_floor
+    print_summary "POSIX floor"
+    exit_with_status
+}
+
+# `NUT_CHECK_LOAD_ONLY` is the door a test uses to reach the readers without a
+# whole run over a repository.
+[[ -n "${NUT_CHECK_LOAD_ONLY:-}" ]] || main "$@"

--- a/nut.toml
+++ b/nut.toml
@@ -254,3 +254,19 @@ show_summary = true
 [deps.shebang]
 git = "https://github.com/orgrinrt/the-whole-shebang.git"
 ref = "main"
+
+# How much of this library a POSIX shell can read.
+#
+# The floor is meant to be POSIX sh, with a `when=` row selecting a better file
+# where a tool or a modern shell earns it. That is a direction rather than a
+# state, so this reports a number rather than passing or failing: 31 of 40 at
+# the time it was first measured, which is the honest starting point.
+#
+# `max_unreadable` is the budget. Left at -1 it reports and never blocks, which
+# is right while the number is still large, because a gate that fails every run
+# is one people stop reading. Lower it as the number comes down and it becomes
+# a ratchet.
+[tests.posix_floor]
+enabled = true
+max_unreadable = -1
+exempt = []

--- a/tests/check_posix_floor_test.sh
+++ b/tests/check_posix_floor_test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Tests for the check that says how much of this a POSIX shell can read.
+#
+# The floor is meant to be POSIX sh, with a `when=` row selecting a better file
+# where a tool or a modern shell earns it. That is a direction rather than a
+# state, so it needs a number that moves.
+#
+# The instrument is the part worth testing. Written against `sh` it reports a
+# clean floor on a library that has none, because `sh` on macOS is bash in
+# POSIX mode and accepts arrays, `[[` and here-strings. The first measurement
+# taken here was exactly that and was worthless, so the shell it picks is
+# verified against a probe rather than trusted by name.
+
+use test
+
+NUT_CHECK_LOAD_ONLY=1 . "${BASH_SOURCE[0]%/*}/../examples/checks/check_posix_floor.sh"
+
+_pf_tmp() { mktemp "${TMPDIR:-/tmp}/nutshell-pf.XXXXXX"; }
+
+#[test]
+it_finds_a_shell_that_is_actually_posix() {
+    local sh; sh="$(_posix_shell)" || { assert_eq "no posix shell here" "skipped"; return 0; }
+    assert_ne "$sh" ""
+    assert_ok command -v "$sh"
+}
+
+#[test]
+it_refuses_a_named_shell_that_accepts_an_array() {
+    # The control that makes every number this check prints mean anything, and
+    # it has to be driven rather than observed: with `dash` on the machine the
+    # selection returns `dash` first whatever the probes do, so asserting
+    # properties of what came back tests dash and not the choosing.
+    #
+    # `POSIX_SHELL` goes to the front of the candidate list, so naming `bash`
+    # asks the probes to reject the shell they exist to reject. Written the
+    # other way first, and removing both probes killed nothing.
+    POSIX_SHELL="bash"
+    local got; got="$(_posix_shell)" || got=""
+    POSIX_SHELL=""
+    assert_ne "$got" "bash"
+}
+
+#[test]
+it_refuses_the_sh_on_this_machine_when_that_sh_is_bash() {
+    # The specific trap, named. `sh` here is bash 3.2 in POSIX mode and takes
+    # arrays, `[[` and here-strings, so a check written against it reports a
+    # clean floor on a library that has none.
+    local probe; probe="$(_pf_tmp)"
+    printf 'a=(1 2)\n' > "$probe"
+    if sh -n "$probe" >/dev/null 2>&1; then
+        # This machine's `sh` is not POSIX enough, so the selection must not
+        # return it even when asked for it by name.
+        POSIX_SHELL="sh"
+        local got; got="$(_posix_shell)" || got=""
+        POSIX_SHELL=""
+        assert_ne "$got" "sh"
+    else
+        # Somewhere whose `sh` really is POSIX. Then it is a legitimate answer
+        # and the assertion is that it is reachable rather than excluded.
+        POSIX_SHELL="sh"
+        assert_eq "$(_posix_shell)" "sh"
+        POSIX_SHELL=""
+    fi
+    rm -f "$probe"
+}
+
+#[test]
+it_refuses_a_named_shell_that_cannot_read_ordinary_posix() {
+    # The other half of the probe. Without it the selection would take
+    # anything that merely rejects arrays, including something that rejects
+    # everything, and the library would read as entirely unreadable.
+    local fake; fake="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-pf.XXXXXX")"
+    printf '#!/bin/sh\nexit 1\n' > "$fake/refuses-all"
+    chmod +x "$fake/refuses-all"
+
+    POSIX_SHELL="$fake/refuses-all"
+    local got; got="$(PATH="$fake:$PATH" _posix_shell)" || got=""
+    POSIX_SHELL=""
+    assert_ne "$got" "$fake/refuses-all"
+    rm -rf "$fake"
+}
+
+#[test]
+it_reads_a_bashism_as_unreadable_and_plain_posix_as_readable() {
+    # End to end on two files whose answers are known, because everything
+    # above is about the shell and nothing yet about the reading.
+    local sh; sh="$(_posix_shell)" || return 0
+    local bad good
+    bad="$(_pf_tmp)";  printf 'a=(1 2)\necho "${a[0]}"\n' > "$bad"
+    good="$(_pf_tmp)"; printf 'x=1\necho "${x}"\n' > "$good"
+
+    assert_fails "$sh" -n "$bad"
+    assert_ok    "$sh" -n "$good"
+    rm -f "$bad" "$good"
+}
+
+#[test]
+it_matches_an_exempt_pattern_and_not_a_neighbour() {
+    POSIX_EXEMPT=('lib/legacy/*.sh' 'lib/one.sh')
+    assert_ok    _is_exempt "lib/legacy/thing.sh"
+    assert_ok    _is_exempt "lib/one.sh"
+    assert_fails _is_exempt "lib/two.sh"
+    assert_fails _is_exempt "lib/legacy.sh"
+    POSIX_EXEMPT=()
+}
+
+#[test]
+it_exempts_nothing_when_nothing_is_configured() {
+    # The control for the one above. An exemption matcher that said yes to
+    # everything would empty the report and read as a clean floor.
+    POSIX_EXEMPT=()
+    assert_fails _is_exempt "lib/anything.sh"
+    assert_fails _is_exempt ""
+}


### PR DESCRIPTION
The floor is meant to be POSIX sh, with a `when=` row selecting a better file where a tool or a modern shell earns it. That is a direction rather than a state, so it needs a number that moves rather than an opinion that does not.

**The number is 20 of 27.** That is the honest starting point and it is what the overhaul has to bring down.

## The instrument is most of the work

Because the obvious one is worthless. `sh` on macOS is bash 3.2 in POSIX mode and takes arrays, `[[` and here-strings, so a check written against `sh` reports a clean floor on a library that has none. The first measurement I took here was exactly that, and it said nine files failed when the real answer is twenty.

The shell is chosen by probing it rather than by name: it has to reject an array assignment and still accept ordinary POSIX. `dash`, `ash`, `yash`, `posh` and `busybox` are tried before `sh`, and `sh` is only taken if it passes.

## What it can and cannot see

It sees a **parse** failure, which is fatal in a way a runtime failure is not: the shell rejects the whole file before running a line of it, so no guard inside the file can help and the only answer is not to source that file on that shell. Which is exactly what a `when=` row is for.

It cannot see a construct that parses and then misbehaves. `declare -A` is the standing example: dash parses it as a command and fails when it runs. So a clean report means readable, not portable, and the check says so in its own header rather than letting a green be read as more than it is.

`max_unreadable` is a budget and it is off. A gate that fails every run is one people stop reading; lower it as the number comes down and it becomes a ratchet.

## It refuses rather than grading the wrong repository

Through the `#!/usr/bin/env nutshell` shebang, `check-runner` resolves its root from the interpreter's own checkout, so a check run on its own reads the config and the files of whichever nutshell is on `PATH`. Standalone here that was a different clone entirely, and it happily reported warnings about someone else's files under this project's name.

That is `check-runner`'s to fix, and it is the same class it fixed at `0.4.0`, in the one path that does not go through its walk. What this check can do is not pretend, so it says which tree it would have read and stops.

## Three of the seven tests could not fail

They took whatever `_posix_shell` returned and asserted properties of it, which with `dash` on the machine tests dash rather than the choosing. Removing both probes killed nothing.

They drive the selection with a named candidate now, so the probes are asked to reject the shell they exist to reject.

## Sanity

585 pass. The gate is nine checks and five warnings, one of them this.

| mutation | dies |
|---|---|
| trust a named shell, skip the array probe | the array test and the `sh`-is-bash test |
| drop the still-accepts-POSIX probe | `it_refuses_a_named_shell_that_cannot_read_ordinary_posix` |
| exempt everything | both exemption tests |