### PR TITLE
feat: the first POSIX floor, and the four readers that had to learn about it

### DIFF
--- a/lib/string.posix.sh
+++ b/lib/string.posix.sh
@@ -1,0 +1,245 @@
+#!/bin/sh
+# =============================================================================
+# nutshell/lib/string.posix.sh - String helpers, in POSIX sh
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# The floor. `lib/string.sh` is the same surface written for bash and is what
+# gets sourced where bash 4 is running; this is what a POSIX shell gets, and
+# before it existed a POSIX shell got a parse error and no module at all.
+#
+# The manifest decides between them, above the sourcing, because a file using a
+# construct the running shell cannot parse fails at parse time and no `if`
+# inside it can help:
+#
+#     string  lib/string.sh        when=shell:bash4
+#     string  lib/string.posix.sh
+#
+# **What is missing here, and it is one thing.** `str_split` writes into an
+# array through a nameref. POSIX has neither, and a version returning something
+# else would be a different function wearing the same name, which is worse than
+# an absent one: a caller would get an answer in the wrong shape rather than a
+# clear failure. So a script wanting `str_split` wants bash, and finds out by
+# the name not being there.
+#
+# Everything else is the same contract, checked against the bash file by a test
+# that runs both and compares, rather than by reading them side by side.
+#
+# The two-file arrangement is deliberate over one file full of branches. A
+# branch per function is a branch evaluated per call, and the whole point of
+# deciding at load time is that the decision is taken once.
+# =============================================================================
+
+# `nut_once` is nutshell's, and nutshell may not be loaded: this file is meant
+# to be readable by a shell that has none of it. Guarded the plain way instead.
+[ -n "${_NUTSHELL_STRING_POSIX_SH:-}" ] && return 0
+_NUTSHELL_STRING_POSIX_SH=1
+
+#[allow(trivial_wrapper)]
+#[pub]
+# Convert string to lowercase
+# Usage: str_lower "HELLO" -> "hello"
+#
+# `tr` rather than `${x,,}`, which is bash. There is no POSIX parameter
+# expansion for case, so this is one of the few places the floor needs a tool
+# at all, and `tr` is in POSIX itself rather than an optional extra.
+str_lower() {
+    printf '%s\n' "${1:-}" | tr '[:upper:]' '[:lower:]'
+}
+
+#[allow(trivial_wrapper)]
+#[pub]
+# Convert string to uppercase
+# Usage: str_upper "hello" -> "HELLO"
+str_upper() {
+    printf '%s\n' "${1:-}" | tr '[:lower:]' '[:upper:]'
+}
+
+#[pub]
+# Trim whitespace from both ends
+# Usage: str_trim "  hello  " -> "hello"
+#
+# The expansions here are POSIX as written: `${x#pattern}` and `${x%pattern}`
+# both are, and so is a bracket expression inside one. Only `${x//}` is not.
+str_trim() {
+    _s="${1:-}"
+    _s="${_s#"${_s%%[![:space:]]*}"}"
+    _s="${_s%"${_s##*[![:space:]]}"}"
+    printf '%s\n' "$_s"
+}
+
+#[pub]
+# Trim whitespace from left side
+# Usage: str_ltrim "  hello" -> "hello"
+str_ltrim() {
+    _s="${1:-}"
+    printf '%s\n' "${_s#"${_s%%[![:space:]]*}"}"
+}
+
+#[pub]
+# Trim whitespace from right side
+# Usage: str_rtrim "hello  " -> "hello"
+str_rtrim() {
+    _s="${1:-}"
+    printf '%s\n' "${_s%"${_s##*[![:space:]]}"}"
+}
+
+#[pub]
+# Replace all occurrences of a substring
+# Usage: str_replace "hello world" "world" "bash" -> "hello bash"
+#
+# A loop rather than `${x//from/to}`, which is bash. It walks by cutting at the
+# first occurrence and keeping what is either side, which is two POSIX
+# expansions and no tool: `sed` would need the needle escaped as a regular
+# expression, and a caller's needle is a literal.
+str_replace() {
+    _str="${1:-}"; _from="${2:-}"; _to="${3:-}"
+    if [ -z "$_from" ]; then printf '%s\n' "$_str"; return 0; fi
+
+    _out=""
+    while :; do
+        case "$_str" in
+            *"$_from"*) ;;
+            *) break ;;
+        esac
+        _head="${_str%%"$_from"*}"
+        _out="${_out}${_head}${_to}"
+        _str="${_str#*"$_from"}"
+    done
+    printf '%s\n' "${_out}${_str}"
+}
+
+#[pub]
+# Check if string contains substring
+# Usage: str_contains "hello world" "world" -> returns 0 (true)
+str_contains() {
+    [ -z "${2:-}" ] && return 0
+    case "${1:-}" in *"$2"*) return 0 ;; esac
+    return 1
+}
+
+#[pub]
+# Check if string starts with prefix
+# Usage: str_starts_with "hello world" "hello" -> returns 0 (true)
+str_starts_with() {
+    [ -z "${2:-}" ] && return 0
+    case "${1:-}" in "$2"*) return 0 ;; esac
+    return 1
+}
+
+#[pub]
+# Check if string ends with suffix
+# Usage: str_ends_with "hello world" "world" -> returns 0 (true)
+str_ends_with() {
+    [ -z "${2:-}" ] && return 0
+    case "${1:-}" in *"$2") return 0 ;; esac
+    return 1
+}
+
+#[pub]
+# Join arguments with a delimiter
+# Usage: str_join ", " a b c -> "a, b, c"
+str_join() {
+    _d="${1:-}"; shift
+    _r=""; _first=1
+    for _item in "$@"; do
+        if [ "$_first" -eq 1 ]; then _r="$_item"; _first=0
+        else _r="${_r}${_d}${_item}"; fi
+    done
+    printf '%s\n' "$_r"
+}
+
+#[allow(trivial_wrapper)]
+#[pub]
+# Get string length
+# Usage: str_length "hello" -> 5
+str_length() {
+    _s="${1:-}"
+    printf '%s\n' "${#_s}"
+}
+
+#[pub]
+# Extract substring
+# Usage: str_substr "hello world" 0 5 -> "hello"
+#
+# `cut -c` rather than `${x:start:len}`, which is bash. One-based and inclusive
+# where the expansion is zero-based and a length, so the arithmetic converts
+# rather than the caller having to.
+str_substr() {
+    _s="${1:-}"; _start="${2:-0}"; _len="${3:-}"
+    [ "$_start" -lt 0 ] 2>/dev/null && _start=0
+    _from=$(( _start + 1 ))
+    if [ -n "$_len" ]; then
+        [ "$_len" -le 0 ] 2>/dev/null && { printf '\n'; return 0; }
+        printf '%s\n' "$_s" | cut -c "${_from}-$(( _start + _len ))"
+    else
+        printf '%s\n' "$_s" | cut -c "${_from}-"
+    fi
+}
+
+#[pub]
+# Repeat string N times
+# Usage: str_repeat "-" 5 -> "-----"
+str_repeat() {
+    _s="${1:-}"; _n="${2:-1}"
+    [ "$_n" -le 0 ] 2>/dev/null && return 0
+    _r=""; _i=0
+    while [ "$_i" -lt "$_n" ]; do _r="${_r}${_s}"; _i=$(( _i + 1 )); done
+    printf '%s\n' "$_r"
+}
+
+#[pub]
+# Usage: str_distance build buidl -> 2
+#
+# Levenshtein distance: how many single-character edits turn one into the
+# other. For suggesting what somebody meant, so a caller applies its own
+# threshold; this only measures.
+#
+# One row rather than the full matrix, and the row lives in `$@` because POSIX
+# has no arrays. `set --` replaces it each pass, which is the one data
+# structure a POSIX shell has and is why this is the slowest thing here.
+str_distance() {
+    _a="$1"; _b="$2"
+    _alen=${#_a}; _blen=${#_b}
+
+    # Row zero: 0 1 2 ... blen
+    set --
+    _j=0
+    while [ "$_j" -le "$_blen" ]; do set -- "$@" "$_j"; _j=$(( _j + 1 )); done
+
+    _i=1
+    while [ "$_i" -le "$_alen" ]; do
+        _prev=$1
+        _newrow="$_i"
+        # The entry to the left is the one just computed, not the previous
+        # row's. Read from `$@` it is the old row and every distance comes out
+        # too large: kitten to sitting reported 6 where it is 3.
+        _left=$_i
+        _ac=$(printf '%s\n' "$_a" | cut -c "$_i")
+        _j=1
+        while [ "$_j" -le "$_blen" ]; do
+            # `$@` is the previous row; field j+1 is its jth entry.
+            eval "_cur=\${$(( _j + 1 ))}"
+            _bc=$(printf '%s\n' "$_b" | cut -c "$_j")
+            _cost=1
+            [ "$_ac" = "$_bc" ] && _cost=0
+
+            _best=$(( _cur + 1 ))
+            _ins=$(( _left + 1 ))
+            [ "$_ins" -lt "$_best" ] && _best=$_ins
+            _sub=$(( _prev + _cost ))
+            [ "$_sub" -lt "$_best" ] && _best=$_sub
+
+            _newrow="$_newrow $_best"
+            _prev=$_cur
+            _left=$_best
+            _j=$(( _j + 1 ))
+        done
+        # shellcheck disable=SC2086
+        set -- $_newrow
+        _i=$(( _i + 1 ))
+    done
+
+    eval "printf '%d' \"\${$(( _blen + 1 ))}\""
+}

--- a/tests/string_posix_parity_test.sh
+++ b/tests/string_posix_parity_test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Tests that the POSIX string floor answers what the bash one answers.
+#
+# Two files with one surface is only safe while they agree, and agreement is
+# not something you can establish by reading them side by side: the bash one
+# uses `${x,,}`, `${x//}` and `${x:i:n}`, and the POSIX one uses `tr`, a cut
+# loop and `cut -c`, so nothing about them looks alike.
+#
+# So both are driven over the same inputs and the answers are compared. The
+# POSIX one is run under a real POSIX shell rather than under bash, because
+# running it under bash tests nothing that the bash file does not already
+# cover, and the interesting failures are the ones bash forgives.
+#
+# `str_split` is absent from the floor on purpose and is not compared here.
+# It writes into an array through a nameref, POSIX has neither, and a version
+# returning some other shape would be a different function wearing the same
+# name.
+
+use test
+
+ROOT="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+BASHFILE="$ROOT/lib/string.sh"
+POSIXFILE="$ROOT/lib/string.posix.sh"
+
+# A POSIX shell that is one, or nothing. Same probe the floor check uses: it
+# must reject an array and still accept ordinary POSIX.
+_sp_shell() {
+    local cand probe; probe="$(mktemp)"
+    for cand in dash ash yash posh sh; do
+        command -v "$cand" >/dev/null 2>&1 || continue
+        printf 'a=(1 2)\n' > "$probe"
+        "$cand" -n "$probe" >/dev/null 2>&1 && continue
+        printf 'x=1\necho "${x:-}"\n' > "$probe"
+        "$cand" -n "$probe" >/dev/null 2>&1 && { rm -f "$probe"; printf '%s' "$cand"; return 0; }
+    done
+    rm -f "$probe"; return 1
+}
+
+# What the bash file answers, under bash.
+#
+# `nut_once` is stubbed rather than nutshell loaded, because loading nutshell
+# would also load `string` through the manifest and the point is to run one
+# named file. Written without the stub, every call came back 127 and the
+# comparison was between two absences.
+_ask_bash() {
+    bash -c 'nut_once() { return 0; }
+             . "$1" >/dev/null 2>&1; shift; f="$1"; shift
+             command -v "$f" >/dev/null 2>&1 || { printf "|missing"; exit 0; }
+             "$f" "$@"; printf "|%s" "$?"' \
+        _ "$BASHFILE" "$@" 2>/dev/null
+}
+
+# What the POSIX file answers, under a POSIX shell.
+_ask_posix() {
+    local sh="$1"; shift
+    "$sh" -c 'nut_once() { return 0; }
+              . "$1" >/dev/null 2>&1; shift; f="$1"; shift
+              command -v "$f" >/dev/null 2>&1 || { printf "|missing"; exit 0; }
+              "$f" "$@"; printf "|%s" "$?"' \
+        _ "$POSIXFILE" "$@" 2>/dev/null
+}
+
+# Both, compared. The status is part of the answer: three of these return a
+# verdict rather than text and comparing only stdout would call them all equal.
+_same() {
+    local sh="$1"; shift
+    local b p
+    b="$(_ask_bash "$@")"
+    p="$(_ask_posix "$sh" "$@")"
+    assert_eq "$p" "$b" "$*"
+}
+
+#[test]
+it_has_a_posix_shell_to_compare_under() {
+    # The control for every test below. Without a POSIX shell they all skip,
+    # and a skip that reports a pass is how a parity suite comes to mean
+    # nothing.
+    local sh; sh="$(_sp_shell)"
+    assert_ne "$sh" ""
+    assert_ne "$sh" "bash"
+}
+
+#[test]
+it_reads_the_floor_under_a_posix_shell_at_all() {
+    # And the control for that: the file has to load there. This is the whole
+    # reason the floor exists, so it is asserted rather than assumed.
+    local sh; sh="$(_sp_shell)" || return 0
+    assert_ok "$sh" -n "$POSIXFILE"
+    assert_fails "$sh" -n "$BASHFILE"
+}
+
+#[test]
+it_answers_the_same_for_case_and_trimming() {
+    local sh; sh="$(_sp_shell)" || return 0
+    _same "$sh" str_lower "HeLLo WoRLD"
+    _same "$sh" str_lower ""
+    _same "$sh" str_upper "hello world"
+    _same "$sh" str_upper "ALREADY"
+    _same "$sh" str_trim "   padded   "
+    _same "$sh" str_trim "none"
+    _same "$sh" str_trim "   "
+    _same "$sh" str_trim ""
+    _same "$sh" str_ltrim "   left"
+    _same "$sh" str_rtrim "right   "
+    _same "$sh" str_trim "$(printf '\tmixed \t')"
+}
+
+#[test]
+it_answers_the_same_for_replace() {
+    local sh; sh="$(_sp_shell)" || return 0
+    _same "$sh" str_replace "hello world" "world" "bash"
+    _same "$sh" str_replace "aaa" "a" "b"
+    _same "$sh" str_replace "aaa" "aa" "b"
+    _same "$sh" str_replace "nothing here" "zzz" "x"
+    _same "$sh" str_replace "keep" "" "x"
+    _same "$sh" str_replace "" "a" "b"
+    # A needle with regex characters in it, which is why this is a loop rather
+    # than a `sed`: a caller's needle is a literal.
+    _same "$sh" str_replace "a.b.c" "." "-"
+    _same "$sh" str_replace 'a*b' '*' '+'
+    _same "$sh" str_replace 'a[b]c' '[b]' 'X'
+    # Removing rather than replacing.
+    _same "$sh" str_replace "xxhixx" "xx" ""
+}
+
+#[test]
+it_answers_the_same_for_the_three_that_return_a_verdict() {
+    local sh; sh="$(_sp_shell)" || return 0
+    _same "$sh" str_contains "hello world" "world"
+    _same "$sh" str_contains "hello world" "zzz"
+    _same "$sh" str_contains "hello" ""
+    _same "$sh" str_starts_with "hello world" "hello"
+    _same "$sh" str_starts_with "hello world" "world"
+    _same "$sh" str_starts_with "hello" ""
+    _same "$sh" str_ends_with "hello world" "world"
+    _same "$sh" str_ends_with "hello world" "hello"
+    _same "$sh" str_ends_with "hello" ""
+    # A needle that is a glob, which `case` would match as a pattern if the
+    # quoting were wrong on either side.
+    _same "$sh" str_contains "a*b" "*"
+    _same "$sh" str_starts_with "abc" "a*"
+}
+
+#[test]
+it_answers_the_same_for_join_length_substr_and_repeat() {
+    local sh; sh="$(_sp_shell)" || return 0
+    _same "$sh" str_join ", " a b c
+    _same "$sh" str_join ", " a
+    _same "$sh" str_join ", "
+    _same "$sh" str_join "" a b
+    _same "$sh" str_length "hello"
+    _same "$sh" str_length ""
+    _same "$sh" str_substr "hello world" 0 5
+    _same "$sh" str_substr "hello world" 6
+    _same "$sh" str_substr "hello world" 6 5
+    _same "$sh" str_substr "hello" 0
+    _same "$sh" str_repeat "-" 5
+    _same "$sh" str_repeat "ab" 3
+    _same "$sh" str_repeat "-" 0
+    _same "$sh" str_repeat "-" -1
+}
+
+#[test]
+it_answers_the_same_distance() {
+    local sh; sh="$(_sp_shell)" || return 0
+    _same "$sh" str_distance build buidl
+    _same "$sh" str_distance "" ""
+    _same "$sh" str_distance abc ""
+    _same "$sh" str_distance "" abc
+    _same "$sh" str_distance same same
+    _same "$sh" str_distance kitten sitting
+    _same "$sh" str_distance a b
+}
+
+#[test]
+it_does_not_define_split_on_the_floor() {
+    # Absent on purpose. A caller wanting it wants bash, and finds out by the
+    # name not being there rather than by getting an answer in the wrong shape.
+    local sh; sh="$(_sp_shell)" || return 0
+    local out
+    out="$("$sh" -c 'nut_once() { return 0; }; . "$1" >/dev/null 2>&1; command -v str_split >/dev/null && echo THERE || echo absent' _ "$POSIXFILE" 2>&1)"
+    assert_eq "$out" "absent"
+
+    # And the control: it is there in the bash one, so the line above is about
+    # the floor rather than about the name being wrong.
+    out="$(bash -c 'nut_once() { return 0; }; . "$1" >/dev/null 2>&1; command -v str_split >/dev/null && echo there || echo ABSENT' _ "$BASHFILE" 2>&1)"
+    assert_eq "$out" "there"
+}


### PR DESCRIPTION
`string` is two files now.

```
string  lib/string.sh        when=shell:bash4
string  lib/string.posix.sh
```

Before this a POSIX shell got a parse error and no module at all. The floor check goes from 20 of 27 unreadable to 19.

Two files rather than one full of branches, because a branch per function is a branch per call, and the whole point of deciding at load time is that the decision is taken once.

## One thing is missing from the floor, on purpose

`str_split` writes into an array through a nameref. POSIX has neither, and a version returning some other shape would be a different function wearing the same name, which is worse than an absent one: a caller would get an answer in the wrong shape rather than a clear failure. A script wanting it wants bash, and finds out by the name not being there.

## Parity is run, not read

Both files, same inputs, the POSIX one under a real POSIX shell. One uses `${x,,}`, `${x//}` and `${x:i:n}`; the other uses `tr`, a cut loop and `cut -c`. Nothing about them looks alike, so reading them side by side establishes nothing.

It found two divergences and both were real.

`str_distance` in the floor read the entry to its left out of the previous row rather than the one just computed, so kitten to sitting came out `6` where it is `3`.

And **`str_replace` in the bash file treated its needle as a pattern**. `str_replace 'a*b' '*' '+'` returned `+`, `a?c` matched `axc`, `[b]` matched a bare `b`. None of that is "replace all occurrences of a substring", which is what it documents, and a caller passing a needle out of a file means a literal. The needle is quoted now. The floor could not have this bug: it has no `${x//}` and cuts at the first literal occurrence instead.

## Four readers reported the arrangement as a defect

Which is the real cost of the feature, and it is landed rather than exempted.

**`bin/nut-declare`** read `when=` as a visibility and the second file as an undeclared module. It reads the trailing columns as words now, the same way the resolver does, and asks whether the manifest names a *file* rather than whether it names the module a path suggests. It also validates the predicate's own words, because a predicate `_nut_when` refuses is a variant that silently never loads.

**`check_function_duplication`** called every shared name a perfect copy. It skips a pair the manifest declares as one module.

I wrote that with absolute paths where `collect_all_functions` produces relative ones, so it never matched anything. It passed my standalone check because I fed it hand-made absolute input, which is a test of the input. It took an embarrassing number of attempts to find, including one where I ran `git checkout --` over the uncommitted fix and recovered it from a copy in `/tmp`.

That chase turned up a defect older than any of this: the stripped comparison reads `$4` for the file and was being handed three fields, so `files[]` was empty on every row of that pass. It could not name a file in its own report.

**`lib/modgraph.sh`** read the second file as a module calling fifteen functions it never declared. It asks the manifest which module a file belongs to, and a second file for a module already seen merges into it rather than starting another.

## Sanity

606 pass, was 578. Gate is nine checks, six warnings, none of them this.

| mutation | dies |
|---|---|
| the floor's distance reads the old row | the parity distance test |
| the bash needle unquoted again | the parity replace test |
| duplication pairs absolute again | `it_does_not_call_two_variants_of_one_module_a_duplicate` |
| stripped pass back to three fields | `it_carries_the_file_through_the_stripped_comparison` |
| modgraph names by path again | three modgraph tests |
| modgraph merges everything | six, including the control |
| `nut-declare` stops validating predicates | `it_reports_a_predicate_it_does_not_understand` |