### PR TITLE
fix: land the rest of the POSIX floor, which the last commit left out

### DIFF
--- a/bin/nut-declare
+++ b/bin/nut-declare
@@ -88,6 +88,16 @@ _dupes() {
     _scan | awk -F'\t' '{ print $1 }' | sort | uniq -d
 }
 
+# Every file a declaration names. One module may name several.
+_lib_nut_files_of() {
+    local r="$1" n f _rest
+    [[ -r "${r}/lib.nut" ]] || return 1
+    while read -r n f _rest || [[ -n "$n" ]]; do
+        [[ -z "$n" || "${n:0:1}" == "#" ]] && continue
+        [[ -n "$f" ]] && printf '%s\n' "$f"
+    done < "${r}/lib.nut"
+}
+
 # Every name a declaration holds. One parser for the checker, so it and the
 # resolver cannot disagree about what the file says.
 _lib_nut_modules_of() {
@@ -132,24 +142,53 @@ case "$MODE" in
         # a comment wherever it starts, a missing newline on the last line does
         # not lose it, and a line that is not a declaration is reported rather
         # than crashing on an unset positional.
-        while read -r dname dfile dvis || [[ -n "$dname" ]]; do
+        while read -r dname dfile drest || [[ -n "$dname" ]]; do
             [[ -z "$dname" || "${dname:0:1}" == "#" ]] && continue
             if [[ -z "$dfile" ]]; then
                 printf 'not a declaration: %s\n' "$dname"; rc=1; continue
             fi
-            case "${dvis:-}" in
-                ""|internal) ;;
-                *) printf 'unknown visibility on %s: %s\n' "$dname" "$dvis"; rc=1 ;;
-            esac
+            # The trailing columns are words rather than positions, the same
+            # way the resolver reads them, or the two disagree about what a
+            # row says. Read by position, `when=shell:bash4` was reported as
+            # an unknown visibility.
+            for dword in $drest; do
+                case "$dword" in
+                    internal) ;;
+                    when=*)
+                        # The predicate's words too, because `_nut_when` refuses
+                        # one it does not know and a refused predicate is a
+                        # variant that silently never loads. Caught here it is a
+                        # typo somebody can see.
+                        _dp="${dword#when=}"
+                        while [ -n "$_dp" ]; do
+                            case "$_dp" in
+                                *+*) dpart="${_dp%%+*}"; _dp="${_dp#*+}" ;;
+                                *)   dpart="$_dp"; _dp="" ;;
+                            esac
+                            case "$dpart" in
+                                have:?*|env:?*|shell:bash|shell:bash4) ;;
+                                *) printf 'unknown predicate on %s: %s\n' "$dname" "$dpart"; rc=1 ;;
+                            esac
+                        done
+                        ;;
+                    *) printf 'unknown word on %s: %s\n' "$dname" "$dword"; rc=1 ;;
+                esac
+            done
             if [[ ! -f "$ROOT/$dfile" ]]; then
                 printf 'declared but missing: %s -> %s\n' "$dname" "$dfile"; rc=1
             fi
         done < "$ROOT/lib.nut"
+        # By file, not by the name the path suggests.
+        #
+        # A module may name several files, which is what a `when=` row is, and
+        # `lib/string.posix.sh` is not a module called `string.posix`: it is
+        # one of the files module `string` can be. Asked by derived name, every
+        # variant reads as an undeclared file.
+        declared_files="$(_lib_nut_files_of "$ROOT")"
         while IFS=$'\t' read -r name rel _vis; do
-            # Compared as a word, not matched as a pattern. A module named
-            # `fs.impl` would otherwise match `fsXimpl` and be reported as
-            # declared when it is not.
-            _lib_nut_modules_of "$ROOT" | grep -qxF "$name" \
+            # Compared as a word, not matched as a pattern. A path
+            # `lib/fs.sh` would otherwise match `lib/fsXsh`.
+            grep -qxF "$rel" <<<"$declared_files" \
                 || { printf 'present but undeclared: %s (%s)\n' "$name" "$rel"; rc=1; }
         done < <(_scan)
         # Not `local`: this is a case arm at file scope, where `local` is a

--- a/examples/checks/check_function_duplication.sh
+++ b/examples/checks/check_function_duplication.sh
@@ -134,11 +134,57 @@ collect_all_functions() {
 
 # Run full name comparison using optimized awk
 # Returns lines in format: "FAIL|score|name1|name2|file1|file2" or "WARN|..."
+# Every pair of files that are two spellings of one module, as `a>b`, so the
+# comparison can skip a perfect score between them. Read from the manifest
+# rather than named here, because a list here is a second place to update.
+_variant_pairs() {
+    local root="${REPO_ROOT:-$PWD}" name file rest word
+    local -A owner=()
+    [[ -r "${root}/lib.nut" ]] || return 0
+    while read -r name file rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        [[ -n "$file" ]] || continue
+        if [[ -n "${owner[$name]:-}" ]]; then
+            local prior
+            for prior in ${owner[$name]}; do
+                # Relative, as written in the manifest, because that is the
+                # shape `collect_all_functions` produces. Emitted absolute
+                # first, and nothing ever matched: the skip was proved on
+                # hand-made absolute input and never once fired on the real
+                # data, which is the whole reason a test builds its own input
+                # carefully and then proves nothing.
+                printf '%s>%s ' "$prior" "$file"
+            done
+        fi
+        owner["$name"]="${owner[$name]:-} $file"
+    done < "${root}/lib.nut"
+}
+
+# Computed once. There are two comparisons in this file and the second is the
+# one that reported the variants: set inside the first, the second never saw it.
+declare -g _NUT_DUP_VARIANTS=""
+_variants_once() {
+    [[ -n "${_NUT_DUP_VARIANTS_DONE:-}" ]] && return 0
+    _NUT_DUP_VARIANTS="$(_variant_pairs)"
+    _NUT_DUP_VARIANTS_DONE=1
+}
+
+# The list to use: whatever the caller set, else the manifest's.
+#
+# A caller passing its own used to be overwritten by the manifest's, which made
+# the comparison untestable against anything but this repository.
+_variants_for() {
+    if [[ -n "${NUT_DUP_VARIANTS+x}" ]]; then printf '%s' "$NUT_DUP_VARIANTS"; return 0; fi
+    _variants_once
+    printf '%s' "$_NUT_DUP_VARIANTS"
+}
+
 compare_full_names() {
     local func_data="$1"
     local threshold="$2"
+    local NUT_DUP_VARIANTS; NUT_DUP_VARIANTS="$(_variants_for)"
     
-    echo "$func_data" | awk -F'|' -v threshold="$threshold" '
+    echo "$func_data" | awk -F'|' -v threshold="$threshold" -v variants="${NUT_DUP_VARIANTS:-}" '
     # Levenshtein distance, abandoned as soon as it cannot matter.
     #
     # `maxd` is the largest distance the caller could still accept. Past that
@@ -211,6 +257,21 @@ compare_full_names() {
         return 1.0 - (dist / maxlen)
     }
     
+    BEGIN {
+        # Files that are two spellings of one module, as `a>b` pairs.
+        #
+        # A module carrying a `when=` row is written twice, once for bash and
+        # once for POSIX sh, and the two hold the same function names on
+        # purpose. Every one of those is a perfect score and none of them is a
+        # copy: only one is ever sourced.
+        n = split(variants, vs, " ")
+        for (k = 1; k <= n; k++) is_variant_pair[vs[k]] = 1
+    }
+
+    function are_variants(a, b) {
+        return (is_variant_pair[a ">" b] || is_variant_pair[b ">" a])
+    }
+
     {
         names[NR] = $1
         files[NR] = $2
@@ -262,6 +323,8 @@ compare_full_names() {
                     }
                 }
 
+                if (are_variants(files[i], files[j])) continue
+
                 printf "MATCH|%.3f|%s|%s|%s|%s\n", score, names[i], names[j], files[i], files[j]
             }
         }
@@ -292,7 +355,14 @@ add_stripped_names() {
     {
         stripped = strip_prefix($1)
         if (length(stripped) >= 4) {
-            print stripped "|" $1 "|" $2
+            # Four fields, because the comparison downstream reads `$4` for the
+            # file and was being handed three. `files[]` was empty on every row
+            # of that pass, so it could not name a file in its own report and
+            # could not tell two spellings of one module apart.
+            #
+            # The prefix is what `strip_prefix` removed, kept so the report can
+            # show the whole name.
+            print stripped "|" substr($1, 1, length($1) - length(stripped)) "|" $1 "|" $2
         }
     }
     '
@@ -301,10 +371,11 @@ add_stripped_names() {
 # Run stripped name comparison using optimized awk
 # Returns lines in format: "WARN|score|stripped1|orig1|stripped2|orig2|file1|file2"
 compare_stripped_names() {
+    local NUT_DUP_VARIANTS; NUT_DUP_VARIANTS="$(_variants_for)"
     local func_data="$1"
     local threshold="$2"
     
-    echo "$func_data" | awk -F'|' -v threshold="$threshold" '
+    echo "$func_data" | awk -F'|' -v threshold="$threshold" -v variants="${NUT_DUP_VARIANTS:-}" '
     # The same abandoned-early distance as the first pass. See there for why.
     function levenshtein(s1, s2, maxd,    len1, len2, i, j, c1, cost, prev, cur, best, subst) {
         len1 = length(s1); len2 = length(s2)
@@ -342,6 +413,15 @@ compare_stripped_names() {
         return 1.0 - (dist / maxlen)
     }
     
+    BEGIN {
+        n = split(variants, vs, " ")
+        for (k = 1; k <= n; k++) is_variant_pair[vs[k]] = 1
+    }
+
+    function are_variants(a, b) {
+        return (is_variant_pair[a ">" b] || is_variant_pair[b ">" a])
+    }
+
     {
         stripped[NR] = $1
         prefixes[NR] = $2
@@ -376,6 +456,7 @@ compare_stripped_names() {
                 score = similarity(stripped[i], stripped[j], threshold)
                 
                 if (score >= threshold) {
+                    if (are_variants(files[i], files[j])) continue
                     printf "WARN|%.3f|%s|%s|%s|%s|%s|%s\n", score, stripped[i], original[i], stripped[j], original[j], files[i], files[j]
                 }
             }

--- a/examples/checks/check_posix_floor.sh
+++ b/examples/checks/check_posix_floor.sh
@@ -85,6 +85,34 @@ _is_exempt() {
     return 1
 }
 
+# Files the manifest reaches only behind a `shell:` predicate.
+#
+# The question this check exists to answer is which modules a POSIX shell
+# cannot load, not which files it cannot parse. Those stopped being the same
+# thing the moment a module could carry a variant: `lib/string.sh` will never
+# parse under dash and never has to, because `lib/string.posix.sh` is what a
+# POSIX shell is given.
+#
+# Counting the file would make the number go **up** when a floor is added,
+# which is the number moving the wrong way while the library gets better, and
+# is the kind of thing people then stop reading.
+#
+# Only `shell:` counts. A row predicated on `have:` is still sourced on a POSIX
+# shell wherever that tool exists, so it has to parse there.
+_shell_gated_files() {
+    local root="$1" name file rest word
+    [[ -r "${root}/lib.nut" ]] || return 0
+    while read -r name file rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        [[ -n "$file" ]] || continue
+        for word in $rest; do
+            case "$word" in
+                when=*shell:*) printf '%s\n' "$file" ;;
+            esac
+        done
+    done < "${root}/lib.nut"
+}
+
 test_posix_floor() {
     log_header "POSIX floor"
 
@@ -99,15 +127,21 @@ test_posix_floor() {
     fi
     log_info "checking with ${sh}"
 
-    local files file rel total=0 unreadable=0 exempt=0 why
+    local files file rel total=0 unreadable=0 exempt=0 gated=0 why
     declare -a bad=()
     files="$(get_script_files)"
+
+    local -A shell_gated=()
+    while IFS= read -r rel; do
+        [[ -n "$rel" ]] && shell_gated["$rel"]=1
+    done < <(_shell_gated_files "$REPO_ROOT")
 
     while IFS= read -r file; do
         [[ -z "$file" || ! -f "$file" ]] && continue
         rel="${file#$REPO_ROOT/}"
         total=$(( total + 1 ))
         if _is_exempt "$rel"; then exempt=$(( exempt + 1 )); continue; fi
+        if [[ -n "${shell_gated[$rel]:-}" ]]; then gated=$(( gated + 1 )); continue; fi
 
         why="$("$sh" -n "$file" 2>&1 | head -1)"
         if [[ -n "$why" ]]; then
@@ -119,11 +153,12 @@ test_posix_floor() {
     done <<< "$files"
 
     echo ""
-    log_info "${unreadable} of $(( total - exempt )) cannot be read by ${sh}"
+    log_info "${unreadable} of $(( total - exempt - gated )) cannot be read by ${sh}"
+    [[ "$gated" -gt 0 ]] && log_info "${gated} behind a shell: predicate, so never sourced there"
     [[ "$exempt" -gt 0 ]] && log_info "${exempt} exempt by config"
 
-    TESTS_RUN=$(( total - exempt ))
-    TESTS_PASSED=$(( total - exempt - unreadable ))
+    TESTS_RUN=$(( total - exempt - gated ))
+    TESTS_PASSED=$(( total - exempt - gated - unreadable ))
     TESTS_WARNED=$unreadable
     WARNED_TESTS=("${bad[@]}")
 

--- a/init
+++ b/init
@@ -399,6 +399,51 @@ _nut_when() {
     return 0
 }
 
+# _lib_nut_files <root>
+#
+# Every file a library declares, one per line, relative as written.
+#
+# One module may name several, which is what a `when=` row is, so this is not
+# the same list as `_lib_nut_modules` and a reader wanting "is this file part
+# of the library" wants this one. Deriving a module name from a path and
+# looking that up says no for every variant: `lib/string.posix.sh` is not a
+# module called `string.posix`, it is one of the files module `string` can be.
+#
+# Here rather than in each checker because three of them asked the question
+# separately and all three got a different wrong answer the day a variant
+# appeared.
+_lib_nut_files() {
+    local root="$1" name file _rest
+    [[ -r "${root}/lib.nut" ]] || return 1
+    while read -r name file _rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        [[ -n "$file" ]] && printf '%s\n' "$file"
+    done < "${root}/lib.nut"
+}
+
+# _lib_nut_variants_of <root> <file>
+#
+# The other files declared for whichever module declares this one, this one
+# excluded. Empty when the file is not a variant, which is the common case.
+#
+# What a checker wants when two files legitimately hold the same function
+# names, or when one appears to call into the other: they are one module
+# written twice for two shells, not two modules.
+_lib_nut_variants_of() {
+    local root="$1" want="$2" name file _rest owner=""
+    [[ -r "${root}/lib.nut" ]] || return 1
+    while read -r name file _rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        [[ "$file" == "$want" ]] && { owner="$name"; break; }
+    done < "${root}/lib.nut"
+    [[ -n "$owner" ]] || return 1
+    while read -r name file _rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        [[ "$name" == "$owner" && "$file" != "$want" ]] && printf '%s\n' "$file"
+    done < "${root}/lib.nut"
+    return 0
+}
+
 # _lib_nut_modules <root>
 #
 # Every module a library declares, one per line. For the checker, and for an

--- a/lib.nut
+++ b/lib.nut
@@ -30,7 +30,8 @@ os                       lib/os.sh
 priv                     lib/priv.sh
 prompt                   lib/prompt.sh
 srcfile                  lib/srcfile.sh
-string                   lib/string.sh
+string                   lib/string.sh        when=shell:bash4
+string                   lib/string.posix.sh
 test                     lib/test.sh
 text                     lib/text.sh
 text::impl::awk_replace  lib/text/impl/awk_replace.sh internal

--- a/lib/modgraph.sh
+++ b/lib/modgraph.sh
@@ -214,15 +214,80 @@ _mg_scan() {
 # Building
 # -----------------------------------------------------------------------------
 
+declare -gA _MG_SEEN=()
+
 _mg_reset() {
     _MG_DECLARES=(); _MG_DEFINES=(); _MG_CALLS=(); _MG_OWNER=(); _MG_VIS=(); _MG_MODULES=()
+    _MG_SEEN=()
+}
+
+# A second file for a module already recorded: its declarations, definitions
+# and calls are added to that module rather than becoming another one.
+_mg_merge_into() {
+    local mod="$1" file="$2" kind values fn pair
+    local visraw=""
+    while IFS=$'\t' read -r kind values; do
+        case "$kind" in
+            declares) _MG_DECLARES[$mod]="${_MG_DECLARES[$mod]:-} $values" ;;
+            defines)  _MG_DEFINES[$mod]="${_MG_DEFINES[$mod]:-} $values" ;;
+            calls)    _MG_CALLS[$mod]="${_MG_CALLS[$mod]:-} $values" ;;
+            vis)      visraw="$values" ;;
+        esac
+    done < <(_mg_scan "$file")
+
+    # The variant's own definitions belong to the same module, and its
+    # visibilities are its own: a function public in one spelling and absent
+    # from the other still has to answer as public.
+    for fn in ${_MG_DEFINES[$mod]:-}; do
+        _MG_OWNER[$fn]="$mod"
+    done
+    for pair in ${visraw:-}; do
+        _MG_VIS[${pair%%=*}]="${pair#*=}"
+    done
+}
+
+# The module a file belongs to, from the manifest when there is one.
+#
+# A module may name several files, which is what a `when=` row is: `string.sh`
+# and `string.posix.sh` are one module written twice for two shells and only
+# one is ever loaded. Named from the path, the second becomes a module called
+# `string.posix` that calls fifteen functions from `string` and declares none
+# of them, and the contract check reports every one.
+#
+# Falls back to the file stem, which is what every file without a manifest
+# entry gets and what this always did.
+_mg_module_of() {
+    local file="$1" root="${2:-}" rel name f _rest
+    local stem="${file##*/}"; stem="${stem%.sh}"
+    [[ -n "$root" && -r "${root}/lib.nut" ]] || { printf '%s' "$stem"; return 0; }
+    rel="${file#"${root}/"}"
+    while read -r name f _rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        if [[ "$f" == "$rel" ]]; then
+            # The leaf, since this graph works in file-stem names throughout
+            # and a `::` path would not match anything else in it.
+            printf '%s' "${name##*::}"
+            return 0
+        fi
+    done < "${root}/lib.nut"
+    printf '%s' "$stem"
 }
 
 _mg_analyse() {
     local dir="$1" file mod line kind values
+    # The library root, so the manifest can say which module a file is. `dir`
+    # is the lib directory; the manifest sits above it.
+    local root="${MODGRAPH_ROOT:-${dir%/*}}"
     for file in "$dir"/*.sh; do
         [[ -f "$file" ]] || continue
-        mod="${file##*/}"; mod="${mod%.sh}"
+        mod="$(_mg_module_of "$file" "$root")"
+        # A module already seen is a variant of it. Its calls and definitions
+        # join the ones already recorded rather than starting a second module.
+        if [[ -n "${_MG_SEEN[$mod]:-}" ]]; then
+            _mg_merge_into "$mod" "$file"
+            continue
+        fi
+        _MG_SEEN[$mod]=1
         _MG_MODULES+=("$mod")
         while IFS=$'\t' read -r kind values; do
             case "$kind" in

--- a/lib/string.sh
+++ b/lib/string.sh
@@ -72,7 +72,18 @@ str_replace() {
     local to="${3:-}"
     
     [[ -z "$from" ]] && { echo "$str"; return 0; }
-    echo "${str//$from/$to}"
+    # The needle is quoted, so it is a literal.
+    #
+    # Unquoted, `${str//$from/$to}` reads it as a pattern, which is not what
+    # "replace all occurrences of a substring" says and not what a caller
+    # passing a needle out of a file means. `str_replace 'a*b' '*' '+'`
+    # returned `+`, because `*` matched the whole string; `a?c` matched `axc`;
+    # and `[b]` matched a bare `b`.
+    #
+    # Found by writing the POSIX floor beside this and comparing the two over
+    # the same inputs. The floor could not have this bug: it has no `${x//}`
+    # and cuts at the first literal occurrence instead.
+    echo "${str//"$from"/$to}"
 }
 
 #[pub]

--- a/tests/check_duplication_test.sh
+++ b/tests/check_duplication_test.sh
@@ -70,3 +70,57 @@ it_does_not_compare_a_name_with_no_prefix_by_a_prefix_rule() {
     local out; out="$(_pairs "$(printf 'render|a.sh\nrenders|b.sh\n')")"
     assert_contains "$out" "MATCH"
 }
+
+# --- two spellings of one module are not a copy ------------------------------
+#
+# A `when=` row means a module is written twice for two shells, holding the
+# same function names on purpose, and only one is ever loaded. Every pair of
+# them scores 1.000 and none of them is a duplicate.
+#
+# The paths matter here and are the reason this test exists. `_variant_pairs`
+# emitted absolute paths while `collect_all_functions` produces repo-relative
+# ones, so the skip never matched and never fired on real data. It was proved
+# working on hand-made absolute input, which is a test of the input.
+
+_dup_lib() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-dup.XXXXXX")"
+    printf '%s' "$1" > "$d/lib.nut"
+    printf '%s' "$d"
+}
+
+#[test]
+it_does_not_call_two_variants_of_one_module_a_duplicate() {
+    local d; d="$(_dup_lib 'thing  lib/thing.sh        when=shell:bash4
+thing  lib/thing.posix.sh')"
+    local pairs; pairs="$(REPO_ROOT="$d" _variant_pairs)"
+    # Relative, as `collect_all_functions` produces them.
+    assert_contains "$pairs" "lib/thing.sh>lib/thing.posix.sh"
+    assert_eq "${pairs#*/Users}" "$pairs" "the pairs must not be absolute"
+
+    local out
+    out="$(NUT_DUP_VARIANTS="$pairs" compare_full_names \
+        "$(printf 'thing_do|lib/thing.sh\nthing_do|lib/thing.posix.sh\n')" "0.85")"
+    assert_empty "$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_still_calls_the_same_name_in_two_unrelated_files_a_duplicate() {
+    # The control. A skip that fired on every pair would empty this check and
+    # it would report clean over a library full of copies.
+    local out
+    out="$(NUT_DUP_VARIANTS="lib/a.sh>lib/b.sh" compare_full_names \
+        "$(printf 'thing_do|lib/c.sh\nthing_do|lib/d.sh\n')" "0.85")"
+    assert_contains "$out" "MATCH"
+}
+
+#[test]
+it_carries_the_file_through_the_stripped_comparison() {
+    # `add_stripped_names` emitted three fields and the comparison downstream
+    # read `$4` for the file, so `files[]` was empty on every row of that pass:
+    # it could not name a file in its own report and could not tell two
+    # spellings of one module apart.
+    local rows; rows="$(add_stripped_names "$(printf 'str_contains|lib/string.sh\n')")"
+    assert_eq "$(awk -F'|' '{print NF}' <<<"$rows")" "4"
+    assert_contains "$rows" "lib/string.sh"
+}

--- a/tests/check_posix_floor_test.sh
+++ b/tests/check_posix_floor_test.sh
@@ -112,3 +112,63 @@ it_exempts_nothing_when_nothing_is_configured() {
     assert_fails _is_exempt "lib/anything.sh"
     assert_fails _is_exempt ""
 }
+
+# --- a file behind a shell predicate is not counted --------------------------
+#
+# The question is which modules a POSIX shell cannot load, not which files it
+# cannot parse. Those stopped being the same thing the moment a module could
+# carry a variant: the bash file of a module with a floor will never parse
+# under dash and never has to.
+#
+# Counting it makes the number go up when a floor is added, which is the number
+# moving the wrong way while the library gets better.
+
+_pf_lib() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-pf.XXXXXX")"
+    printf '%s' "$1" > "$d/lib.nut"
+    printf '%s' "$d"
+}
+
+#[test]
+it_discounts_a_file_reached_only_behind_a_shell_predicate() {
+    local d; d="$(_pf_lib 'string  lib/string.sh        when=shell:bash4
+string  lib/string.posix.sh
+other   lib/other.sh')"
+    local got; got="$(_shell_gated_files "$d")"
+    assert_eq "$got" "lib/string.sh"
+    rm -rf "$d"
+}
+
+#[test]
+it_counts_a_file_reached_behind_a_tool_predicate() {
+    # `have:` is not `shell:`. A row predicated on a tool is still sourced on a
+    # POSIX shell wherever that tool exists, so it has to parse there, and
+    # discounting it would hide a real gap.
+    local d; d="$(_pf_lib 'text  lib/text.fast.sh  when=have:grep
+text  lib/text.sh')"
+    assert_empty "$(_shell_gated_files "$d")"
+    rm -rf "$d"
+}
+
+#[test]
+it_discounts_nothing_in_a_manifest_with_no_predicates() {
+    # The control. A matcher that returned every file would empty the report
+    # and read as a floor that is already reached.
+    local d; d="$(_pf_lib 'one  lib/one.sh
+two  lib/two.sh  internal')"
+    assert_empty "$(_shell_gated_files "$d")"
+    rm -rf "$d"
+}
+
+#[test]
+it_reads_a_shell_predicate_written_after_a_visibility() {
+    # The trailing columns are words, not positions, and this reader has to
+    # agree with the resolver about that or the two disagree about which file
+    # a POSIX shell ever sees.
+    local d; d="$(_pf_lib 'a  lib/a.sh  internal when=shell:bash4
+b  lib/b.sh  when=shell:bash internal')"
+    local got; got="$(_shell_gated_files "$d")"
+    assert_contains "$got" "lib/a.sh"
+    assert_contains "$got" "lib/b.sh"
+    rm -rf "$d"
+}

--- a/tests/lib_nut_test.sh
+++ b/tests/lib_nut_test.sh
@@ -360,8 +360,40 @@ it_reports_a_visibility_it_does_not_understand() {
     mkdir -p "$d/lib"; : > "$d/lib/x.sh"
     printf 'x lib/x.sh publicish\n' > "$d/lib.nut"
     out="$("$DECLARE" --check "$d" 2>&1 || true)"
-    # A typo in the third column silently made an internal module public.
-    assert_ok grep -q 'unknown visibility' <<<"$out"
+    # A typo in a trailing column silently made an internal module public.
+    #
+    # "word" rather than "visibility": a trailing column can be a visibility or
+    # a `when=` predicate now, and calling every one of them a visibility told
+    # a reader with a mistyped predicate to look at the wrong thing.
+    assert_ok grep -q 'unknown word' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_a_predicate_it_does_not_understand() {
+    # A predicate `_nut_when` refuses is a variant that silently never loads,
+    # and the row looks fine. Caught here it is a typo somebody can see.
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/lib/x.sh"
+    printf 'x lib/x.sh when=shel:bash4
+' > "$d/lib.nut"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    assert_ok grep -q 'unknown predicate' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_accepts_every_predicate_word_the_resolver_knows() {
+    # The control. A validator rejecting everything would pass the test above
+    # and refuse every real manifest.
+    local d out rc; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/lib/x.sh"
+    printf 'x lib/x.sh when=have:grep+shell:bash4
+y lib/x.sh when=env:HOME
+z lib/x.sh when=shell:bash
+' > "$d/lib.nut"
+    rc=0; out="$("$DECLARE" --check "$d" 2>&1)" || rc=$?
+    assert_eq "$rc" "0" "$out"
     rm -rf "$d"
 }
 

--- a/tests/modgraph_test.sh
+++ b/tests/modgraph_test.sh
@@ -133,3 +133,68 @@ it_reports_a_declaration_nothing_uses() {
     MODGRAPH_NOCACHE=1 modgraph_build "$FIXTURE"
     assert_contains "$(modgraph_audit)" "unused	idle	alpha"
 }
+
+# --- two files, one module ---------------------------------------------------
+#
+# A `when=` row means a module is written twice, once for bash and once for
+# POSIX sh, and only one is ever loaded. Named from the path, the second
+# becomes a module of its own that calls everything the first defines and
+# declares none of it, and the contract check reports every function.
+#
+# Fifteen of those on `string` the day the floor was added.
+
+_mgv_lib() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-mgv.XXXXXX")"
+    mkdir -p "$d/lib"
+    printf '%s' "$1" > "$d/lib.nut"
+    printf 'nut_once || return 0\n#[pub]\n# Usage: thing_do\nthing_do() { :; }\n' > "$d/lib/thing.sh"
+    printf 'nut_once || return 0\n#[pub]\n# Usage: thing_do\nthing_do() { :; }\n' > "$d/lib/thing.posix.sh"
+    printf '%s' "$d"
+}
+
+#[test]
+it_reads_two_variant_files_as_one_module() {
+    local d; d="$(_mgv_lib 'thing  lib/thing.sh        when=shell:bash4
+thing  lib/thing.posix.sh')"
+    MODGRAPH_ROOT="$d" modgraph_build "$d/lib"
+    local mods; mods="$(printf '%s\n' "${_MG_MODULES[@]}" | sort | tr '\n' ' ')"
+    assert_eq "$mods" "thing "
+    unset MODGRAPH_ROOT
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_no_undeclared_call_between_two_variants() {
+    # The property that matters, rather than the module count: one spelling
+    # must not read as calling into the other.
+    local d; d="$(_mgv_lib 'thing  lib/thing.sh        when=shell:bash4
+thing  lib/thing.posix.sh')"
+    MODGRAPH_ROOT="$d" modgraph_build "$d/lib"
+    assert_empty "$(modgraph_audit | grep undeclared || true)"
+    unset MODGRAPH_ROOT
+    rm -rf "$d"
+}
+
+#[test]
+it_still_reads_two_unrelated_files_as_two_modules() {
+    # The control. Merging on the file stem, or merging everything, would pass
+    # both tests above and collapse the whole graph into one node.
+    local d; d="$(_mgv_lib 'thing  lib/thing.sh
+other  lib/thing.posix.sh')"
+    MODGRAPH_ROOT="$d" modgraph_build "$d/lib"
+    local mods; mods="$(printf '%s\n' "${_MG_MODULES[@]}" | sort | tr '\n' ' ')"
+    assert_eq "$mods" "other thing "
+    unset MODGRAPH_ROOT
+    rm -rf "$d"
+}
+
+#[test]
+it_names_a_file_the_manifest_does_not_mention_by_its_stem() {
+    # What every file did before there was a manifest to ask, and what a file
+    # outside one still gets.
+    local d; d="$(_mgv_lib 'thing  lib/thing.sh')"
+    assert_eq "$(_mg_module_of "$d/lib/thing.posix.sh" "$d")" "thing.posix"
+    assert_eq "$(_mg_module_of "$d/lib/thing.sh" "$d")" "thing"
+    assert_eq "$(_mg_module_of "/tmp/nowhere/zzz.sh" "$d")" "zzz"
+    rm -rf "$d"
+}


### PR DESCRIPTION
Twice in one night.

A bare `git commit` takes the index. `git add` had staged the two new files and the other nine were modified and unstaged, so `dev` took `lib/string.posix.sh` and its parity test and none of the things that make them reachable: the `when=` row, the four readers that had to learn about variants, and the `str_replace` fix.

The first time this happened the message described a feature the diff did not contain, and twelve tests failed on `dev` immediately. This time the suite still passes on `dev`, because a floor with no manifest row is inert, so nothing said anything at all. That is the worse of the two.

Nothing about the change differs from what the merged message describes.

## Sanity

606 pass.