### PR TITLE
chore: 0.6.0

### DIFF
--- a/bin/nutshell
+++ b/bin/nutshell
@@ -79,7 +79,7 @@ use extern log
 # scalar. Same shape mockspace.toml uses for the same job, because it is the
 # same job and a reader should not have to learn two spellings:
 #
-#     nutshell_version = "0.5.0"     the released form
+#     nutshell_version = "0.6.0"     the released form
 #     nutshell_branch  = "dev"       when there is no release yet
 #
 # Root level, before any [table] header. A bare key written after one belongs

--- a/init
+++ b/init
@@ -58,7 +58,7 @@ _NUTSHELL_ROOT="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 
 # Export for use by modules
 export NUTSHELL_ROOT="${_NUTSHELL_ROOT}"
-export NUTSHELL_VERSION="0.5.0"
+export NUTSHELL_VERSION="0.6.0"
 
 # Script identity belongs to the interpreter invocation, not to ancestry. The
 # interpreter exports NUTSHELL_SCRIPT and NUTSHELL_SCRIPT_DIR after this file


### PR DESCRIPTION
The first POSIX floor and the check that measures the rest, plus a fix to `str_replace` that changes what it returns for any needle carrying a glob character.

That last one is a behaviour change, which is why this is a minor rather than a patch.

## Sanity

606 pass.