### PR TITLE
release: 0.6.0, the first POSIX floor and the number that measures the rest

### DIFF
--- a/bin/nut-declare
+++ b/bin/nut-declare
@@ -88,6 +88,16 @@ _dupes() {
     _scan | awk -F'\t' '{ print $1 }' | sort | uniq -d
 }
 
+# Every file a declaration names. One module may name several.
+_lib_nut_files_of() {
+    local r="$1" n f _rest
+    [[ -r "${r}/lib.nut" ]] || return 1
+    while read -r n f _rest || [[ -n "$n" ]]; do
+        [[ -z "$n" || "${n:0:1}" == "#" ]] && continue
+        [[ -n "$f" ]] && printf '%s\n' "$f"
+    done < "${r}/lib.nut"
+}
+
 # Every name a declaration holds. One parser for the checker, so it and the
 # resolver cannot disagree about what the file says.
 _lib_nut_modules_of() {
@@ -132,24 +142,53 @@ case "$MODE" in
         # a comment wherever it starts, a missing newline on the last line does
         # not lose it, and a line that is not a declaration is reported rather
         # than crashing on an unset positional.
-        while read -r dname dfile dvis || [[ -n "$dname" ]]; do
+        while read -r dname dfile drest || [[ -n "$dname" ]]; do
             [[ -z "$dname" || "${dname:0:1}" == "#" ]] && continue
             if [[ -z "$dfile" ]]; then
                 printf 'not a declaration: %s\n' "$dname"; rc=1; continue
             fi
-            case "${dvis:-}" in
-                ""|internal) ;;
-                *) printf 'unknown visibility on %s: %s\n' "$dname" "$dvis"; rc=1 ;;
-            esac
+            # The trailing columns are words rather than positions, the same
+            # way the resolver reads them, or the two disagree about what a
+            # row says. Read by position, `when=shell:bash4` was reported as
+            # an unknown visibility.
+            for dword in $drest; do
+                case "$dword" in
+                    internal) ;;
+                    when=*)
+                        # The predicate's words too, because `_nut_when` refuses
+                        # one it does not know and a refused predicate is a
+                        # variant that silently never loads. Caught here it is a
+                        # typo somebody can see.
+                        _dp="${dword#when=}"
+                        while [ -n "$_dp" ]; do
+                            case "$_dp" in
+                                *+*) dpart="${_dp%%+*}"; _dp="${_dp#*+}" ;;
+                                *)   dpart="$_dp"; _dp="" ;;
+                            esac
+                            case "$dpart" in
+                                have:?*|env:?*|shell:bash|shell:bash4) ;;
+                                *) printf 'unknown predicate on %s: %s\n' "$dname" "$dpart"; rc=1 ;;
+                            esac
+                        done
+                        ;;
+                    *) printf 'unknown word on %s: %s\n' "$dname" "$dword"; rc=1 ;;
+                esac
+            done
             if [[ ! -f "$ROOT/$dfile" ]]; then
                 printf 'declared but missing: %s -> %s\n' "$dname" "$dfile"; rc=1
             fi
         done < "$ROOT/lib.nut"
+        # By file, not by the name the path suggests.
+        #
+        # A module may name several files, which is what a `when=` row is, and
+        # `lib/string.posix.sh` is not a module called `string.posix`: it is
+        # one of the files module `string` can be. Asked by derived name, every
+        # variant reads as an undeclared file.
+        declared_files="$(_lib_nut_files_of "$ROOT")"
         while IFS=$'\t' read -r name rel _vis; do
-            # Compared as a word, not matched as a pattern. A module named
-            # `fs.impl` would otherwise match `fsXimpl` and be reported as
-            # declared when it is not.
-            _lib_nut_modules_of "$ROOT" | grep -qxF "$name" \
+            # Compared as a word, not matched as a pattern. A path
+            # `lib/fs.sh` would otherwise match `lib/fsXsh`.
+            grep -qxF "$rel" <<<"$declared_files" \
                 || { printf 'present but undeclared: %s (%s)\n' "$name" "$rel"; rc=1; }
         done < <(_scan)
         # Not `local`: this is a case arm at file scope, where `local` is a

--- a/bin/nutshell
+++ b/bin/nutshell
@@ -79,7 +79,7 @@ use extern log
 # scalar. Same shape mockspace.toml uses for the same job, because it is the
 # same job and a reader should not have to learn two spellings:
 #
-#     nutshell_version = "0.5.0"     the released form
+#     nutshell_version = "0.6.0"     the released form
 #     nutshell_branch  = "dev"       when there is no release yet
 #
 # Root level, before any [table] header. A bare key written after one belongs

--- a/examples/checks/check_function_duplication.sh
+++ b/examples/checks/check_function_duplication.sh
@@ -134,11 +134,57 @@ collect_all_functions() {
 
 # Run full name comparison using optimized awk
 # Returns lines in format: "FAIL|score|name1|name2|file1|file2" or "WARN|..."
+# Every pair of files that are two spellings of one module, as `a>b`, so the
+# comparison can skip a perfect score between them. Read from the manifest
+# rather than named here, because a list here is a second place to update.
+_variant_pairs() {
+    local root="${REPO_ROOT:-$PWD}" name file rest word
+    local -A owner=()
+    [[ -r "${root}/lib.nut" ]] || return 0
+    while read -r name file rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        [[ -n "$file" ]] || continue
+        if [[ -n "${owner[$name]:-}" ]]; then
+            local prior
+            for prior in ${owner[$name]}; do
+                # Relative, as written in the manifest, because that is the
+                # shape `collect_all_functions` produces. Emitted absolute
+                # first, and nothing ever matched: the skip was proved on
+                # hand-made absolute input and never once fired on the real
+                # data, which is the whole reason a test builds its own input
+                # carefully and then proves nothing.
+                printf '%s>%s ' "$prior" "$file"
+            done
+        fi
+        owner["$name"]="${owner[$name]:-} $file"
+    done < "${root}/lib.nut"
+}
+
+# Computed once. There are two comparisons in this file and the second is the
+# one that reported the variants: set inside the first, the second never saw it.
+declare -g _NUT_DUP_VARIANTS=""
+_variants_once() {
+    [[ -n "${_NUT_DUP_VARIANTS_DONE:-}" ]] && return 0
+    _NUT_DUP_VARIANTS="$(_variant_pairs)"
+    _NUT_DUP_VARIANTS_DONE=1
+}
+
+# The list to use: whatever the caller set, else the manifest's.
+#
+# A caller passing its own used to be overwritten by the manifest's, which made
+# the comparison untestable against anything but this repository.
+_variants_for() {
+    if [[ -n "${NUT_DUP_VARIANTS+x}" ]]; then printf '%s' "$NUT_DUP_VARIANTS"; return 0; fi
+    _variants_once
+    printf '%s' "$_NUT_DUP_VARIANTS"
+}
+
 compare_full_names() {
     local func_data="$1"
     local threshold="$2"
+    local NUT_DUP_VARIANTS; NUT_DUP_VARIANTS="$(_variants_for)"
     
-    echo "$func_data" | awk -F'|' -v threshold="$threshold" '
+    echo "$func_data" | awk -F'|' -v threshold="$threshold" -v variants="${NUT_DUP_VARIANTS:-}" '
     # Levenshtein distance, abandoned as soon as it cannot matter.
     #
     # `maxd` is the largest distance the caller could still accept. Past that
@@ -211,6 +257,21 @@ compare_full_names() {
         return 1.0 - (dist / maxlen)
     }
     
+    BEGIN {
+        # Files that are two spellings of one module, as `a>b` pairs.
+        #
+        # A module carrying a `when=` row is written twice, once for bash and
+        # once for POSIX sh, and the two hold the same function names on
+        # purpose. Every one of those is a perfect score and none of them is a
+        # copy: only one is ever sourced.
+        n = split(variants, vs, " ")
+        for (k = 1; k <= n; k++) is_variant_pair[vs[k]] = 1
+    }
+
+    function are_variants(a, b) {
+        return (is_variant_pair[a ">" b] || is_variant_pair[b ">" a])
+    }
+
     {
         names[NR] = $1
         files[NR] = $2
@@ -262,6 +323,8 @@ compare_full_names() {
                     }
                 }
 
+                if (are_variants(files[i], files[j])) continue
+
                 printf "MATCH|%.3f|%s|%s|%s|%s\n", score, names[i], names[j], files[i], files[j]
             }
         }
@@ -292,7 +355,14 @@ add_stripped_names() {
     {
         stripped = strip_prefix($1)
         if (length(stripped) >= 4) {
-            print stripped "|" $1 "|" $2
+            # Four fields, because the comparison downstream reads `$4` for the
+            # file and was being handed three. `files[]` was empty on every row
+            # of that pass, so it could not name a file in its own report and
+            # could not tell two spellings of one module apart.
+            #
+            # The prefix is what `strip_prefix` removed, kept so the report can
+            # show the whole name.
+            print stripped "|" substr($1, 1, length($1) - length(stripped)) "|" $1 "|" $2
         }
     }
     '
@@ -301,10 +371,11 @@ add_stripped_names() {
 # Run stripped name comparison using optimized awk
 # Returns lines in format: "WARN|score|stripped1|orig1|stripped2|orig2|file1|file2"
 compare_stripped_names() {
+    local NUT_DUP_VARIANTS; NUT_DUP_VARIANTS="$(_variants_for)"
     local func_data="$1"
     local threshold="$2"
     
-    echo "$func_data" | awk -F'|' -v threshold="$threshold" '
+    echo "$func_data" | awk -F'|' -v threshold="$threshold" -v variants="${NUT_DUP_VARIANTS:-}" '
     # The same abandoned-early distance as the first pass. See there for why.
     function levenshtein(s1, s2, maxd,    len1, len2, i, j, c1, cost, prev, cur, best, subst) {
         len1 = length(s1); len2 = length(s2)
@@ -342,6 +413,15 @@ compare_stripped_names() {
         return 1.0 - (dist / maxlen)
     }
     
+    BEGIN {
+        n = split(variants, vs, " ")
+        for (k = 1; k <= n; k++) is_variant_pair[vs[k]] = 1
+    }
+
+    function are_variants(a, b) {
+        return (is_variant_pair[a ">" b] || is_variant_pair[b ">" a])
+    }
+
     {
         stripped[NR] = $1
         prefixes[NR] = $2
@@ -376,6 +456,7 @@ compare_stripped_names() {
                 score = similarity(stripped[i], stripped[j], threshold)
                 
                 if (score >= threshold) {
+                    if (are_variants(files[i], files[j])) continue
                     printf "WARN|%.3f|%s|%s|%s|%s|%s|%s\n", score, stripped[i], original[i], stripped[j], original[j], files[i], files[j]
                 }
             }

--- a/examples/checks/check_posix_floor.sh
+++ b/examples/checks/check_posix_floor.sh
@@ -85,6 +85,34 @@ _is_exempt() {
     return 1
 }
 
+# Files the manifest reaches only behind a `shell:` predicate.
+#
+# The question this check exists to answer is which modules a POSIX shell
+# cannot load, not which files it cannot parse. Those stopped being the same
+# thing the moment a module could carry a variant: `lib/string.sh` will never
+# parse under dash and never has to, because `lib/string.posix.sh` is what a
+# POSIX shell is given.
+#
+# Counting the file would make the number go **up** when a floor is added,
+# which is the number moving the wrong way while the library gets better, and
+# is the kind of thing people then stop reading.
+#
+# Only `shell:` counts. A row predicated on `have:` is still sourced on a POSIX
+# shell wherever that tool exists, so it has to parse there.
+_shell_gated_files() {
+    local root="$1" name file rest word
+    [[ -r "${root}/lib.nut" ]] || return 0
+    while read -r name file rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        [[ -n "$file" ]] || continue
+        for word in $rest; do
+            case "$word" in
+                when=*shell:*) printf '%s\n' "$file" ;;
+            esac
+        done
+    done < "${root}/lib.nut"
+}
+
 test_posix_floor() {
     log_header "POSIX floor"
 
@@ -99,15 +127,21 @@ test_posix_floor() {
     fi
     log_info "checking with ${sh}"
 
-    local files file rel total=0 unreadable=0 exempt=0 why
+    local files file rel total=0 unreadable=0 exempt=0 gated=0 why
     declare -a bad=()
     files="$(get_script_files)"
+
+    local -A shell_gated=()
+    while IFS= read -r rel; do
+        [[ -n "$rel" ]] && shell_gated["$rel"]=1
+    done < <(_shell_gated_files "$REPO_ROOT")
 
     while IFS= read -r file; do
         [[ -z "$file" || ! -f "$file" ]] && continue
         rel="${file#$REPO_ROOT/}"
         total=$(( total + 1 ))
         if _is_exempt "$rel"; then exempt=$(( exempt + 1 )); continue; fi
+        if [[ -n "${shell_gated[$rel]:-}" ]]; then gated=$(( gated + 1 )); continue; fi
 
         why="$("$sh" -n "$file" 2>&1 | head -1)"
         if [[ -n "$why" ]]; then
@@ -119,11 +153,12 @@ test_posix_floor() {
     done <<< "$files"
 
     echo ""
-    log_info "${unreadable} of $(( total - exempt )) cannot be read by ${sh}"
+    log_info "${unreadable} of $(( total - exempt - gated )) cannot be read by ${sh}"
+    [[ "$gated" -gt 0 ]] && log_info "${gated} behind a shell: predicate, so never sourced there"
     [[ "$exempt" -gt 0 ]] && log_info "${exempt} exempt by config"
 
-    TESTS_RUN=$(( total - exempt ))
-    TESTS_PASSED=$(( total - exempt - unreadable ))
+    TESTS_RUN=$(( total - exempt - gated ))
+    TESTS_PASSED=$(( total - exempt - gated - unreadable ))
     TESTS_WARNED=$unreadable
     WARNED_TESTS=("${bad[@]}")
 

--- a/examples/checks/check_posix_floor.sh
+++ b/examples/checks/check_posix_floor.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env nutshell
+# =============================================================================
+# check_posix_floor.sh - How much of this library a POSIX shell can read
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# The floor is meant to be POSIX sh, with a predicate selecting a better file
+# where a tool or a modern shell earns it. That is a direction rather than a
+# state, so it needs a number that moves rather than an opinion that does not.
+#
+# **What this can and cannot see.** It parses each file with a real POSIX
+# shell and reports what will not parse. A parse failure is fatal in a way a
+# runtime failure is not: the shell rejects the whole file before running a
+# line of it, so no guard inside the file can help and the only fix is to not
+# source that file on that shell. That is exactly what a `when=` row is for.
+#
+# It cannot see a construct that parses and then misbehaves. `declare -A` is
+# the standing example: dash parses it as a command and fails at runtime. So a
+# clean report here means readable, not portable, and the check says so rather
+# than letting a green be read as more than it is.
+#
+# **It needs a real POSIX shell and refuses without one.** `sh` on macOS is
+# bash in POSIX mode and accepts `[[`, arrays and here-strings, so a check
+# written against `sh` reports a clean floor on a library that has none. That
+# is not hypothetical: the first measurement here was taken that way and was
+# worthless.
+#
+# Usage: ./examples/checks/check_posix_floor.sh
+#
+# Exit codes:
+#   0 - within the configured budget
+#   1 - over it, or no POSIX shell to check with
+# =============================================================================
+
+set -uo pipefail
+
+use check-runner
+
+POSIX_SHELL=""
+POSIX_MAX_UNREADABLE=-1
+declare -a POSIX_EXEMPT=()
+
+load_config() {
+    if ! cfg_is_true "tests.posix_floor"; then
+        log_info "POSIX floor test is disabled in config"
+        exit 0
+    fi
+    POSIX_SHELL="$(cfg_get_or "tests.posix_floor.shell" "")"
+    POSIX_MAX_UNREADABLE="$(cfg_get_or "tests.posix_floor.max_unreadable" "-1")"
+    cfg_get_array "tests.posix_floor.exempt" POSIX_EXEMPT || POSIX_EXEMPT=()
+}
+
+# A shell that is actually POSIX, or nothing.
+#
+# Verified rather than trusted, because the whole check is worthless run
+# against a shell that accepts what it is looking for. The probe is an array
+# assignment: POSIX has no arrays, so a shell that parses one is not the
+# instrument this needs.
+_posix_shell() {
+    local cand probe rc
+    probe="$(mktemp "${TMPDIR:-/tmp}/nutshell-posix.XXXXXX")" || return 1
+    printf 'a=(1 2)\n' > "$probe"
+
+    for cand in ${POSIX_SHELL:+$POSIX_SHELL} dash ash yash posh busybox-sh sh; do
+        command -v "$cand" >/dev/null 2>&1 || continue
+        "$cand" -n "$probe" >/dev/null 2>&1 && continue   # accepted it: not POSIX enough
+        rc=0
+        # And it has to accept ordinary POSIX, or it rejects everything and
+        # reports a library that cannot be read at all.
+        printf 'x=1\necho "${x:-}"\n' > "$probe"
+        "$cand" -n "$probe" >/dev/null 2>&1 || rc=1
+        printf 'a=(1 2)\n' > "$probe"
+        [[ "$rc" -eq 0 ]] && { rm -f "$probe"; printf '%s' "$cand"; return 0; }
+    done
+    rm -f "$probe"
+    return 1
+}
+
+_is_exempt() {
+    local f="$1" p
+    for p in ${POSIX_EXEMPT[@]+"${POSIX_EXEMPT[@]}"}; do
+        [[ "$f" == $p ]] && return 0
+    done
+    return 1
+}
+
+test_posix_floor() {
+    log_header "POSIX floor"
+
+    local sh
+    if ! sh="$(_posix_shell)"; then
+        log_fail "no POSIX shell here to check with"
+        printf '  dash, ash, yash, posh or busybox. `sh` on macOS is bash in\n'
+        printf '  POSIX mode and accepts arrays, so it cannot answer this.\n'
+        TESTS_RUN=1; TESTS_FAILED=1
+        FAILED_TESTS=("no POSIX shell available")
+        return 1
+    fi
+    log_info "checking with ${sh}"
+
+    local files file rel total=0 unreadable=0 exempt=0 why
+    declare -a bad=()
+    files="$(get_script_files)"
+
+    while IFS= read -r file; do
+        [[ -z "$file" || ! -f "$file" ]] && continue
+        rel="${file#$REPO_ROOT/}"
+        total=$(( total + 1 ))
+        if _is_exempt "$rel"; then exempt=$(( exempt + 1 )); continue; fi
+
+        why="$("$sh" -n "$file" 2>&1 | head -1)"
+        if [[ -n "$why" ]]; then
+            unreadable=$(( unreadable + 1 ))
+            why="${why##*: }"
+            bad+=("${rel}: ${why}")
+            log_test_warn "${rel} - ${why}"
+        fi
+    done <<< "$files"
+
+    echo ""
+    log_info "${unreadable} of $(( total - exempt )) cannot be read by ${sh}"
+    [[ "$exempt" -gt 0 ]] && log_info "${exempt} exempt by config"
+
+    TESTS_RUN=$(( total - exempt ))
+    TESTS_PASSED=$(( total - exempt - unreadable ))
+    TESTS_WARNED=$unreadable
+    WARNED_TESTS=("${bad[@]}")
+
+    # A budget, when one is configured. Without one this reports and never
+    # blocks, which is right while the number is still large: a gate that
+    # fails every run is one people stop reading.
+    if [[ "$POSIX_MAX_UNREADABLE" -ge 0 && "$unreadable" -gt "$POSIX_MAX_UNREADABLE" ]]; then
+        TESTS_FAILED=$(( unreadable - POSIX_MAX_UNREADABLE ))
+        FAILED_TESTS=("${bad[@]}")
+        printf '  over the budget of %s\n' "$POSIX_MAX_UNREADABLE" >&2
+        return 1
+    fi
+    return 0
+}
+
+main() {
+    # Refuse rather than grade the wrong repository.
+    #
+    # Through the `#!/usr/bin/env nutshell` shebang, `check-runner` resolves
+    # its root from the interpreter's own checkout, so a check run on its own
+    # reads the config and the files of whichever nutshell is on PATH. Run
+    # standalone here that was somebody else's clone, and it reported warnings
+    # about their files under this project's name.
+    #
+    # That is `check-runner`'s to fix and it is the same class it fixed at
+    # 0.4.0, in the one path that does not go through its walk. What this can
+    # do is not pretend: `./check` sets the root correctly and everything works
+    # there, and anywhere else this says so instead of answering.
+    if [[ -f "${PWD}/nut.toml" && -n "${REPO_ROOT:-}" && "${REPO_ROOT}" != "${PWD}" ]]; then
+        log_fail "this would read ${REPO_ROOT}, not ${PWD}"
+        printf '  run it through `./check`, which resolves the root from the\n' >&2
+        printf '  project rather than from the interpreter on PATH.\n' >&2
+        TESTS_RUN=1; TESTS_FAILED=1
+        FAILED_TESTS=("would have checked the wrong repository")
+        print_summary "POSIX floor"
+        exit_with_status
+    fi
+    load_config
+    test_posix_floor
+    print_summary "POSIX floor"
+    exit_with_status
+}
+
+# `NUT_CHECK_LOAD_ONLY` is the door a test uses to reach the readers without a
+# whole run over a repository.
+[[ -n "${NUT_CHECK_LOAD_ONLY:-}" ]] || main "$@"

--- a/init
+++ b/init
@@ -58,7 +58,7 @@ _NUTSHELL_ROOT="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 
 # Export for use by modules
 export NUTSHELL_ROOT="${_NUTSHELL_ROOT}"
-export NUTSHELL_VERSION="0.5.0"
+export NUTSHELL_VERSION="0.6.0"
 
 # Script identity belongs to the interpreter invocation, not to ancestry. The
 # interpreter exports NUTSHELL_SCRIPT and NUTSHELL_SCRIPT_DIR after this file

--- a/init
+++ b/init
@@ -399,6 +399,51 @@ _nut_when() {
     return 0
 }
 
+# _lib_nut_files <root>
+#
+# Every file a library declares, one per line, relative as written.
+#
+# One module may name several, which is what a `when=` row is, so this is not
+# the same list as `_lib_nut_modules` and a reader wanting "is this file part
+# of the library" wants this one. Deriving a module name from a path and
+# looking that up says no for every variant: `lib/string.posix.sh` is not a
+# module called `string.posix`, it is one of the files module `string` can be.
+#
+# Here rather than in each checker because three of them asked the question
+# separately and all three got a different wrong answer the day a variant
+# appeared.
+_lib_nut_files() {
+    local root="$1" name file _rest
+    [[ -r "${root}/lib.nut" ]] || return 1
+    while read -r name file _rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        [[ -n "$file" ]] && printf '%s\n' "$file"
+    done < "${root}/lib.nut"
+}
+
+# _lib_nut_variants_of <root> <file>
+#
+# The other files declared for whichever module declares this one, this one
+# excluded. Empty when the file is not a variant, which is the common case.
+#
+# What a checker wants when two files legitimately hold the same function
+# names, or when one appears to call into the other: they are one module
+# written twice for two shells, not two modules.
+_lib_nut_variants_of() {
+    local root="$1" want="$2" name file _rest owner=""
+    [[ -r "${root}/lib.nut" ]] || return 1
+    while read -r name file _rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        [[ "$file" == "$want" ]] && { owner="$name"; break; }
+    done < "${root}/lib.nut"
+    [[ -n "$owner" ]] || return 1
+    while read -r name file _rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        [[ "$name" == "$owner" && "$file" != "$want" ]] && printf '%s\n' "$file"
+    done < "${root}/lib.nut"
+    return 0
+}
+
 # _lib_nut_modules <root>
 #
 # Every module a library declares, one per line. For the checker, and for an

--- a/lib.nut
+++ b/lib.nut
@@ -30,7 +30,8 @@ os                       lib/os.sh
 priv                     lib/priv.sh
 prompt                   lib/prompt.sh
 srcfile                  lib/srcfile.sh
-string                   lib/string.sh
+string                   lib/string.sh        when=shell:bash4
+string                   lib/string.posix.sh
 test                     lib/test.sh
 text                     lib/text.sh
 text::impl::awk_replace  lib/text/impl/awk_replace.sh internal

--- a/lib/modgraph.sh
+++ b/lib/modgraph.sh
@@ -214,15 +214,80 @@ _mg_scan() {
 # Building
 # -----------------------------------------------------------------------------
 
+declare -gA _MG_SEEN=()
+
 _mg_reset() {
     _MG_DECLARES=(); _MG_DEFINES=(); _MG_CALLS=(); _MG_OWNER=(); _MG_VIS=(); _MG_MODULES=()
+    _MG_SEEN=()
+}
+
+# A second file for a module already recorded: its declarations, definitions
+# and calls are added to that module rather than becoming another one.
+_mg_merge_into() {
+    local mod="$1" file="$2" kind values fn pair
+    local visraw=""
+    while IFS=$'\t' read -r kind values; do
+        case "$kind" in
+            declares) _MG_DECLARES[$mod]="${_MG_DECLARES[$mod]:-} $values" ;;
+            defines)  _MG_DEFINES[$mod]="${_MG_DEFINES[$mod]:-} $values" ;;
+            calls)    _MG_CALLS[$mod]="${_MG_CALLS[$mod]:-} $values" ;;
+            vis)      visraw="$values" ;;
+        esac
+    done < <(_mg_scan "$file")
+
+    # The variant's own definitions belong to the same module, and its
+    # visibilities are its own: a function public in one spelling and absent
+    # from the other still has to answer as public.
+    for fn in ${_MG_DEFINES[$mod]:-}; do
+        _MG_OWNER[$fn]="$mod"
+    done
+    for pair in ${visraw:-}; do
+        _MG_VIS[${pair%%=*}]="${pair#*=}"
+    done
+}
+
+# The module a file belongs to, from the manifest when there is one.
+#
+# A module may name several files, which is what a `when=` row is: `string.sh`
+# and `string.posix.sh` are one module written twice for two shells and only
+# one is ever loaded. Named from the path, the second becomes a module called
+# `string.posix` that calls fifteen functions from `string` and declares none
+# of them, and the contract check reports every one.
+#
+# Falls back to the file stem, which is what every file without a manifest
+# entry gets and what this always did.
+_mg_module_of() {
+    local file="$1" root="${2:-}" rel name f _rest
+    local stem="${file##*/}"; stem="${stem%.sh}"
+    [[ -n "$root" && -r "${root}/lib.nut" ]] || { printf '%s' "$stem"; return 0; }
+    rel="${file#"${root}/"}"
+    while read -r name f _rest || [[ -n "$name" ]]; do
+        [[ -z "$name" || "${name:0:1}" == "#" ]] && continue
+        if [[ "$f" == "$rel" ]]; then
+            # The leaf, since this graph works in file-stem names throughout
+            # and a `::` path would not match anything else in it.
+            printf '%s' "${name##*::}"
+            return 0
+        fi
+    done < "${root}/lib.nut"
+    printf '%s' "$stem"
 }
 
 _mg_analyse() {
     local dir="$1" file mod line kind values
+    # The library root, so the manifest can say which module a file is. `dir`
+    # is the lib directory; the manifest sits above it.
+    local root="${MODGRAPH_ROOT:-${dir%/*}}"
     for file in "$dir"/*.sh; do
         [[ -f "$file" ]] || continue
-        mod="${file##*/}"; mod="${mod%.sh}"
+        mod="$(_mg_module_of "$file" "$root")"
+        # A module already seen is a variant of it. Its calls and definitions
+        # join the ones already recorded rather than starting a second module.
+        if [[ -n "${_MG_SEEN[$mod]:-}" ]]; then
+            _mg_merge_into "$mod" "$file"
+            continue
+        fi
+        _MG_SEEN[$mod]=1
         _MG_MODULES+=("$mod")
         while IFS=$'\t' read -r kind values; do
             case "$kind" in

--- a/lib/string.posix.sh
+++ b/lib/string.posix.sh
@@ -1,0 +1,245 @@
+#!/bin/sh
+# =============================================================================
+# nutshell/lib/string.posix.sh - String helpers, in POSIX sh
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# The floor. `lib/string.sh` is the same surface written for bash and is what
+# gets sourced where bash 4 is running; this is what a POSIX shell gets, and
+# before it existed a POSIX shell got a parse error and no module at all.
+#
+# The manifest decides between them, above the sourcing, because a file using a
+# construct the running shell cannot parse fails at parse time and no `if`
+# inside it can help:
+#
+#     string  lib/string.sh        when=shell:bash4
+#     string  lib/string.posix.sh
+#
+# **What is missing here, and it is one thing.** `str_split` writes into an
+# array through a nameref. POSIX has neither, and a version returning something
+# else would be a different function wearing the same name, which is worse than
+# an absent one: a caller would get an answer in the wrong shape rather than a
+# clear failure. So a script wanting `str_split` wants bash, and finds out by
+# the name not being there.
+#
+# Everything else is the same contract, checked against the bash file by a test
+# that runs both and compares, rather than by reading them side by side.
+#
+# The two-file arrangement is deliberate over one file full of branches. A
+# branch per function is a branch evaluated per call, and the whole point of
+# deciding at load time is that the decision is taken once.
+# =============================================================================
+
+# `nut_once` is nutshell's, and nutshell may not be loaded: this file is meant
+# to be readable by a shell that has none of it. Guarded the plain way instead.
+[ -n "${_NUTSHELL_STRING_POSIX_SH:-}" ] && return 0
+_NUTSHELL_STRING_POSIX_SH=1
+
+#[allow(trivial_wrapper)]
+#[pub]
+# Convert string to lowercase
+# Usage: str_lower "HELLO" -> "hello"
+#
+# `tr` rather than `${x,,}`, which is bash. There is no POSIX parameter
+# expansion for case, so this is one of the few places the floor needs a tool
+# at all, and `tr` is in POSIX itself rather than an optional extra.
+str_lower() {
+    printf '%s\n' "${1:-}" | tr '[:upper:]' '[:lower:]'
+}
+
+#[allow(trivial_wrapper)]
+#[pub]
+# Convert string to uppercase
+# Usage: str_upper "hello" -> "HELLO"
+str_upper() {
+    printf '%s\n' "${1:-}" | tr '[:lower:]' '[:upper:]'
+}
+
+#[pub]
+# Trim whitespace from both ends
+# Usage: str_trim "  hello  " -> "hello"
+#
+# The expansions here are POSIX as written: `${x#pattern}` and `${x%pattern}`
+# both are, and so is a bracket expression inside one. Only `${x//}` is not.
+str_trim() {
+    _s="${1:-}"
+    _s="${_s#"${_s%%[![:space:]]*}"}"
+    _s="${_s%"${_s##*[![:space:]]}"}"
+    printf '%s\n' "$_s"
+}
+
+#[pub]
+# Trim whitespace from left side
+# Usage: str_ltrim "  hello" -> "hello"
+str_ltrim() {
+    _s="${1:-}"
+    printf '%s\n' "${_s#"${_s%%[![:space:]]*}"}"
+}
+
+#[pub]
+# Trim whitespace from right side
+# Usage: str_rtrim "hello  " -> "hello"
+str_rtrim() {
+    _s="${1:-}"
+    printf '%s\n' "${_s%"${_s##*[![:space:]]}"}"
+}
+
+#[pub]
+# Replace all occurrences of a substring
+# Usage: str_replace "hello world" "world" "bash" -> "hello bash"
+#
+# A loop rather than `${x//from/to}`, which is bash. It walks by cutting at the
+# first occurrence and keeping what is either side, which is two POSIX
+# expansions and no tool: `sed` would need the needle escaped as a regular
+# expression, and a caller's needle is a literal.
+str_replace() {
+    _str="${1:-}"; _from="${2:-}"; _to="${3:-}"
+    if [ -z "$_from" ]; then printf '%s\n' "$_str"; return 0; fi
+
+    _out=""
+    while :; do
+        case "$_str" in
+            *"$_from"*) ;;
+            *) break ;;
+        esac
+        _head="${_str%%"$_from"*}"
+        _out="${_out}${_head}${_to}"
+        _str="${_str#*"$_from"}"
+    done
+    printf '%s\n' "${_out}${_str}"
+}
+
+#[pub]
+# Check if string contains substring
+# Usage: str_contains "hello world" "world" -> returns 0 (true)
+str_contains() {
+    [ -z "${2:-}" ] && return 0
+    case "${1:-}" in *"$2"*) return 0 ;; esac
+    return 1
+}
+
+#[pub]
+# Check if string starts with prefix
+# Usage: str_starts_with "hello world" "hello" -> returns 0 (true)
+str_starts_with() {
+    [ -z "${2:-}" ] && return 0
+    case "${1:-}" in "$2"*) return 0 ;; esac
+    return 1
+}
+
+#[pub]
+# Check if string ends with suffix
+# Usage: str_ends_with "hello world" "world" -> returns 0 (true)
+str_ends_with() {
+    [ -z "${2:-}" ] && return 0
+    case "${1:-}" in *"$2") return 0 ;; esac
+    return 1
+}
+
+#[pub]
+# Join arguments with a delimiter
+# Usage: str_join ", " a b c -> "a, b, c"
+str_join() {
+    _d="${1:-}"; shift
+    _r=""; _first=1
+    for _item in "$@"; do
+        if [ "$_first" -eq 1 ]; then _r="$_item"; _first=0
+        else _r="${_r}${_d}${_item}"; fi
+    done
+    printf '%s\n' "$_r"
+}
+
+#[allow(trivial_wrapper)]
+#[pub]
+# Get string length
+# Usage: str_length "hello" -> 5
+str_length() {
+    _s="${1:-}"
+    printf '%s\n' "${#_s}"
+}
+
+#[pub]
+# Extract substring
+# Usage: str_substr "hello world" 0 5 -> "hello"
+#
+# `cut -c` rather than `${x:start:len}`, which is bash. One-based and inclusive
+# where the expansion is zero-based and a length, so the arithmetic converts
+# rather than the caller having to.
+str_substr() {
+    _s="${1:-}"; _start="${2:-0}"; _len="${3:-}"
+    [ "$_start" -lt 0 ] 2>/dev/null && _start=0
+    _from=$(( _start + 1 ))
+    if [ -n "$_len" ]; then
+        [ "$_len" -le 0 ] 2>/dev/null && { printf '\n'; return 0; }
+        printf '%s\n' "$_s" | cut -c "${_from}-$(( _start + _len ))"
+    else
+        printf '%s\n' "$_s" | cut -c "${_from}-"
+    fi
+}
+
+#[pub]
+# Repeat string N times
+# Usage: str_repeat "-" 5 -> "-----"
+str_repeat() {
+    _s="${1:-}"; _n="${2:-1}"
+    [ "$_n" -le 0 ] 2>/dev/null && return 0
+    _r=""; _i=0
+    while [ "$_i" -lt "$_n" ]; do _r="${_r}${_s}"; _i=$(( _i + 1 )); done
+    printf '%s\n' "$_r"
+}
+
+#[pub]
+# Usage: str_distance build buidl -> 2
+#
+# Levenshtein distance: how many single-character edits turn one into the
+# other. For suggesting what somebody meant, so a caller applies its own
+# threshold; this only measures.
+#
+# One row rather than the full matrix, and the row lives in `$@` because POSIX
+# has no arrays. `set --` replaces it each pass, which is the one data
+# structure a POSIX shell has and is why this is the slowest thing here.
+str_distance() {
+    _a="$1"; _b="$2"
+    _alen=${#_a}; _blen=${#_b}
+
+    # Row zero: 0 1 2 ... blen
+    set --
+    _j=0
+    while [ "$_j" -le "$_blen" ]; do set -- "$@" "$_j"; _j=$(( _j + 1 )); done
+
+    _i=1
+    while [ "$_i" -le "$_alen" ]; do
+        _prev=$1
+        _newrow="$_i"
+        # The entry to the left is the one just computed, not the previous
+        # row's. Read from `$@` it is the old row and every distance comes out
+        # too large: kitten to sitting reported 6 where it is 3.
+        _left=$_i
+        _ac=$(printf '%s\n' "$_a" | cut -c "$_i")
+        _j=1
+        while [ "$_j" -le "$_blen" ]; do
+            # `$@` is the previous row; field j+1 is its jth entry.
+            eval "_cur=\${$(( _j + 1 ))}"
+            _bc=$(printf '%s\n' "$_b" | cut -c "$_j")
+            _cost=1
+            [ "$_ac" = "$_bc" ] && _cost=0
+
+            _best=$(( _cur + 1 ))
+            _ins=$(( _left + 1 ))
+            [ "$_ins" -lt "$_best" ] && _best=$_ins
+            _sub=$(( _prev + _cost ))
+            [ "$_sub" -lt "$_best" ] && _best=$_sub
+
+            _newrow="$_newrow $_best"
+            _prev=$_cur
+            _left=$_best
+            _j=$(( _j + 1 ))
+        done
+        # shellcheck disable=SC2086
+        set -- $_newrow
+        _i=$(( _i + 1 ))
+    done
+
+    eval "printf '%d' \"\${$(( _blen + 1 ))}\""
+}

--- a/lib/string.sh
+++ b/lib/string.sh
@@ -72,7 +72,18 @@ str_replace() {
     local to="${3:-}"
     
     [[ -z "$from" ]] && { echo "$str"; return 0; }
-    echo "${str//$from/$to}"
+    # The needle is quoted, so it is a literal.
+    #
+    # Unquoted, `${str//$from/$to}` reads it as a pattern, which is not what
+    # "replace all occurrences of a substring" says and not what a caller
+    # passing a needle out of a file means. `str_replace 'a*b' '*' '+'`
+    # returned `+`, because `*` matched the whole string; `a?c` matched `axc`;
+    # and `[b]` matched a bare `b`.
+    #
+    # Found by writing the POSIX floor beside this and comparing the two over
+    # the same inputs. The floor could not have this bug: it has no `${x//}`
+    # and cuts at the first literal occurrence instead.
+    echo "${str//"$from"/$to}"
 }
 
 #[pub]

--- a/nut.toml
+++ b/nut.toml
@@ -254,3 +254,19 @@ show_summary = true
 [deps.shebang]
 git = "https://github.com/orgrinrt/the-whole-shebang.git"
 ref = "main"
+
+# How much of this library a POSIX shell can read.
+#
+# The floor is meant to be POSIX sh, with a `when=` row selecting a better file
+# where a tool or a modern shell earns it. That is a direction rather than a
+# state, so this reports a number rather than passing or failing: 31 of 40 at
+# the time it was first measured, which is the honest starting point.
+#
+# `max_unreadable` is the budget. Left at -1 it reports and never blocks, which
+# is right while the number is still large, because a gate that fails every run
+# is one people stop reading. Lower it as the number comes down and it becomes
+# a ratchet.
+[tests.posix_floor]
+enabled = true
+max_unreadable = -1
+exempt = []

--- a/tests/check_duplication_test.sh
+++ b/tests/check_duplication_test.sh
@@ -70,3 +70,57 @@ it_does_not_compare_a_name_with_no_prefix_by_a_prefix_rule() {
     local out; out="$(_pairs "$(printf 'render|a.sh\nrenders|b.sh\n')")"
     assert_contains "$out" "MATCH"
 }
+
+# --- two spellings of one module are not a copy ------------------------------
+#
+# A `when=` row means a module is written twice for two shells, holding the
+# same function names on purpose, and only one is ever loaded. Every pair of
+# them scores 1.000 and none of them is a duplicate.
+#
+# The paths matter here and are the reason this test exists. `_variant_pairs`
+# emitted absolute paths while `collect_all_functions` produces repo-relative
+# ones, so the skip never matched and never fired on real data. It was proved
+# working on hand-made absolute input, which is a test of the input.
+
+_dup_lib() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-dup.XXXXXX")"
+    printf '%s' "$1" > "$d/lib.nut"
+    printf '%s' "$d"
+}
+
+#[test]
+it_does_not_call_two_variants_of_one_module_a_duplicate() {
+    local d; d="$(_dup_lib 'thing  lib/thing.sh        when=shell:bash4
+thing  lib/thing.posix.sh')"
+    local pairs; pairs="$(REPO_ROOT="$d" _variant_pairs)"
+    # Relative, as `collect_all_functions` produces them.
+    assert_contains "$pairs" "lib/thing.sh>lib/thing.posix.sh"
+    assert_eq "${pairs#*/Users}" "$pairs" "the pairs must not be absolute"
+
+    local out
+    out="$(NUT_DUP_VARIANTS="$pairs" compare_full_names \
+        "$(printf 'thing_do|lib/thing.sh\nthing_do|lib/thing.posix.sh\n')" "0.85")"
+    assert_empty "$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_still_calls_the_same_name_in_two_unrelated_files_a_duplicate() {
+    # The control. A skip that fired on every pair would empty this check and
+    # it would report clean over a library full of copies.
+    local out
+    out="$(NUT_DUP_VARIANTS="lib/a.sh>lib/b.sh" compare_full_names \
+        "$(printf 'thing_do|lib/c.sh\nthing_do|lib/d.sh\n')" "0.85")"
+    assert_contains "$out" "MATCH"
+}
+
+#[test]
+it_carries_the_file_through_the_stripped_comparison() {
+    # `add_stripped_names` emitted three fields and the comparison downstream
+    # read `$4` for the file, so `files[]` was empty on every row of that pass:
+    # it could not name a file in its own report and could not tell two
+    # spellings of one module apart.
+    local rows; rows="$(add_stripped_names "$(printf 'str_contains|lib/string.sh\n')")"
+    assert_eq "$(awk -F'|' '{print NF}' <<<"$rows")" "4"
+    assert_contains "$rows" "lib/string.sh"
+}

--- a/tests/check_posix_floor_test.sh
+++ b/tests/check_posix_floor_test.sh
@@ -112,3 +112,63 @@ it_exempts_nothing_when_nothing_is_configured() {
     assert_fails _is_exempt "lib/anything.sh"
     assert_fails _is_exempt ""
 }
+
+# --- a file behind a shell predicate is not counted --------------------------
+#
+# The question is which modules a POSIX shell cannot load, not which files it
+# cannot parse. Those stopped being the same thing the moment a module could
+# carry a variant: the bash file of a module with a floor will never parse
+# under dash and never has to.
+#
+# Counting it makes the number go up when a floor is added, which is the number
+# moving the wrong way while the library gets better.
+
+_pf_lib() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-pf.XXXXXX")"
+    printf '%s' "$1" > "$d/lib.nut"
+    printf '%s' "$d"
+}
+
+#[test]
+it_discounts_a_file_reached_only_behind_a_shell_predicate() {
+    local d; d="$(_pf_lib 'string  lib/string.sh        when=shell:bash4
+string  lib/string.posix.sh
+other   lib/other.sh')"
+    local got; got="$(_shell_gated_files "$d")"
+    assert_eq "$got" "lib/string.sh"
+    rm -rf "$d"
+}
+
+#[test]
+it_counts_a_file_reached_behind_a_tool_predicate() {
+    # `have:` is not `shell:`. A row predicated on a tool is still sourced on a
+    # POSIX shell wherever that tool exists, so it has to parse there, and
+    # discounting it would hide a real gap.
+    local d; d="$(_pf_lib 'text  lib/text.fast.sh  when=have:grep
+text  lib/text.sh')"
+    assert_empty "$(_shell_gated_files "$d")"
+    rm -rf "$d"
+}
+
+#[test]
+it_discounts_nothing_in_a_manifest_with_no_predicates() {
+    # The control. A matcher that returned every file would empty the report
+    # and read as a floor that is already reached.
+    local d; d="$(_pf_lib 'one  lib/one.sh
+two  lib/two.sh  internal')"
+    assert_empty "$(_shell_gated_files "$d")"
+    rm -rf "$d"
+}
+
+#[test]
+it_reads_a_shell_predicate_written_after_a_visibility() {
+    # The trailing columns are words, not positions, and this reader has to
+    # agree with the resolver about that or the two disagree about which file
+    # a POSIX shell ever sees.
+    local d; d="$(_pf_lib 'a  lib/a.sh  internal when=shell:bash4
+b  lib/b.sh  when=shell:bash internal')"
+    local got; got="$(_shell_gated_files "$d")"
+    assert_contains "$got" "lib/a.sh"
+    assert_contains "$got" "lib/b.sh"
+    rm -rf "$d"
+}

--- a/tests/check_posix_floor_test.sh
+++ b/tests/check_posix_floor_test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Tests for the check that says how much of this a POSIX shell can read.
+#
+# The floor is meant to be POSIX sh, with a `when=` row selecting a better file
+# where a tool or a modern shell earns it. That is a direction rather than a
+# state, so it needs a number that moves.
+#
+# The instrument is the part worth testing. Written against `sh` it reports a
+# clean floor on a library that has none, because `sh` on macOS is bash in
+# POSIX mode and accepts arrays, `[[` and here-strings. The first measurement
+# taken here was exactly that and was worthless, so the shell it picks is
+# verified against a probe rather than trusted by name.
+
+use test
+
+NUT_CHECK_LOAD_ONLY=1 . "${BASH_SOURCE[0]%/*}/../examples/checks/check_posix_floor.sh"
+
+_pf_tmp() { mktemp "${TMPDIR:-/tmp}/nutshell-pf.XXXXXX"; }
+
+#[test]
+it_finds_a_shell_that_is_actually_posix() {
+    local sh; sh="$(_posix_shell)" || { assert_eq "no posix shell here" "skipped"; return 0; }
+    assert_ne "$sh" ""
+    assert_ok command -v "$sh"
+}
+
+#[test]
+it_refuses_a_named_shell_that_accepts_an_array() {
+    # The control that makes every number this check prints mean anything, and
+    # it has to be driven rather than observed: with `dash` on the machine the
+    # selection returns `dash` first whatever the probes do, so asserting
+    # properties of what came back tests dash and not the choosing.
+    #
+    # `POSIX_SHELL` goes to the front of the candidate list, so naming `bash`
+    # asks the probes to reject the shell they exist to reject. Written the
+    # other way first, and removing both probes killed nothing.
+    POSIX_SHELL="bash"
+    local got; got="$(_posix_shell)" || got=""
+    POSIX_SHELL=""
+    assert_ne "$got" "bash"
+}
+
+#[test]
+it_refuses_the_sh_on_this_machine_when_that_sh_is_bash() {
+    # The specific trap, named. `sh` here is bash 3.2 in POSIX mode and takes
+    # arrays, `[[` and here-strings, so a check written against it reports a
+    # clean floor on a library that has none.
+    local probe; probe="$(_pf_tmp)"
+    printf 'a=(1 2)\n' > "$probe"
+    if sh -n "$probe" >/dev/null 2>&1; then
+        # This machine's `sh` is not POSIX enough, so the selection must not
+        # return it even when asked for it by name.
+        POSIX_SHELL="sh"
+        local got; got="$(_posix_shell)" || got=""
+        POSIX_SHELL=""
+        assert_ne "$got" "sh"
+    else
+        # Somewhere whose `sh` really is POSIX. Then it is a legitimate answer
+        # and the assertion is that it is reachable rather than excluded.
+        POSIX_SHELL="sh"
+        assert_eq "$(_posix_shell)" "sh"
+        POSIX_SHELL=""
+    fi
+    rm -f "$probe"
+}
+
+#[test]
+it_refuses_a_named_shell_that_cannot_read_ordinary_posix() {
+    # The other half of the probe. Without it the selection would take
+    # anything that merely rejects arrays, including something that rejects
+    # everything, and the library would read as entirely unreadable.
+    local fake; fake="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-pf.XXXXXX")"
+    printf '#!/bin/sh\nexit 1\n' > "$fake/refuses-all"
+    chmod +x "$fake/refuses-all"
+
+    POSIX_SHELL="$fake/refuses-all"
+    local got; got="$(PATH="$fake:$PATH" _posix_shell)" || got=""
+    POSIX_SHELL=""
+    assert_ne "$got" "$fake/refuses-all"
+    rm -rf "$fake"
+}
+
+#[test]
+it_reads_a_bashism_as_unreadable_and_plain_posix_as_readable() {
+    # End to end on two files whose answers are known, because everything
+    # above is about the shell and nothing yet about the reading.
+    local sh; sh="$(_posix_shell)" || return 0
+    local bad good
+    bad="$(_pf_tmp)";  printf 'a=(1 2)\necho "${a[0]}"\n' > "$bad"
+    good="$(_pf_tmp)"; printf 'x=1\necho "${x}"\n' > "$good"
+
+    assert_fails "$sh" -n "$bad"
+    assert_ok    "$sh" -n "$good"
+    rm -f "$bad" "$good"
+}
+
+#[test]
+it_matches_an_exempt_pattern_and_not_a_neighbour() {
+    POSIX_EXEMPT=('lib/legacy/*.sh' 'lib/one.sh')
+    assert_ok    _is_exempt "lib/legacy/thing.sh"
+    assert_ok    _is_exempt "lib/one.sh"
+    assert_fails _is_exempt "lib/two.sh"
+    assert_fails _is_exempt "lib/legacy.sh"
+    POSIX_EXEMPT=()
+}
+
+#[test]
+it_exempts_nothing_when_nothing_is_configured() {
+    # The control for the one above. An exemption matcher that said yes to
+    # everything would empty the report and read as a clean floor.
+    POSIX_EXEMPT=()
+    assert_fails _is_exempt "lib/anything.sh"
+    assert_fails _is_exempt ""
+}

--- a/tests/lib_nut_test.sh
+++ b/tests/lib_nut_test.sh
@@ -360,8 +360,40 @@ it_reports_a_visibility_it_does_not_understand() {
     mkdir -p "$d/lib"; : > "$d/lib/x.sh"
     printf 'x lib/x.sh publicish\n' > "$d/lib.nut"
     out="$("$DECLARE" --check "$d" 2>&1 || true)"
-    # A typo in the third column silently made an internal module public.
-    assert_ok grep -q 'unknown visibility' <<<"$out"
+    # A typo in a trailing column silently made an internal module public.
+    #
+    # "word" rather than "visibility": a trailing column can be a visibility or
+    # a `when=` predicate now, and calling every one of them a visibility told
+    # a reader with a mistyped predicate to look at the wrong thing.
+    assert_ok grep -q 'unknown word' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_a_predicate_it_does_not_understand() {
+    # A predicate `_nut_when` refuses is a variant that silently never loads,
+    # and the row looks fine. Caught here it is a typo somebody can see.
+    local d out; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/lib/x.sh"
+    printf 'x lib/x.sh when=shel:bash4
+' > "$d/lib.nut"
+    out="$("$DECLARE" --check "$d" 2>&1 || true)"
+    assert_ok grep -q 'unknown predicate' <<<"$out"
+    rm -rf "$d"
+}
+
+#[test]
+it_accepts_every_predicate_word_the_resolver_knows() {
+    # The control. A validator rejecting everything would pass the test above
+    # and refuse every real manifest.
+    local d out rc; d="$(mktemp -d)"
+    mkdir -p "$d/lib"; : > "$d/lib/x.sh"
+    printf 'x lib/x.sh when=have:grep+shell:bash4
+y lib/x.sh when=env:HOME
+z lib/x.sh when=shell:bash
+' > "$d/lib.nut"
+    rc=0; out="$("$DECLARE" --check "$d" 2>&1)" || rc=$?
+    assert_eq "$rc" "0" "$out"
     rm -rf "$d"
 }
 

--- a/tests/modgraph_test.sh
+++ b/tests/modgraph_test.sh
@@ -133,3 +133,68 @@ it_reports_a_declaration_nothing_uses() {
     MODGRAPH_NOCACHE=1 modgraph_build "$FIXTURE"
     assert_contains "$(modgraph_audit)" "unused	idle	alpha"
 }
+
+# --- two files, one module ---------------------------------------------------
+#
+# A `when=` row means a module is written twice, once for bash and once for
+# POSIX sh, and only one is ever loaded. Named from the path, the second
+# becomes a module of its own that calls everything the first defines and
+# declares none of it, and the contract check reports every function.
+#
+# Fifteen of those on `string` the day the floor was added.
+
+_mgv_lib() {
+    local d; d="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-mgv.XXXXXX")"
+    mkdir -p "$d/lib"
+    printf '%s' "$1" > "$d/lib.nut"
+    printf 'nut_once || return 0\n#[pub]\n# Usage: thing_do\nthing_do() { :; }\n' > "$d/lib/thing.sh"
+    printf 'nut_once || return 0\n#[pub]\n# Usage: thing_do\nthing_do() { :; }\n' > "$d/lib/thing.posix.sh"
+    printf '%s' "$d"
+}
+
+#[test]
+it_reads_two_variant_files_as_one_module() {
+    local d; d="$(_mgv_lib 'thing  lib/thing.sh        when=shell:bash4
+thing  lib/thing.posix.sh')"
+    MODGRAPH_ROOT="$d" modgraph_build "$d/lib"
+    local mods; mods="$(printf '%s\n' "${_MG_MODULES[@]}" | sort | tr '\n' ' ')"
+    assert_eq "$mods" "thing "
+    unset MODGRAPH_ROOT
+    rm -rf "$d"
+}
+
+#[test]
+it_reports_no_undeclared_call_between_two_variants() {
+    # The property that matters, rather than the module count: one spelling
+    # must not read as calling into the other.
+    local d; d="$(_mgv_lib 'thing  lib/thing.sh        when=shell:bash4
+thing  lib/thing.posix.sh')"
+    MODGRAPH_ROOT="$d" modgraph_build "$d/lib"
+    assert_empty "$(modgraph_audit | grep undeclared || true)"
+    unset MODGRAPH_ROOT
+    rm -rf "$d"
+}
+
+#[test]
+it_still_reads_two_unrelated_files_as_two_modules() {
+    # The control. Merging on the file stem, or merging everything, would pass
+    # both tests above and collapse the whole graph into one node.
+    local d; d="$(_mgv_lib 'thing  lib/thing.sh
+other  lib/thing.posix.sh')"
+    MODGRAPH_ROOT="$d" modgraph_build "$d/lib"
+    local mods; mods="$(printf '%s\n' "${_MG_MODULES[@]}" | sort | tr '\n' ' ')"
+    assert_eq "$mods" "other thing "
+    unset MODGRAPH_ROOT
+    rm -rf "$d"
+}
+
+#[test]
+it_names_a_file_the_manifest_does_not_mention_by_its_stem() {
+    # What every file did before there was a manifest to ask, and what a file
+    # outside one still gets.
+    local d; d="$(_mgv_lib 'thing  lib/thing.sh')"
+    assert_eq "$(_mg_module_of "$d/lib/thing.posix.sh" "$d")" "thing.posix"
+    assert_eq "$(_mg_module_of "$d/lib/thing.sh" "$d")" "thing"
+    assert_eq "$(_mg_module_of "/tmp/nowhere/zzz.sh" "$d")" "zzz"
+    rm -rf "$d"
+}

--- a/tests/string_posix_parity_test.sh
+++ b/tests/string_posix_parity_test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Tests that the POSIX string floor answers what the bash one answers.
+#
+# Two files with one surface is only safe while they agree, and agreement is
+# not something you can establish by reading them side by side: the bash one
+# uses `${x,,}`, `${x//}` and `${x:i:n}`, and the POSIX one uses `tr`, a cut
+# loop and `cut -c`, so nothing about them looks alike.
+#
+# So both are driven over the same inputs and the answers are compared. The
+# POSIX one is run under a real POSIX shell rather than under bash, because
+# running it under bash tests nothing that the bash file does not already
+# cover, and the interesting failures are the ones bash forgives.
+#
+# `str_split` is absent from the floor on purpose and is not compared here.
+# It writes into an array through a nameref, POSIX has neither, and a version
+# returning some other shape would be a different function wearing the same
+# name.
+
+use test
+
+ROOT="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+BASHFILE="$ROOT/lib/string.sh"
+POSIXFILE="$ROOT/lib/string.posix.sh"
+
+# A POSIX shell that is one, or nothing. Same probe the floor check uses: it
+# must reject an array and still accept ordinary POSIX.
+_sp_shell() {
+    local cand probe; probe="$(mktemp)"
+    for cand in dash ash yash posh sh; do
+        command -v "$cand" >/dev/null 2>&1 || continue
+        printf 'a=(1 2)\n' > "$probe"
+        "$cand" -n "$probe" >/dev/null 2>&1 && continue
+        printf 'x=1\necho "${x:-}"\n' > "$probe"
+        "$cand" -n "$probe" >/dev/null 2>&1 && { rm -f "$probe"; printf '%s' "$cand"; return 0; }
+    done
+    rm -f "$probe"; return 1
+}
+
+# What the bash file answers, under bash.
+#
+# `nut_once` is stubbed rather than nutshell loaded, because loading nutshell
+# would also load `string` through the manifest and the point is to run one
+# named file. Written without the stub, every call came back 127 and the
+# comparison was between two absences.
+_ask_bash() {
+    bash -c 'nut_once() { return 0; }
+             . "$1" >/dev/null 2>&1; shift; f="$1"; shift
+             command -v "$f" >/dev/null 2>&1 || { printf "|missing"; exit 0; }
+             "$f" "$@"; printf "|%s" "$?"' \
+        _ "$BASHFILE" "$@" 2>/dev/null
+}
+
+# What the POSIX file answers, under a POSIX shell.
+_ask_posix() {
+    local sh="$1"; shift
+    "$sh" -c 'nut_once() { return 0; }
+              . "$1" >/dev/null 2>&1; shift; f="$1"; shift
+              command -v "$f" >/dev/null 2>&1 || { printf "|missing"; exit 0; }
+              "$f" "$@"; printf "|%s" "$?"' \
+        _ "$POSIXFILE" "$@" 2>/dev/null
+}
+
+# Both, compared. The status is part of the answer: three of these return a
+# verdict rather than text and comparing only stdout would call them all equal.
+_same() {
+    local sh="$1"; shift
+    local b p
+    b="$(_ask_bash "$@")"
+    p="$(_ask_posix "$sh" "$@")"
+    assert_eq "$p" "$b" "$*"
+}
+
+#[test]
+it_has_a_posix_shell_to_compare_under() {
+    # The control for every test below. Without a POSIX shell they all skip,
+    # and a skip that reports a pass is how a parity suite comes to mean
+    # nothing.
+    local sh; sh="$(_sp_shell)"
+    assert_ne "$sh" ""
+    assert_ne "$sh" "bash"
+}
+
+#[test]
+it_reads_the_floor_under_a_posix_shell_at_all() {
+    # And the control for that: the file has to load there. This is the whole
+    # reason the floor exists, so it is asserted rather than assumed.
+    local sh; sh="$(_sp_shell)" || return 0
+    assert_ok "$sh" -n "$POSIXFILE"
+    assert_fails "$sh" -n "$BASHFILE"
+}
+
+#[test]
+it_answers_the_same_for_case_and_trimming() {
+    local sh; sh="$(_sp_shell)" || return 0
+    _same "$sh" str_lower "HeLLo WoRLD"
+    _same "$sh" str_lower ""
+    _same "$sh" str_upper "hello world"
+    _same "$sh" str_upper "ALREADY"
+    _same "$sh" str_trim "   padded   "
+    _same "$sh" str_trim "none"
+    _same "$sh" str_trim "   "
+    _same "$sh" str_trim ""
+    _same "$sh" str_ltrim "   left"
+    _same "$sh" str_rtrim "right   "
+    _same "$sh" str_trim "$(printf '\tmixed \t')"
+}
+
+#[test]
+it_answers_the_same_for_replace() {
+    local sh; sh="$(_sp_shell)" || return 0
+    _same "$sh" str_replace "hello world" "world" "bash"
+    _same "$sh" str_replace "aaa" "a" "b"
+    _same "$sh" str_replace "aaa" "aa" "b"
+    _same "$sh" str_replace "nothing here" "zzz" "x"
+    _same "$sh" str_replace "keep" "" "x"
+    _same "$sh" str_replace "" "a" "b"
+    # A needle with regex characters in it, which is why this is a loop rather
+    # than a `sed`: a caller's needle is a literal.
+    _same "$sh" str_replace "a.b.c" "." "-"
+    _same "$sh" str_replace 'a*b' '*' '+'
+    _same "$sh" str_replace 'a[b]c' '[b]' 'X'
+    # Removing rather than replacing.
+    _same "$sh" str_replace "xxhixx" "xx" ""
+}
+
+#[test]
+it_answers_the_same_for_the_three_that_return_a_verdict() {
+    local sh; sh="$(_sp_shell)" || return 0
+    _same "$sh" str_contains "hello world" "world"
+    _same "$sh" str_contains "hello world" "zzz"
+    _same "$sh" str_contains "hello" ""
+    _same "$sh" str_starts_with "hello world" "hello"
+    _same "$sh" str_starts_with "hello world" "world"
+    _same "$sh" str_starts_with "hello" ""
+    _same "$sh" str_ends_with "hello world" "world"
+    _same "$sh" str_ends_with "hello world" "hello"
+    _same "$sh" str_ends_with "hello" ""
+    # A needle that is a glob, which `case` would match as a pattern if the
+    # quoting were wrong on either side.
+    _same "$sh" str_contains "a*b" "*"
+    _same "$sh" str_starts_with "abc" "a*"
+}
+
+#[test]
+it_answers_the_same_for_join_length_substr_and_repeat() {
+    local sh; sh="$(_sp_shell)" || return 0
+    _same "$sh" str_join ", " a b c
+    _same "$sh" str_join ", " a
+    _same "$sh" str_join ", "
+    _same "$sh" str_join "" a b
+    _same "$sh" str_length "hello"
+    _same "$sh" str_length ""
+    _same "$sh" str_substr "hello world" 0 5
+    _same "$sh" str_substr "hello world" 6
+    _same "$sh" str_substr "hello world" 6 5
+    _same "$sh" str_substr "hello" 0
+    _same "$sh" str_repeat "-" 5
+    _same "$sh" str_repeat "ab" 3
+    _same "$sh" str_repeat "-" 0
+    _same "$sh" str_repeat "-" -1
+}
+
+#[test]
+it_answers_the_same_distance() {
+    local sh; sh="$(_sp_shell)" || return 0
+    _same "$sh" str_distance build buidl
+    _same "$sh" str_distance "" ""
+    _same "$sh" str_distance abc ""
+    _same "$sh" str_distance "" abc
+    _same "$sh" str_distance same same
+    _same "$sh" str_distance kitten sitting
+    _same "$sh" str_distance a b
+}
+
+#[test]
+it_does_not_define_split_on_the_floor() {
+    # Absent on purpose. A caller wanting it wants bash, and finds out by the
+    # name not being there rather than by getting an answer in the wrong shape.
+    local sh; sh="$(_sp_shell)" || return 0
+    local out
+    out="$("$sh" -c 'nut_once() { return 0; }; . "$1" >/dev/null 2>&1; command -v str_split >/dev/null && echo THERE || echo absent' _ "$POSIXFILE" 2>&1)"
+    assert_eq "$out" "absent"
+
+    # And the control: it is there in the bash one, so the line above is about
+    # the floor rather than about the name being wrong.
+    out="$(bash -c 'nut_once() { return 0; }; . "$1" >/dev/null 2>&1; command -v str_split >/dev/null && echo there || echo ABSENT' _ "$BASHFILE" 2>&1)"
+    assert_eq "$out" "there"
+}


### PR DESCRIPTION
## A module can be written twice, and a POSIX shell gets the one it can read

`string` is the first. `lib/string.sh` is what bash 4 gets, `lib/string.posix.sh` is what a POSIX shell gets, and the manifest picks between them above the sourcing. Before this a POSIX shell got a parse error and no module at all.

`str_split` is the one thing missing from the floor. It writes into an array through a nameref, POSIX has neither, and a version returning some other shape would be a different function wearing the same name.

## And a number for how far there is to go

`./check` gains `posix_floor`: **19 of 27** files cannot be read by a POSIX shell. It reports and does not block, because a gate that fails every run is one people stop reading; `max_unreadable` is the budget to lower as the number comes down.

The instrument is verified rather than trusted. `sh` on macOS is bash in POSIX mode and takes arrays, `[[` and here-strings, so a check written against it reports a clean floor on a library that has none.

## What changes for you

**`str_replace` treats its needle as a literal.** It was reading it as a pattern, so `str_replace 'a*b' '*' '+'` returned `+`, `a?c` matched `axc`, and `[b]` matched a bare `b`. If you were relying on the pattern behaviour, you were relying on a bug, and this is the release that takes it away.

Nothing else moves. A manifest with no `when=` row resolves exactly as before.

## Sanity

606 pass. `./check` is nine checks with six warnings.

Found by writing the floor and comparing the two over the same inputs, which is also how the `str_replace` bug surfaced: the POSIX one cuts at the first literal occurrence and could not have it.