### PR TITLE
release: 0.6.1, what the lowering bench actually measures

### DIFF
--- a/benches/startup/bench.sh
+++ b/benches/startup/bench.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/benches/startup - What a lowered form would save at load time
+# =============================================================================
+#
+# Every `use` resolves through `_lib_nut_lookup`, and every caller of that
+# wraps it in a command substitution, which is a fork. Add the manifest read
+# per lookup and the predicate evaluation on top, and the cost sits in front of
+# everything: it is paid before a single line of anybody's script runs.
+#
+# The proposal is a pre-process that lowers the source into a resolved form and
+# runs that from a cache. This prices the ceiling of that idea before any of it
+# is built: the lowered arm here is the crudest possible version, the files
+# concatenated in the order the resolver would have loaded them, with no
+# resolution left to do at all.
+#
+# It is a ceiling and not an estimate. A real lowering has to invalidate, has
+# to key on the machine facts a predicate reads, and has to keep something a
+# reader can debug. Whatever it costs, it cannot beat the number here.
+#
+# Usage:
+#   ./bench startup [modules]
+# =============================================================================
+
+use bench
+
+MODS="${1:-string log fs os toml}"
+
+_ST_TMP="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-st.XXXXXX")"
+trap '[[ -n "${_ST_TMP:-}" ]] && rm -rf "$_ST_TMP"' EXIT
+
+_ST_ROOT="${NUTSHELL_ROOT:-$PWD}"
+_ST_LOWERED="$_ST_TMP/lowered.sh"
+
+# The lowered form: what the resolver would have sourced, already sourced in.
+#
+# Crude on purpose. It resolves each module once, now, and concatenates. No
+# `use` survives in it, so nothing forks at load time.
+_st_lower() {
+    local m file
+    {
+        printf 'nut_once() { return 0; }\n'
+        printf 'use() { return 0; }\n'
+        for m in $MODS; do
+            file="$(_lib_nut_lookup "$_ST_ROOT" "$m" 2>/dev/null)" || continue
+            printf '# --- %s ---\n' "$m"
+            cat "$file"
+        done
+    } > "$_ST_LOWERED"
+}
+
+# The real path: a fresh shell, nutshell loaded, the modules used.
+arm_resolved() {
+    bash -c '
+        . "$1"/init >/dev/null 2>&1 || exit 1
+        shift
+        for m in $1; do use "$m" >/dev/null 2>&1; done
+        printf "%s" "$(str_upper ok)"
+    ' _ "$_ST_ROOT" "$MODS" 2>/dev/null
+}
+
+# The lowered path: a fresh shell, one file.
+arm_lowered() {
+    bash -c '
+        . "$1" >/dev/null 2>&1 || exit 1
+        printf "%s" "$(str_upper ok)"
+    ' _ "$_ST_LOWERED" 2>/dev/null
+}
+
+# The floor: a fresh shell that loads nothing, so the arms above can be read
+# against what a shell costs before anybody asks it for anything.
+arm_bare_shell() {
+    bash -c 'printf "%s" "OK"' 2>/dev/null
+}
+
+_st_lower
+
+_answer_of() { "$1"; }
+
+bench_case "What a lowered form would save at load time"
+bench_size "$(printf '%s\n' $MODS | wc -l | tr -d ' ')"
+bench_verify _answer_of
+
+bench_arm "resolved through the manifest" arm_resolved
+bench_arm "lowered, one file"             arm_lowered
+bench_arm "a bare shell, loading nothing" arm_bare_shell
+
+bench_run || exit 1
+
+printf '\n'
+printf 'The lowered arm is a ceiling rather than an estimate: it is the files\n'
+printf 'concatenated with nothing left to resolve, and no invalidation, no\n'
+printf 'machine-fact key and nothing a reader could debug. A real lowering\n'
+printf 'cannot beat it.\n'
+printf '\n'
+printf 'The bare shell is here so the other two can be read against what a\n'
+printf 'shell costs before anybody asks it for anything. Without it a 2x\n'
+printf 'between the first two could be almost all process startup.\n'

--- a/benches/startup/bench.sh
+++ b/benches/startup/bench.sh
@@ -1,22 +1,28 @@
 #!/usr/bin/env bash
 # =============================================================================
-# nutshell/benches/startup - What a lowered form would save at load time
+# nutshell/benches/startup - What a lowered form saves at load time
 # =============================================================================
 #
-# Every `use` resolves through `_lib_nut_lookup`, and every caller of that
-# wraps it in a command substitution, which is a fork. Add the manifest read
-# per lookup and the predicate evaluation on top, and the cost sits in front of
-# everything: it is paid before a single line of anybody's script runs.
+# Every `use` resolves through `_lib_nut_lookup`, every caller of that wraps it
+# in a command substitution, and a fork is not cheap. The cost sits in front of
+# everything: it is paid before a line of anybody's script runs.
 #
-# The proposal is a pre-process that lowers the source into a resolved form and
-# runs that from a cache. This prices the ceiling of that idea before any of it
-# is built: the lowered arm here is the crudest possible version, the files
-# concatenated in the order the resolver would have loaded them, with no
-# resolution left to do at all.
+# The lowered arm here resolves `use` **at lower time** rather than stubbing it
+# out. That is the difference between this and the first version of this bench,
+# which concatenated the named modules only, never loaded their dependencies,
+# and reported a number that was partly the arm doing less work.
 #
-# It is a ceiling and not an estimate. A real lowering has to invalidate, has
-# to key on the machine facts a predicate reads, and has to keep something a
-# reader can debug. Whatever it costs, it cannot beat the number here.
+# So the closure is walked: each module's file is read, its own `use` lines
+# resolved, and so on until nothing new appears. What is emitted is every file
+# the resolver would have sourced, in the order it would have sourced them.
+# `use` is a no-op in the result because by then there is nothing left for it
+# to do, which is a fact about the lowering rather than a shortcut.
+#
+# **The arms are held to the same surface by the harness.** `bench_verify`
+# compares the sorted list of every function defined, so an arm that loaded
+# less is a disagreement and the run is refused rather than reported. The first
+# version compared one function's output, and both arms answered `str_upper ok`
+# identically while differing by 76 functions.
 #
 # Usage:
 #   ./bench startup [modules]
@@ -32,67 +38,118 @@ trap '[[ -n "${_ST_TMP:-}" ]] && rm -rf "$_ST_TMP"' EXIT
 _ST_ROOT="${NUTSHELL_ROOT:-$PWD}"
 _ST_LOWERED="$_ST_TMP/lowered.sh"
 
-# The lowered form: what the resolver would have sourced, already sourced in.
+# Every module a file reaches for, as the resolver would read them.
 #
-# Crude on purpose. It resolves each module once, now, and concatenates. No
-# `use` survives in it, so nothing forks at load time.
+# `super::x` inside a unit means x in that unit, and the manifest names it by
+# its full path, so the prefix is dropped and the leaf looked up. That is what
+# `_use_resolve` does and this has to agree with it or the closure is short.
+_st_uses_in() {
+    local file="$1" line m
+    while IFS= read -r line; do
+        case "$line" in
+            *use[[:space:]]*) ;;
+            *) continue ;;
+        esac
+        # Command position only. `# use foo` in prose is not a load.
+        line="${line#"${line%%[![:space:]]*}"}"
+        case "$line" in
+            use[[:space:]]*) ;;
+            *) continue ;;
+        esac
+        line="${line#use }"
+        for m in $line; do
+            case "$m" in
+                -*|'||'*|'&&'*|'{'*) continue ;;
+            esac
+            m="${m%%;*}"; m="${m%\"}"; m="${m#\"}"
+            [[ -n "$m" ]] && printf '%s\n' "${m#super::}"
+        done
+    done < "$file"
+}
+
+# The closure, in load order: a module's dependencies before the module.
+declare -A _ST_SEEN=()
+declare -a _ST_ORDER=()
+_st_walk() {
+    local m="$1" file dep
+    [[ -n "${_ST_SEEN[$m]:-}" ]] && return 0
+    _ST_SEEN[$m]=1
+    file="$(_lib_nut_lookup "$_ST_ROOT" "$m" 2>/dev/null)" || return 0
+    while IFS= read -r dep; do
+        [[ -n "$dep" ]] && _st_walk "$dep"
+    done < <(_st_uses_in "$file")
+    _ST_ORDER+=("$file")
+}
+
 _st_lower() {
-    local m file
+    local m
+    for m in $MODS; do _st_walk "$m"; done
     {
-        printf 'nut_once() { return 0; }\n'
+        # The interpreter still loads. A lowering removes the resolution, not
+        # nutshell: `nut_once` and `use` have to exist because the files call
+        # them, and by this point `use` has nothing left to resolve.
+        printf '. "%s/init" >/dev/null 2>&1 || exit 1\n' "$_ST_ROOT"
         printf 'use() { return 0; }\n'
-        for m in $MODS; do
-            file="$(_lib_nut_lookup "$_ST_ROOT" "$m" 2>/dev/null)" || continue
-            printf '# --- %s ---\n' "$m"
-            cat "$file"
+        for m in "${_ST_ORDER[@]}"; do
+            printf '# --- %s ---\n' "${m#"$_ST_ROOT/"}"
+            # The per-file inclusion guard goes.
+            #
+            # `nut_once` answers about the file being sourced, and concatenated
+            # every file is the same file: the first call registers the lowered
+            # one and every guard after it says "already loaded" and does
+            # `return 0`, which returns from the whole thing. So the lowered
+            # file defined the first module and nothing else, and the harness
+            # refused the run because the arms disagreed by 130 functions.
+            #
+            # A real lowering strips them for the same reason. Inclusion is
+            # decided at lower time; there is nothing left to guard at run
+            # time, which is the point.
+            sed -e 's/^nut_once || return 0$//' \
+                -e 's/^nut_once || return$//' "$m"
         done
     } > "$_ST_LOWERED"
 }
 
-# The real path: a fresh shell, nutshell loaded, the modules used.
+# Every function defined, sorted. The surface, not one call's answer.
+_ST_PROBE='declare -F | sed "s/^declare -f //" | sort | tr "\n" " "'
+
 arm_resolved() {
     bash -c '
         . "$1"/init >/dev/null 2>&1 || exit 1
-        shift
-        for m in $1; do use "$m" >/dev/null 2>&1; done
-        printf "%s" "$(str_upper ok)"
-    ' _ "$_ST_ROOT" "$MODS" 2>/dev/null
+        for m in $2; do use "$m" >/dev/null 2>&1; done
+        eval "$3"
+    ' _ "$_ST_ROOT" "$MODS" "$_ST_PROBE" 2>/dev/null
 }
 
-# The lowered path: a fresh shell, one file.
 arm_lowered() {
-    bash -c '
-        . "$1" >/dev/null 2>&1 || exit 1
-        printf "%s" "$(str_upper ok)"
-    ' _ "$_ST_LOWERED" 2>/dev/null
+    bash -c '. "$1" >/dev/null 2>&1 || exit 1; eval "$2"' \
+        _ "$_ST_LOWERED" "$_ST_PROBE" 2>/dev/null
 }
 
-# The floor: a fresh shell that loads nothing, so the arms above can be read
-# against what a shell costs before anybody asks it for anything.
-arm_bare_shell() {
-    bash -c 'printf "%s" "OK"' 2>/dev/null
+# The interpreter and nothing else, so the two above can be read against what
+# is paid before any module is asked for at all.
+arm_init_only() {
+    bash -c '. "$1"/init >/dev/null 2>&1 || exit 1; printf init-only' \
+        _ "$_ST_ROOT" 2>/dev/null
 }
 
 _st_lower
 
 _answer_of() { "$1"; }
 
-bench_case "What a lowered form would save at load time"
-bench_size "$(printf '%s\n' $MODS | wc -l | tr -d ' ')"
+bench_case "What a lowered form saves at load time"
+bench_size "${#_ST_ORDER[@]}"
 bench_verify _answer_of
 
 bench_arm "resolved through the manifest" arm_resolved
-bench_arm "lowered, one file"             arm_lowered
-bench_arm "a bare shell, loading nothing" arm_bare_shell
+bench_arm "lowered, use resolved already" arm_lowered
 
 bench_run || exit 1
 
 printf '\n'
-printf 'The lowered arm is a ceiling rather than an estimate: it is the files\n'
-printf 'concatenated with nothing left to resolve, and no invalidation, no\n'
-printf 'machine-fact key and nothing a reader could debug. A real lowering\n'
-printf 'cannot beat it.\n'
+printf 'The closure is %s files for the %s modules named.\n' \
+    "${#_ST_ORDER[@]}" "$(printf '%s\n' $MODS | wc -l | tr -d ' ')"
 printf '\n'
-printf 'The bare shell is here so the other two can be read against what a\n'
-printf 'shell costs before anybody asks it for anything. Without it a 2x\n'
-printf 'between the first two could be almost all process startup.\n'
+printf 'The interpreter loads in both arms, so this is the resolution cost and\n'
+printf 'not the cost of nutshell existing. `./bench startup` with one module\n'
+printf 'shows how much of it is per-module rather than fixed.\n'

--- a/benches/startup/findings.md
+++ b/benches/startup/findings.md
@@ -1,0 +1,46 @@
+# What a lowered form would save at load time
+
+**Not established. The first measurement was not sound and is recorded here so
+nobody quotes it.**
+
+## The unsound run
+
+    resolved through the manifest    217 ms
+    lowered, one file                 15 ms
+    a bare shell, loading nothing     12 ms
+
+Read as written that is the load cost falling from 205 ms to 3 ms. It is not,
+because the two arms did not load the same thing: the resolved arm defined 165
+functions and the lowered arm 90.
+
+The lowered arm concatenates the modules named on the command line and stubs
+`use` to a no-op, so a module reaching for its own dependencies at load time
+gets nothing. The resolved arm loads those dependencies for real. So part of
+the gap is the lowered arm doing less work rather than doing it faster.
+
+The direction is almost certainly right. Every `use` resolves through
+`_lib_nut_lookup`, every caller of that wraps it in a command substitution, and
+a fork is not cheap. But the size of it is unmeasured.
+
+## What a sound version needs
+
+The arms have to load the same set. Two ways, and the second is better:
+
+- Expand the module list to the transitive closure before concatenating, so
+  both arms end with the same functions defined. Straightforward and still
+  hand-rolled.
+- Have the lowering resolve `use` itself rather than stubbing it, which is what
+  a real lowering does anyway. Then the arms are the same program by
+  construction and the bench prices the thing rather than a sketch of it.
+
+Either way the harness will refuse a run whose arms disagree once they are
+asked the right question, which is `bench_verify` over the loaded surface
+rather than over one function's output. The current verify calls `str_upper`,
+which both arms answer identically while differing by 75 functions.
+
+## What is not in question
+
+That the resolved path forks per module. That is structural: `_lib_nut_lookup`
+prints its answer and all five call sites capture it with `$( )`.
+`benches/module-resolve` prices a predicated row against a plain one and names
+this as the larger cost sitting underneath both.

--- a/benches/startup/results/20260827064341.csv
+++ b/benches/startup/results/20260827064341.csv
@@ -1,0 +1,4 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+resolved through the manifest,216,253,within the noise,yes
+lowered  one file,15,18,6%,yes
+a bare shell  loading nothing,12,14,5%,yes

--- a/benches/startup/results/20260827064341.meta
+++ b/benches/startup/results/20260827064341.meta
@@ -1,0 +1,7 @@
+case      What a lowered form would save at load time
+size      5
+repeats   7
+baseline  resolved through the manifest
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T03:43:41Z

--- a/benches/startup/results/20260827064351.csv
+++ b/benches/startup/results/20260827064351.csv
@@ -1,0 +1,4 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+resolved through the manifest,217,228,within the noise,yes
+lowered  one file,15,17,6%,yes
+a bare shell  loading nothing,12,13,5%,yes

--- a/benches/startup/results/20260827064351.meta
+++ b/benches/startup/results/20260827064351.meta
@@ -1,0 +1,7 @@
+case      What a lowered form would save at load time
+size      5
+repeats   7
+baseline  resolved through the manifest
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T03:43:51Z

--- a/benches/startup/results/20260827065553.csv
+++ b/benches/startup/results/20260827065553.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+resolved through the manifest,222,250,within the noise,yes
+lowered  use resolved already,205,223,within the noise,yes

--- a/benches/startup/results/20260827065553.meta
+++ b/benches/startup/results/20260827065553.meta
@@ -1,0 +1,7 @@
+case      What a lowered form saves at load time
+size      7
+repeats   7
+baseline  resolved through the manifest
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T03:55:53Z

--- a/benches/startup/results/20260827065614.csv
+++ b/benches/startup/results/20260827065614.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+resolved through the manifest,19,24,within the noise,yes
+lowered  use resolved already,16,27,within the noise,yes

--- a/benches/startup/results/20260827065614.meta
+++ b/benches/startup/results/20260827065614.meta
@@ -1,0 +1,7 @@
+case      What a lowered form saves at load time
+size      1
+repeats   7
+baseline  resolved through the manifest
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T03:56:14Z

--- a/benches/startup/results/20260827065618.csv
+++ b/benches/startup/results/20260827065618.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+resolved through the manifest,224,263,within the noise,yes
+lowered  use resolved already,197,226,within the noise,yes

--- a/benches/startup/results/20260827065618.meta
+++ b/benches/startup/results/20260827065618.meta
@@ -1,0 +1,7 @@
+case      What a lowered form saves at load time
+size      7
+repeats   7
+baseline  resolved through the manifest
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T03:56:18Z

--- a/docs/LOWERING.md
+++ b/docs/LOWERING.md
@@ -1,0 +1,98 @@
+# Lowering, and where the branching belongs
+
+Op's shape, recorded before it is built.
+
+## The manifest carries the gates, attribute-shaped
+
+Module gating goes in `lib.nut`, on the declaration, the way Rust gates a top
+level module: the attribute sits where the module is declared, and it resolves
+either to an equally named module tree or to the module not being there at all.
+
+```
+#[has(bin(grep))]
+text                     lib/text.fast.sh
+text                     lib/text.sh
+```
+
+The `when=` column is retired in favour of this. Two spellings for one idea was
+an extra layer, and the attribute form is the one the rest of the library
+already speaks.
+
+## Why the shell gate cannot move into the file
+
+This is the constraint that decides the shape, and it is worth stating plainly
+because the obvious answer is wrong.
+
+A tool predicate can live inline. `#[has(bin(grep))]` on a function picks an
+implementation, the file parses either way, and nothing is at risk.
+
+A shell predicate cannot. The file it gates contains `[[ ]]` or `declare -A`,
+and a POSIX shell rejects the whole file at parse time, before running a line
+of it. An attribute inside that file is inside the thing that fails to parse.
+So the shell gate has to sit where the module is declared, outside the file it
+is about, and `lib.nut` is that place.
+
+## `bin(...)` rather than a bare argument
+
+`#[has(grep)]` reads well and has to guess what kind of thing `grep` is. The
+predicate already distinguishes three: a binary on `PATH`, an environment
+variable, and the running shell. The inner form says which without ambiguity
+and extends when a fourth appears.
+
+## What the measurements say so far
+
+**Resolving `use` at lower time does not pay.** Both arms loading the same
+surface, `benches/startup`:
+
+| modules | resolved | lowered | |
+|---|---|---|---|
+| 1 | 19 ms | 16 ms | within the noise |
+| 5 | 224 ms | 197 ms | within the noise |
+
+The cost is parsing the files, not finding them. An earlier run of this bench
+reported 217 ms against 15 ms and was wrong: the lowered arm stubbed `use` and
+never loaded the dependencies, so it was doing less work rather than doing it
+faster. The harness refuses that shape now, because `bench_verify` compares the
+whole loaded surface rather than one function's output.
+
+**Two things are not yet measured and are where the win would be.**
+
+Dropping what nobody calls. Of the 76 functions the truncated arm was missing,
+71 were referenced by nothing, so a lowering that keeps only what is reachable
+would parse far less. That is the candidate worth pricing next.
+
+Resolving the lazy dispatch. `nut_lazy_guard`, `nut_reload` and `deps_has` are
+the machinery that picks an implementation at first call, and a lowering knows
+the answer already: it can emit the chosen impl directly and delete the guard.
+Those same names are what broke the ten-module run of this bench, which is the
+problem showing itself rather than a bench defect.
+
+## What lowering has to do that is not obvious
+
+Strip the per-file inclusion guards. `nut_once` answers about the file being
+sourced, and concatenated every file is the same file: the first call registers
+it and every guard after says "already loaded" and returns from the whole
+thing. Found by the lowered arm defining one module and nothing else.
+
+## Visibility is the same pass
+
+Not a second mechanism. The rungs decide the retained set: `#[pub]` from
+anywhere, `#[pub(lib)]` from inside the library, `#[pub(super)]` from the
+parent module, and anything unmarked from its own module only. What is not
+retained is not in the emitted file, which is real unreachability rather than a
+naming convention.
+
+Anything not marked `#[pub]` is private. That is the rule, and it is not the
+leading-underscore convention: 19 functions carry no marker and no underscore
+today, and they read as api.
+
+`#[pub(lib)]` already works end to end and nothing uses it. `attr` parses the
+argument, `modgraph`'s scanner records it, and the audit has the rung.
+`#[pub(super)]` parses and records but the audit treats it as private, because
+nothing yet knows that `super` means the parent in the `::` path.
+
+## Where enforcement is today
+
+The gate catches a private cross-module call, including unmarked and
+underscore-prefixed ones. Runtime catches nothing: `use attr` hands you
+`_attr_name` and it runs, because sourcing fills one namespace.


### PR DESCRIPTION
Documentation and a bench. No code outside `benches/` moves, so nothing you depend on changes.

`docs/LOWERING.md` records where module branching belongs: on the declaration in `lib.nut`, attribute-shaped, the way Rust gates a top level module. A tool predicate can live inline because the file parses either way; a shell predicate cannot, because the file it gates is the file that fails to parse.

`benches/startup` prices resolving `use` at lower time and finds it does not pay: 197 ms against 224 ms at five modules, 16 against 19 at one, within the noise both times. The cost is parsing the files rather than finding them.

An earlier run of that bench said 217 against 15. It was wrong, the arm was doing less work rather than doing it faster, and the correction is committed beside it rather than replacing it.

## Sanity

606 pass. `./check` is nine checks with six warnings.