### PR TITLE
chore: 0.6.2, and the constant that drifted from the tag

### DIFF
--- a/init
+++ b/init
@@ -58,7 +58,7 @@ _NUTSHELL_ROOT="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 
 # Export for use by modules
 export NUTSHELL_ROOT="${_NUTSHELL_ROOT}"
-export NUTSHELL_VERSION="0.6.0"
+export NUTSHELL_VERSION="0.6.2"
 
 # Script identity belongs to the interpreter invocation, not to ancestry. The
 # interpreter exports NUTSHELL_SCRIPT and NUTSHELL_SCRIPT_DIR after this file


### PR DESCRIPTION
`init` said `0.6.0` while the newest tag was `0.6.1`. The 0.6.1 release was documentation and a bench, so I reverted its version bump before merging and the constant stayed behind.

That is the drift `docs/TODO.md` already names as the reason the constant should go: it is a thing somebody has to remember, and forgetting it is silent. Worth noting that a release with nothing else to bump is exactly when it gets forgotten.

0.6.2 also carries `fs.sh` naming its stat implementations literally, which is behaviour-preserving on a path every consumer takes.

## Sanity

610 pass.