### PR TITLE
release: 0.6.2, every dispatch target named literally

### DIFF
--- a/benches/startup/bench.sh
+++ b/benches/startup/bench.sh
@@ -30,7 +30,7 @@
 
 use bench
 
-MODS="${1:-string log fs os toml}"
+MODS="${1:-string log fs os toml validate}"
 
 _ST_TMP="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-st.XXXXXX")"
 trap '[[ -n "${_ST_TMP:-}" ]] && rm -rf "$_ST_TMP"' EXIT
@@ -65,6 +65,22 @@ _st_uses_in() {
             [[ -n "$m" ]] && printf '%s\n' "${m#super::}"
         done
     done < "$file"
+
+    # `nut_reload` targets too. A module reached only by the lazy dispatch is
+    # as much a dependency as one reached by `use`, and following only `use`
+    # left the impl out of the closure: the lowered arm answered nothing for
+    # `fs_size` and the harness refused the run.
+    #
+    # This is possible at all because every one of those is written literally.
+    # Assembled from a variable, as two in `fs.sh` were until today, there is
+    # nothing here to follow.
+    # Anywhere in a non-comment line, not at the start of one: after today's
+    # change `fs.sh`'s are inside a `case` arm, so the line begins
+    # `stat_gnu)` and an anchored pattern finds nothing at all.
+    grep -hE 'nut_reload[[:space:]]' "$file" 2>/dev/null \
+        | grep -vE '^[[:space:]]*#' \
+        | grep -oE 'nut_reload[[:space:]]+"?[^";[:space:]]+' \
+        | sed -e 's/^nut_reload[[:space:]]*//' -e 's/"//g' -e 's/^super:://'
 }
 
 # The closure, in load order: a module's dependencies before the module.
@@ -89,7 +105,25 @@ _st_lower() {
         # nutshell: `nut_once` and `use` have to exist because the files call
         # them, and by this point `use` has nothing left to resolve.
         printf '. "%s/init" >/dev/null 2>&1 || exit 1\n' "$_ST_ROOT"
-        printf 'use() { return 0; }\n'
+        # The lowered file registers what it contains rather than stubbing the
+        # resolver.
+        #
+        # `use() { return 0; }` looks equivalent and is not: `nut_reload` goes
+        # through `use`, so a stub breaks the lazy dispatch. `fs_size` answered
+        # nothing in this arm and the harness refused the run, correctly.
+        #
+        # Registering instead means `use` short-circuits on everything already
+        # here, which is the truthful thing for a lowering to do: inclusion was
+        # decided at lower time and the registry is where that is recorded.
+        # Every registration first, before any body.
+        #
+        # Emitted per module they interleave with the code, and a shake that
+        # keeps the preamble by reading up to the first module marker then
+        # keeps one of them. `fs_size` reached for an impl that nothing had
+        # registered and answered nothing.
+        for m in "${_ST_ORDER[@]}"; do
+            printf '_NUTSHELL_LOADED["%s"]=1\n' "$m"
+        done
         for m in "${_ST_ORDER[@]}"; do
             printf '# --- %s ---\n' "${m#"$_ST_ROOT/"}"
             # The per-file inclusion guard goes.
@@ -104,14 +138,114 @@ _st_lower() {
             # A real lowering strips them for the same reason. Inclusion is
             # decided at lower time; there is nothing left to guard at run
             # time, which is the point.
+            #
+            # And `super::` is rewritten away.
+            #
+            # It resolves relative to the file that wrote the call, through
+            # `BASH_SOURCE[1]`, and concatenated every call comes from the
+            # lowered file. That file is in a temp directory with no manifest
+            # above it, so `super::fs::impl::stat_bsd` resolved to nothing and
+            # `fs_size` failed with a message about a missing `nut.toml`.
+            #
+            # A lowering knows the unit at lower time, which is the whole
+            # point, so it writes the name the resolver can answer instead of
+            # one that depends on where the file ends up.
             sed -e 's/^nut_once || return 0$//' \
-                -e 's/^nut_once || return$//' "$m"
+                -e 's/^nut_once || return$//' \
+                -e 's/super:://g' "$m"
         done
     } > "$_ST_LOWERED"
 }
 
-# Every function defined, sorted. The surface, not one call's answer.
-_ST_PROBE='declare -F | sed "s/^declare -f //" | sort | tr "\n" " "'
+_ST_WORKLOAD="${_ST_ROOT}/benches/startup/workload.sh"
+_ST_SHAKEN="$_ST_TMP/shaken.sh"
+
+# The lowered file with everything unreachable removed.
+#
+# Roots are the names the workload mentions. Then the closure: anything a
+# retained body mentions is retained too. Whatever survives is emitted, the
+# rest is not there at all.
+#
+# It reads names rather than parsing shell, so it over-retains: a name in a
+# comment or a string counts. That is the safe direction, and the number it
+# produces is a floor on what a real pass could drop rather than a claim about
+# what it would.
+#
+# What it cannot do is see a name assembled at run time, which is why every
+# `nut_reload` in this library is written literally. Two in `fs.sh` were not,
+# and a shake would have dropped two of the three stat implementations.
+_st_shake() {
+    local keep; keep="$(
+        bash -c '
+            set -uo pipefail
+            . "$1" >/dev/null 2>&1 || exit 1
+            declare -A BODY=()
+            while IFS= read -r fn; do
+                BODY["$fn"]="$(declare -f "$fn" 2>/dev/null)"
+            done < <(declare -F | sed "s/^declare -f //")
+
+            declare -A KEEP=(); declare -a WORK=()
+            _seed() {
+                local n
+                while IFS= read -r n; do
+                    [ -n "${BODY[$n]:-}" ] || continue
+                    [ -n "${KEEP[$n]:-}" ] && continue
+                    KEEP["$n"]=1; WORK+=("$n")
+                done
+            }
+            _seed < <(grep -ohE "\b[a-z_][a-zA-Z0-9_]*\b" "$2" | sort -u)
+            while [ ${#WORK[@]} -gt 0 ]; do
+                fn="${WORK[0]}"; WORK=("${WORK[@]:1}")
+                _seed < <(printf "%s" "${BODY[$fn]}" | grep -ohE "\b[a-z_][a-zA-Z0-9_]*\b" | sort -u)
+            done
+            printf "%s\n" "${!KEEP[@]}"
+        ' _ "$_ST_LOWERED" "$_ST_WORKLOAD"
+    )"
+
+    # The lowered file with unretained function definitions cut out of it, and
+    # everything else left exactly where it was.
+    #
+    # Filtered rather than rebuilt from `declare -f`. Rebuilt, the result is
+    # functions and nothing else: every module's file-scope initialisation
+    # goes, and `deps.sh` populating its tool table at load time was the one
+    # that showed. `fs_size` then read an empty variant table, chose no impl,
+    # and answered nothing.
+    #
+    # So the unit of shaking is one function definition. Anything outside one
+    # is kept, because nothing here can tell what it was for.
+    # Through a file, not `-v`. An awk variable cannot hold a newline, and the
+    # retained set is one name per line, so `-v` gives `newline in string`.
+    printf '%s\n' "$keep" > "$_ST_TMP/keep.txt"
+
+    awk -v keepfile="$_ST_TMP/keep.txt" '
+        BEGIN { while ((getline line < keepfile) > 0) if (line != "") K[line] = 1 }
+        # A definition starts a block. Depth counts braces until it closes.
+        depth == 0 && match($0, /^[[:space:]]*(function[[:space:]]+)?[a-zA-Z_][a-zA-Z0-9_-]*[[:space:]]*\(\)[[:space:]]*\{?[[:space:]]*$/) {
+            name = $0
+            sub(/^[[:space:]]*/, "", name); sub(/^function[[:space:]]+/, "", name)
+            sub(/[[:space:]]*\(\).*$/, "", name)
+            infn = 1; depth = 0; drop = (name in K) ? 0 : 1
+        }
+        {
+            if (infn) {
+                depth += gsub(/\{/, "{")
+                depth -= gsub(/\}/, "}")
+                if (!drop) print
+                if (depth <= 0) { infn = 0; drop = 0 }
+                next
+            }
+            print
+        }
+    ' "$_ST_LOWERED" > "$_ST_SHAKEN"
+}
+
+# What the workload answers. The arms load the library three ways and this is
+# what says they still do the same thing.
+#
+# Not the loaded surface, which is what the other comparison in this file uses:
+# a shaken arm loads less by design, so comparing surfaces would refuse it for
+# doing exactly what it is for.
+_ST_PROBE='. "'"$_ST_WORKLOAD"'" >/dev/null 2>&1; _wl'
 
 arm_resolved() {
     bash -c '
@@ -126,6 +260,11 @@ arm_lowered() {
         _ "$_ST_LOWERED" "$_ST_PROBE" 2>/dev/null
 }
 
+arm_shaken() {
+    bash -c '. "$1" >/dev/null 2>&1 || exit 1; eval "$2"' \
+        _ "$_ST_SHAKEN" "$_ST_PROBE" 2>/dev/null
+}
+
 # The interpreter and nothing else, so the two above can be read against what
 # is paid before any module is asked for at all.
 arm_init_only() {
@@ -134,6 +273,7 @@ arm_init_only() {
 }
 
 _st_lower
+_st_shake
 
 _answer_of() { "$1"; }
 
@@ -143,6 +283,7 @@ bench_verify _answer_of
 
 bench_arm "resolved through the manifest" arm_resolved
 bench_arm "lowered, use resolved already" arm_lowered
+bench_arm "lowered and shaken"            arm_shaken
 
 bench_run || exit 1
 

--- a/benches/startup/findings.md
+++ b/benches/startup/findings.md
@@ -1,46 +1,71 @@
-# What a lowered form would save at load time
+# What lowering saves at load time
 
-**Not established. The first measurement was not sound and is recorded here so
-nobody quotes it.**
+Three arms, all running the same workload and compared on its answer rather
+than on the loaded surface, because a shaken arm loads less by design.
 
-## The unsound run
+| arm | best ms | against the first |
+|---|---|---|
+| resolved through the manifest | 247 | |
+| lowered, `use` resolved already | 235 | within the noise |
+| lowered and shaken | 67 | **26%** |
 
-    resolved through the manifest    217 ms
-    lowered, one file                 15 ms
-    a bare shell, loading nothing     12 ms
+Reproducible across runs. Six modules, a ten file closure.
 
-Read as written that is the load cost falling from 205 ms to 3 ms. It is not,
-because the two arms did not load the same thing: the resolved arm defined 165
-functions and the lowered arm 90.
+## The answer
 
-The lowered arm concatenates the modules named on the command line and stubs
-`use` to a no-op, so a module reaching for its own dependencies at load time
-gets nothing. The resolved arm loads those dependencies for real. So part of
-the gap is the lowered arm doing less work rather than doing it faster.
+**Resolving `use` ahead of time does not pay.** Twelve milliseconds in two
+hundred and fifty, and the harness reports it as noise. The cost is parsing the
+files, not finding them.
 
-The direction is almost certainly right. Every `use` resolves through
-`_lib_nut_lookup`, every caller of that wraps it in a command substitution, and
-a fork is not cheap. But the size of it is unmeasured.
+**Dropping what nothing calls does.** 3.7x, and it is the whole of the win.
+Statically, for one real program, 24 of the 165 functions it loads are
+reachable and 141 are not.
 
-## What a sound version needs
+So the lowering worth building is a shaker. The resolution half is a
+simplification rather than an optimisation and should be argued for on those
+grounds if at all.
 
-The arms have to load the same set. Two ways, and the second is better:
+## Four things a lowering has to do, each found by getting it wrong
 
-- Expand the module list to the transitive closure before concatenating, so
-  both arms end with the same functions defined. Straightforward and still
-  hand-rolled.
-- Have the lowering resolve `use` itself rather than stubbing it, which is what
-  a real lowering does anyway. Then the arms are the same program by
-  construction and the bench prices the thing rather than a sketch of it.
+**Strip the per-file inclusion guards.** `nut_once` answers about the file
+being sourced, and concatenated every file is the same file: the first call
+registers it and every guard after says "already loaded" and returns from the
+whole thing. The lowered arm defined one module and nothing else.
 
-Either way the harness will refuse a run whose arms disagree once they are
-asked the right question, which is `bench_verify` over the loaded surface
-rather than over one function's output. The current verify calls `str_upper`,
-which both arms answer identically while differing by 75 functions.
+**Register what it contains rather than stubbing the resolver.**
+`use() { return 0; }` looks equivalent and is not, because `nut_reload` goes
+through `use`. `fs_size` answered nothing.
 
-## What is not in question
+**Rewrite `super::` away.** It resolves relative to the file that wrote the
+call, through `BASH_SOURCE[1]`, and concatenated every call comes from the
+lowered file. In a temp directory with no manifest above it, that resolves to
+nothing. A lowering knows the unit at lower time, which is the point.
 
-That the resolved path forks per module. That is structural: `_lib_nut_lookup`
-prints its answer and all five call sites capture it with `$( )`.
-`benches/module-resolve` prices a predicated row against a plain one and names
-this as the larger cost sitting underneath both.
+**Shake by cutting definitions out of the file, not by rebuilding from
+`declare -f`.** Rebuilt, the result is functions and nothing else: every
+module's file-scope initialisation goes. `deps.sh` populating its tool table at
+load time was the one that showed, and `fs_size` then read an empty variant
+table and chose no implementation.
+
+## What the shaker here is, and is not
+
+It reads names rather than parsing shell, so a name in a comment or a string
+counts as a use. That over-retains, which is the safe direction, and makes 26%
+a **floor** on what a real pass could reach rather than a claim about what it
+would.
+
+What it cannot see is a name assembled at run time. Every `nut_reload` in this
+library is written literally for exactly that reason; two in `fs.sh` were not
+until today, and a shake would have kept one of the three stat implementations
+and dropped two, failing at first call on whichever machine has the other
+`stat`.
+
+The closure follows `nut_reload` targets as well as `use`. Following only `use`
+left the impl modules out and the harness refused the run.
+
+## What is not measured
+
+Whether the shake is safe for a program whose call graph is not visible: a
+caller reaching a library function through a variable, or a task file loaded by
+name at run time. hulilupteri does the second, so the number here does not
+transfer to it without checking that first.

--- a/benches/startup/results/20260827071443.csv
+++ b/benches/startup/results/20260827071443.csv
@@ -1,0 +1,4 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+resolved through the manifest,251,281,within the noise,yes
+lowered  use resolved already,235,263,within the noise,yes
+lowered and shaken,67,86,26%,yes

--- a/benches/startup/results/20260827071443.meta
+++ b/benches/startup/results/20260827071443.meta
@@ -1,0 +1,7 @@
+case      What a lowered form saves at load time
+size      10
+repeats   7
+baseline  resolved through the manifest
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T04:14:43Z

--- a/benches/startup/results/20260827071458.csv
+++ b/benches/startup/results/20260827071458.csv
@@ -1,0 +1,4 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+resolved through the manifest,246,259,within the noise,yes
+lowered  use resolved already,234,246,within the noise,yes
+lowered and shaken,67,79,27%,yes

--- a/benches/startup/results/20260827071458.meta
+++ b/benches/startup/results/20260827071458.meta
@@ -1,0 +1,7 @@
+case      What a lowered form saves at load time
+size      10
+repeats   7
+baseline  resolved through the manifest
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T04:14:58Z

--- a/benches/startup/results/20260827071503.csv
+++ b/benches/startup/results/20260827071503.csv
@@ -1,0 +1,4 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+resolved through the manifest,247,271,within the noise,yes
+lowered  use resolved already,235,259,within the noise,yes
+lowered and shaken,66,75,26%,yes

--- a/benches/startup/results/20260827071503.meta
+++ b/benches/startup/results/20260827071503.meta
@@ -1,0 +1,7 @@
+case      What a lowered form saves at load time
+size      10
+repeats   7
+baseline  resolved through the manifest
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T04:15:03Z

--- a/benches/startup/results/20260827071509.csv
+++ b/benches/startup/results/20260827071509.csv
@@ -1,0 +1,4 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+resolved through the manifest,247,265,within the noise,yes
+lowered  use resolved already,234,256,within the noise,yes
+lowered and shaken,66,95,26%,yes

--- a/benches/startup/results/20260827071509.meta
+++ b/benches/startup/results/20260827071509.meta
@@ -1,0 +1,7 @@
+case      What a lowered form saves at load time
+size      10
+repeats   7
+baseline  resolved through the manifest
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T04:15:09Z

--- a/benches/startup/workload.sh
+++ b/benches/startup/workload.sh
@@ -1,0 +1,27 @@
+# A slice of real work, run identically by every arm.
+#
+# The arms load the library three different ways and this is what says they
+# still do the same thing. It has to touch enough of the surface that a shaker
+# dropping something needed shows up here rather than in a later run: strings,
+# the filesystem, a toml read, validation and the log.
+_wl() {
+    local d f out=""
+    d="$(fs_temp_dir wl)" || return 1
+    f="$d/x.toml"
+    printf 'name = "thing"\n[sec]\nkey = "v"\n' > "$f"
+
+    out+="$(str_upper "$(str_trim "  hello  ")")|"
+    out+="$(str_replace 'a*b' '*' '+')|"
+    out+="$(str_join , a b c)|"
+    out+="$(str_distance build buidl)|"
+    out+="$(toml_get "$f" name)|"
+    out+="$(toml_get "$f" sec.key)|"
+    out+="$(fs_basename "$f")|"
+    out+="$(fs_extension "$f")|"
+    out+="$([ -n "$(fs_size "$f")" ] && echo sized)|"
+    out+="$(is_integer 42 && echo int)|"
+    out+="$(is_email a@b.c && echo mail)|"
+    out+="$(os_name)|"
+    rm -rf "$d"
+    printf '%s' "$out"
+}

--- a/init
+++ b/init
@@ -58,7 +58,7 @@ _NUTSHELL_ROOT="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 
 # Export for use by modules
 export NUTSHELL_ROOT="${_NUTSHELL_ROOT}"
-export NUTSHELL_VERSION="0.6.0"
+export NUTSHELL_VERSION="0.6.2"
 
 # Script identity belongs to the interpreter invocation, not to ancestry. The
 # interpreter exports NUTSHELL_SCRIPT and NUTSHELL_SCRIPT_DIR after this file

--- a/lib/fs.sh
+++ b/lib/fs.sh
@@ -277,14 +277,28 @@ fs_size() {
         impl="perl_stat"
     fi
     
-    if [[ -n "$impl" ]]; then
-        # Named, not sourced by an assembled path. The resolver knows where
-        # the module is, loads it once however many callers arrive, and the
-        # declaration covers it; a hand-rolled `source` has none of that, and
-        # fails at the moment it is reached rather than before the run.
-        nut_reload "super::fs::impl::${impl}"
-    else
-        # No tool available
+    # Written out rather than assembled from `$impl`.
+    #
+    # Named, not sourced by a path: the resolver knows where the module is,
+    # loads it once however many callers arrive, and the declaration covers
+    # it. That part was already right.
+    #
+    # What was not: `nut_reload "super::fs::impl::${impl}"` builds the name at
+    # run time, so nothing reading this file can tell which modules it can
+    # reach. Every other dispatch in the library is literal, thirteen of them
+    # in `text.sh` alone, and these two were the only ones that were not. A
+    # pass that drops what nothing calls would drop two of these three and
+    # fail at first call on whichever machine has the other `stat`.
+    #
+    # The set is closed and has three members, so writing them out costs four
+    # lines and makes the whole library statically readable.
+    case "$impl" in
+        stat_gnu)  nut_reload super::fs::impl::stat_gnu ;;
+        stat_bsd)  nut_reload super::fs::impl::stat_bsd ;;
+        perl_stat) nut_reload super::fs::impl::perl_stat ;;
+    esac
+
+    if [[ -z "$impl" ]]; then
         fs_size() {
             echo "[ERROR] fs_size: no stat tool available" >&2
             return 1
@@ -324,13 +338,28 @@ fs_mtime() {
         impl="perl_stat"
     fi
     
-    if [[ -n "$impl" ]]; then
-        # Named, not sourced by an assembled path. The resolver knows where
-        # the module is, loads it once however many callers arrive, and the
-        # declaration covers it; a hand-rolled `source` has none of that, and
-        # fails at the moment it is reached rather than before the run.
-        nut_reload "super::fs::impl::${impl}"
-    else
+    # Written out rather than assembled from `$impl`.
+    #
+    # Named, not sourced by a path: the resolver knows where the module is,
+    # loads it once however many callers arrive, and the declaration covers
+    # it. That part was already right.
+    #
+    # What was not: `nut_reload "super::fs::impl::${impl}"` builds the name at
+    # run time, so nothing reading this file can tell which modules it can
+    # reach. Every other dispatch in the library is literal, thirteen of them
+    # in `text.sh` alone, and these two were the only ones that were not. A
+    # pass that drops what nothing calls would drop two of these three and
+    # fail at first call on whichever machine has the other `stat`.
+    #
+    # The set is closed and has three members, so writing them out costs four
+    # lines and makes the whole library statically readable.
+    case "$impl" in
+        stat_gnu)  nut_reload super::fs::impl::stat_gnu ;;
+        stat_bsd)  nut_reload super::fs::impl::stat_bsd ;;
+        perl_stat) nut_reload super::fs::impl::perl_stat ;;
+    esac
+
+    if [[ -z "$impl" ]]; then
         fs_mtime() {
             echo "[ERROR] fs_mtime: no stat tool available" >&2
             return 1

--- a/tests/dispatch_is_static_test.sh
+++ b/tests/dispatch_is_static_test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Tests that every module this library loads at run time can be named by
+# reading the source.
+#
+# `nut_reload` picks an implementation at first call. Written literally,
+# `nut_reload super::text::impl::grep_match`, anything reading the file can
+# tell which modules that call site can reach. Written as
+# `nut_reload "super::fs::impl::${impl}"` it cannot, and the name only exists
+# once the branch above it has run.
+#
+# That matters for one specific thing. A pass that keeps only what something
+# calls, which is where the load-time win is, has to see every reachable
+# module. `fs.sh` had two assembled call sites over a closed set of three, so
+# such a pass would have kept one and dropped two, and the failure lands at
+# first call on whichever machine has the other `stat`.
+#
+# Thirteen of the fifteen call sites were already literal. These two were the
+# whole of the exception.
+
+use test
+
+ROOT="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+
+# Every `nut_reload` call site, as written.
+# Comment lines are dropped first. Without that this reads the prose in
+# `fs.sh` explaining what the assembled form was and reports it as an
+# assembled form, which is the test failing on its own documentation.
+_dis_sites() {
+    grep -rhE 'nut_reload' \
+        "$ROOT"/lib/*.sh "$ROOT"/lib/*/*.sh "$ROOT"/lib/*/*/*.sh 2>/dev/null \
+        | grep -vE '^[[:space:]]*#' \
+        | grep -oE 'nut_reload[[:space:]]+"?[^";]*"?' \
+        | sed 's/^nut_reload[[:space:]]*//'
+}
+
+# The ones whose argument is built rather than written.
+_dis_assembled() {
+    _dis_sites | grep -E '\$' || true
+}
+
+#[test]
+it_finds_dispatch_sites_to_check() {
+    # The control. A pattern that matched nothing would make the test below
+    # pass over a library full of assembled names.
+    local n; n="$(_dis_sites | grep -c . || true)"
+    assert_ne "$n" "0"
+    assert_ne "$n" ""
+    # And it has to be finding the real ones.
+    assert_contains "$(_dis_sites)" "super::text::impl::grep_match"
+}
+
+#[test]
+it_names_every_dispatch_target_literally() {
+    local bad; bad="$(_dis_assembled)"
+    assert_empty "$bad"
+}
+
+#[test]
+it_reaches_every_stat_implementation_the_manifest_declares() {
+    # The other half: literal is not enough if the set written out is smaller
+    # than the set that exists. Every `fs::impl::` module the manifest declares
+    # has to appear at a call site, or a machine needing it silently gets the
+    # no-tool stub.
+    local m missing=""
+    while IFS= read -r m; do
+        [[ -n "$m" ]] || continue
+        grep -q "super::${m}" <<<"$(_dis_sites)" || missing+="${m} "
+    done < <(awk '$1 ~ /^fs::impl::/ {print $1}' "$ROOT/lib.nut")
+    assert_empty "$missing"
+}
+
+#[test]
+it_still_answers_for_a_real_file() {
+    # The control for the two above. Rewriting the dispatch and breaking it
+    # would satisfy both of them, since neither calls anything.
+    local size mtime
+    size="$(fs_size "$ROOT/init")"
+    mtime="$(fs_mtime "$ROOT/init")"
+    assert_ok test "$size" -gt 0
+    assert_ok test "$mtime" -gt 0
+}


### PR DESCRIPTION
## `fs.sh` names its stat implementations instead of assembling the name

```
-  nut_reload "super::fs::impl::${impl}"
+  case "$impl" in
+      stat_gnu)  nut_reload super::fs::impl::stat_gnu ;;
+      stat_bsd)  nut_reload super::fs::impl::stat_bsd ;;
+      perl_stat) nut_reload super::fs::impl::perl_stat ;;
+  esac
```

Behaviour-preserving, on a path every consumer takes. The reason is that nothing reading the old form could tell which modules that call site reaches, and thirteen of the fifteen `nut_reload` sites in the library were already literal. These two were the whole of the exception.

## And a version constant that had drifted

`init` said `0.6.0` while the newest tag was `0.6.1`. The 0.6.1 release was documentation, so its version bump was reverted before merging and the constant stayed behind. Both say `0.6.2` now.

## The benches, for anyone reading the tree

`benches/startup` now answers what lowering saves, and the answer decides a design:

| arm | best ms | |
|---|---|---|
| resolved through the manifest | 247 | |
| lowered, `use` resolved already | 235 | within the noise |
| lowered and shaken | 67 | 26% |

Resolving `use` ahead of time does not pay. Dropping what nothing calls is 3.7x. Findings and the four constraints on a lowering are beside the numbers.

## Sanity

610 pass. `./check` is nine checks with six warnings.