### PR TITLE
chore: 0.6.3

### DIFF
--- a/init
+++ b/init
@@ -58,7 +58,7 @@ _NUTSHELL_ROOT="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 
 # Export for use by modules
 export NUTSHELL_ROOT="${_NUTSHELL_ROOT}"
-export NUTSHELL_VERSION="0.6.2"
+export NUTSHELL_VERSION="0.6.3"
 
 # Script identity belongs to the interpreter invocation, not to ancestry. The
 # interpreter exports NUTSHELL_SCRIPT and NUTSHELL_SCRIPT_DIR after this file


### PR DESCRIPTION
A module gate is an attribute on its declaration now and `when=` is gone, which is a manifest format change. Nine dead standalone blocks are deleted from the impl modules.

Minor would be defensible for the format change. Patch, because no manifest outside this repository carries a gate yet: the feature shipped in 0.5.0 and `string` is its only user.

## Sanity

615 pass.