### PR TITLE
feat: the package declares itself, and stop selling it

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -596,11 +596,11 @@ fs_exists() {
 
 ### Config Templates
 
-| Template | Philosophy |
+| Template | What it sets |
 |----------|------------|
 | `empty.nut.toml` | All disabled, fully documented (schema reference) |
 | `default.nut.toml` | Sensible defaults, catches obvious issues |
-| `tough.nut.toml` | No compromises, no technical debt |
+| `tough.nut.toml` | Every gate on, every threshold at its tightest |
 
 ## Error Handling
 

--- a/examples/checks/check_config_schema.sh
+++ b/examples/checks/check_config_schema.sh
@@ -22,21 +22,32 @@ use check-runner
 # =============================================================================
 
 # Valid top-level sections
-VALID_SECTIONS="meta paths deps annotations tests output"
+VALID_SECTIONS="package lib bin meta paths deps annotations tests output qa"
 
 # Valid keys per section
 declare -A VALID_KEYS
+# What the package is. The fields cargo, npm and deno all agree on, because a
+# manifest that invents its own vocabulary makes every reader learn it.
+VALID_KEYS[package]="name version description license repository homepage documentation keywords authors readme"
+# The library entry point, cargo's shape.
+VALID_KEYS[lib]="path"
+# Command name to the file behind it, package.json's shape.
+VALID_KEYS[bin]="*"
 VALID_KEYS[meta]="version name description"
+# Custom checks, which the runner has read since before this list existed and
+# which warned on every project that used one.
+VALID_KEYS[qa]="custom_checks run_builtins"
 VALID_KEYS[paths]="lib_dir exclude include"
 VALID_KEYS[deps.paths]="*"  # Any tool name allowed
 VALID_KEYS[annotations]="public_api allow_trivial_wrapper_ergonomics allow_large_file"
-VALID_KEYS[tests]="syntax trivial_wrappers file_size function_duplication cruft public_api_docs"
+VALID_KEYS[tests]="syntax trivial_wrappers file_size function_duplication cruft public_api_docs posix_floor module_contract config_schema"
 VALID_KEYS[tests.syntax]="shell fail_on_error"
 VALID_KEYS[tests.trivial_wrappers]="max_lines local_usage_threshold global_usage_threshold min_vars_for_ergonomic token_complexity_warn token_complexity_pass warn_threshold fail_threshold exempt_annotations exclude_patterns"
 VALID_KEYS[tests.file_size]="max_loc max_total_lines exempt_annotation_pattern exempt_patterns"
 VALID_KEYS[tests.function_duplication]="similarity_threshold min_lines_to_check ignore_name_patterns exclude_patterns"
 VALID_KEYS[tests.cruft]="debug_patterns todo_patterns fail_on_debug fail_on_todo max_todos"
 VALID_KEYS[tests.public_api_docs]="public_api_annotation required_elements recommended_elements min_doc_lines"
+VALID_KEYS[tests.posix_floor]="shell max_unreadable exempt"
 VALID_KEYS[output]="color verbosity format show_passing show_summary"
 
 # Valid enum values

--- a/examples/configs/tough.nut.toml
+++ b/examples/configs/tough.nut.toml
@@ -4,14 +4,16 @@
 # Part of nutshell - Everything you need, in a nutshell.
 # https://github.com/orgrinrt/nutshell
 #
-# This is the TOUGH template - strict conventions for high-quality codebases.
-# No compromises. No technical debt. No cutting corners.
+# The tough template. Every gate on, every threshold at the tightest value the
+# checks offer.
 #
-# Use this if you believe in:
-#   - Code quality over velocity
-#   - Preventing problems over fixing them
-#   - Self-documenting code
-#   - Small, focused modules
+# What that means in practice: a file over 300 lines of code fails, a public
+# function without a `Usage:` line fails, two functions whose names score above
+# 0.85 similar fail, and a `TODO` is a finding rather than a note.
+#
+# Pick it when a failing gate is what you want from a gate. The default
+# template is the same checks at values a codebase can adopt without a week of
+# work first.
 #
 # For gentler defaults, see: default.nut.toml
 # For all options documented: empty.nut.toml
@@ -20,7 +22,7 @@
 [meta]
 version = "1.0.0"
 name = "Tough Configuration"
-description = "Strict conventions. No compromises. No technical debt."
+description = "Every gate on, every threshold at its tightest."
 
 # -----------------------------------------------------------------------------
 # Paths

--- a/find-nutshell
+++ b/find-nutshell
@@ -611,9 +611,41 @@ _nutshell_adopt() {
 # The version an interpreter reports, without loading it. Reading the file
 # rather than sourcing it, because a candidate that is about to be rejected must
 # not be allowed to run first.
+#
+# From `nut.toml`'s `[package] version`, beside the `init` it was handed. The
+# version used to be a constant in `init` that somebody had to remember to
+# bump, and forgetting it is silent: this repository shipped a tag whose
+# constant said the release before it.
+#
+# `init` is still accepted as a fallback, because a toolchain fetched by an
+# older nutshell has no `[package]` section and the store is full of them.
+# Dropping that would make every existing entry unreadable rather than merely
+# older.
 _nutshell_version_of() {
     local init="$1" line
     [[ -r "$init" ]] || return 1
+
+    local manifest="${init%/init}/nut.toml"
+    if [[ -r "$manifest" ]]; then
+        local in_pkg=0
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            case "$line" in
+                \[package\]*) in_pkg=1; continue ;;
+                \[*\]*)       in_pkg=0; continue ;;
+            esac
+            [[ "$in_pkg" -eq 1 ]] || continue
+            case "$line" in
+                version*=*)
+                    line="${line#*=}"
+                    line="${line#"${line%%[![:space:]]*}"}"
+                    line="${line#[\"\']}"
+                    line="${line%%[!0-9.]*}"
+                    [[ -n "$line" ]] || continue
+                    printf '%s' "$line"; return 0 ;;
+            esac
+        done < "$manifest"
+    fi
+
     while IFS= read -r line || [[ -n "$line" ]]; do
         case "$line" in
             *NUTSHELL_VERSION=*)
@@ -623,7 +655,9 @@ _nutshell_version_of() {
                 # and answer with nothing.
                 line="${line#[\"\']}"
                 line="${line%%[!0-9.]*}"
-                [[ -n "$line" ]] || continue
+                # The reader in `init` itself is a command substitution now, so
+                # the line there is not a literal and must not be read as one.
+                case "$line" in ""|*[!0-9.]*) continue ;; esac
                 printf '%s' "$line"; return 0 ;;
         esac
     done < "$init"

--- a/init
+++ b/init
@@ -58,7 +58,37 @@ _NUTSHELL_ROOT="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 
 # Export for use by modules
 export NUTSHELL_ROOT="${_NUTSHELL_ROOT}"
-export NUTSHELL_VERSION="0.6.3"
+# Read from the manifest rather than written here.
+#
+# It was a constant somebody had to remember to bump, and forgetting it is
+# silent: `init` said 0.6.0 while the newest tag was 0.6.1, because that
+# release was documentation and its bump got reverted before merging. A
+# release with nothing else to change is exactly when it is forgotten.
+#
+# Read as text, not through the toml module, because this runs before any
+# module is loaded and the parser is itself a module. One key, one shape.
+_nutshell_read_version() {
+    local f="${_NUTSHELL_ROOT}/nut.toml" line in_pkg=0
+    [ -r "$f" ] || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            \[package\]*) in_pkg=1; continue ;;
+            \[*\]*)       in_pkg=0; continue ;;
+        esac
+        [ "$in_pkg" -eq 1 ] || continue
+        case "$line" in
+            version*=*)
+                line="${line#*=}"
+                line="${line#"${line%%[![:space:]]*}"}"
+                line="${line#[\"\']}"
+                line="${line%%[!0-9.]*}"
+                [ -n "$line" ] || continue
+                printf '%s' "$line"; return 0 ;;
+        esac
+    done < "$f"
+    return 1
+}
+export NUTSHELL_VERSION="$(_nutshell_read_version 2>/dev/null)"
 
 # Script identity belongs to the interpreter invocation, not to ancestry. The
 # interpreter exports NUTSHELL_SCRIPT and NUTSHELL_SCRIPT_DIR after this file

--- a/nut.toml
+++ b/nut.toml
@@ -4,27 +4,54 @@
 # Part of nutshell - Everything you need, in a nutshell.
 # https://github.com/orgrinrt/nutshell
 #
-# This is the TOUGH template - strict conventions for high-quality codebases.
-# No compromises. No technical debt. No cutting corners.
+# The tough template. Every gate on, every threshold at the tightest value the
+# checks offer.
 #
-# Use this if you believe in:
-#   - Code quality over velocity
-#   - Preventing problems over fixing them
-#   - Self-documenting code
-#   - Small, focused modules
+# What that means in practice: a file over 300 lines of code fails, a public
+# function without a `Usage:` line fails, two functions whose names score above
+# 0.85 similar fail, and a `TODO` is a finding rather than a note.
+#
+# Pick it when a failing gate is what you want from a gate. The default
+# template is the same checks at values a codebase can adopt without a week of
+# work first.
 #
 # For gentler defaults, see: examples/configs/default.nut.toml
 # For all options documented: examples/configs/empty.nut.toml
 # =============================================================================
 
+# -----------------------------------------------------------------------------
+# What this package is
+# -----------------------------------------------------------------------------
+# Its own section, because `[meta]` is about this file and this is about the
+# thing the file describes. A review read `[meta] version` as nutshell's twice,
+# and it is the schema's.
+#
+# The fields are the ones cargo, npm and deno all agree on, because a package
+# manifest that invents its own vocabulary makes every reader learn it: name,
+# version, description, license, repository, keywords. `[lib]` and `[bin]` are
+# cargo's shape, and `[bin]` is a map the way package.json's is.
+[package]
+name = "nutshell"
+version = "0.6.3"
+description = "A bash library: modules with a manifest, a QA gate, and dependency resolution."
+license = "MPL-2.0"
+repository = "https://github.com/orgrinrt/nutshell"
+keywords = ["bash", "shell", "posix", "library", "modules"]
+
+# The library entry point: the file that says what this package provides, the
+# way `src/lib.rs` does for a crate.
+[lib]
+path = "lib.nut"
+
+# Command name to the file behind it.
+[bin]
+nutshell = "bin/nutshell"
+
 [meta]
-# The schema's version, not nutshell's. `examples/configs/empty.nut.toml` says
-# so where the field is documented, and a review read it as a third claim about
-# what nutshell is, next to `init`'s constant and the newest tag. Said here so
-# the next reader does not have to go and check.
+# The schema's version, not this package's. That is `[package] version` above.
 version = "1.0.0"
 name = "nutshell"
-description = "Everything you need, in a nutshell. Strict conventions, no compromises."
+description = "A bash library: modules with a manifest, a QA gate, and dependency resolution."
 
 # -----------------------------------------------------------------------------
 # Paths

--- a/tests/bench_test.sh
+++ b/tests/bench_test.sh
@@ -22,9 +22,20 @@ _bench_fresh() {
 _bench_done() { rm -rf "$BENCH_RESULTS"; unset BENCH_RESULTS; }
 
 # Two arms that agree, and one that does not.
-_arm_a()      { printf 'the same'; }
-_arm_b()      { printf 'the same'; }
-_arm_liar()   { printf 'something else'; }
+#
+# Each does enough work to be measurable. Written as a bare `printf` they take
+# zero milliseconds, and the harness refuses a baseline of zero because nothing
+# can be a ratio against it. That is the guard working, and it made
+# `it_measures_two_arms_that_agree` fail about one run in ten: passing on its
+# own, failing inside the full suite where the machine is busier.
+_spin() {
+    local i s=0
+    for (( i = 0; i < 3000; i++ )); do s=$(( s + i )); done
+    printf '%s' "$1"
+}
+_arm_a()      { _spin 'the same'; }
+_arm_b()      { _spin 'the same'; }
+_arm_liar()   { _spin 'something else'; }
 _answer_of()  { "$1"; }
 
 # --- it measures at all ------------------------------------------------------

--- a/tests/lib_nut_test.sh
+++ b/tests/lib_nut_test.sh
@@ -7,7 +7,7 @@
 # name would fail, and the failure arrived mid-run under `set -eo pipefail`
 # with nothing to read.
 
-use extern test
+use extern test toml
 
 DECLARE="${BASH_SOURCE[0]%/*}/../bin/nut-declare"
 ROOT_DIR="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
@@ -448,4 +448,50 @@ PROBE
     local out; out="$(NUT_ROOT="$ROOT_DIR" bash "$f" 2>&1)"
     rm -f "$f"
     assert_ok grep -q 'COUNT=1' <<<"$out"
+}
+
+# --- the package declares its own version ------------------------------------
+#
+# It was a constant in `init` that somebody had to remember to bump, and
+# forgetting it is silent: this repository shipped a tag whose constant named
+# the release before it, because that release was documentation and its bump
+# got reverted before merging. A release with nothing else to change is
+# exactly when it gets forgotten.
+
+#[test]
+it_reads_the_version_from_the_package_section() {
+    local v; v="$(toml_get "$ROOT_DIR/nut.toml" package.version)"
+    assert_ne "$v" ""
+    assert_eq "$NUTSHELL_VERSION" "$v"
+}
+
+#[test]
+it_does_not_read_the_schema_version_as_the_packages() {
+    # `[meta] version` is the schema's and a review read it as nutshell's
+    # twice. The two have to be able to differ, and here they do.
+    local pkg schema
+    pkg="$(toml_get "$ROOT_DIR/nut.toml" package.version)"
+    schema="$(toml_get "$ROOT_DIR/nut.toml" meta.version)"
+    assert_ne "$pkg" "$schema"
+    assert_eq "$NUTSHELL_VERSION" "$pkg"
+}
+
+#[test]
+it_declares_the_metadata_a_package_manifest_carries() {
+    # The fields cargo, npm and deno all agree on. A manifest that invents its
+    # own vocabulary makes every reader learn it.
+    local k
+    for k in name version description license repository; do
+        assert_ne "$(toml_get "$ROOT_DIR/nut.toml" "package.$k")" "" "package.$k"
+    done
+    assert_ne "$(toml_get "$ROOT_DIR/nut.toml" lib.path)" ""
+    assert_ne "$(toml_get "$ROOT_DIR/nut.toml" bin.nutshell)" ""
+}
+
+#[test]
+it_points_at_files_that_are_there() {
+    # A manifest naming an entry point that does not exist is worse than one
+    # naming none: a reader trusts it.
+    assert_ok test -f "$ROOT_DIR/$(toml_get "$ROOT_DIR/nut.toml" lib.path)"
+    assert_ok test -f "$ROOT_DIR/$(toml_get "$ROOT_DIR/nut.toml" bin.nutshell)"
 }


### PR DESCRIPTION
Three things you called, in one change because they are all the manifest describing the package.

## The version comes from `nut.toml`

It was a constant in `init` that somebody had to remember to bump, and forgetting it is silent. This repository shipped a tag whose constant named the release before it, because that release was documentation and its bump got reverted before merging. A release with nothing else to change is exactly when it gets forgotten.

```toml
[package]
version = "0.6.3"
```

Its own section, because `[meta]` is about the file and this is about the thing the file describes. A review read `[meta] version` as nutshell's twice, and it is the schema's.

Read as text in both places that need it rather than through the toml module, because `init` runs before any module is loaded and `find-nutshell` runs before nutshell exists. `find-nutshell` still falls back to `init`'s constant: a toolchain fetched by an older nutshell has no `[package]` section and the store is full of them.

## And the rest of the metadata with it

`name`, `description`, `license`, `repository`, `keywords`, plus `[lib] path` and `[bin]`. Those are the fields cargo, npm and deno all agree on, and a manifest that invents its own vocabulary makes every reader learn it.

`check_config_schema` knew none of those sections. It also did not know `posix_floor`, `module_contract`, `config_schema` or `qa` — so a project using a custom check was warned at on every run, which is a warning that trains people to ignore warnings.

## The description was marketing

`"Strict conventions, no compromises."` And the tough template's header ran to `"No compromises. No technical debt. No cutting corners."` followed by four things to believe in.

The rules forbid exactly that, and it had been sitting there since before any of them applied. It says what the template *sets* now: every gate on, every threshold at its tightest, and what that means in practice — a file over 300 lines fails, a public function without a `Usage:` line fails.

Six lines across three files. I grepped the whole banned list across all three repositories afterwards; the only other hits are LUKS unlocking.

## And a flaky test, found by the full run

`it_measures_two_arms_that_agree` failed about one run in ten: passing alone, failing inside the suite where the machine is busier. Its arms were a bare `printf`, so the baseline measured zero milliseconds, and `bench_run` refuses a baseline of zero because nothing can be a ratio against it. The guard was right; the test was asking it to divide by nothing.

## Sanity

619 pass, was 615. Three full runs green, where before it took two or three to see the failure.

| mutation | dies |
|---|---|
| version back to a constant in `init` | both version tests |