### PR TITLE
feat: containers that work without bash arrays, and the first files onto the floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,9 @@ use os log json http
 | `deps` | Tool detection (`deps_has`, `deps_require`, `deps_path`) |
 | `fs` | Filesystem (`fs_exists`, `fs_mkdir`, `fs_temp_file`, `fs_size`) |
 | `string` | String manipulation (`str_upper`, `str_lower`, `str_trim`, `str_contains`) |
-| `array` | Array operations (`arr_contains`, `arr_unique`, `arr_length`) |
+| `array` | Operations over a list of arguments (`arr_contains`, `arr_index`, `arr_filter`), and over a `list` in place (`arr_unique`, `arr_reverse`, `arr_sort`) |
+| `list` | An ordered list that needs no bash array (`list_push`, `list_get`, `list_each`, `list_len`) |
+| `map` | A key to value table that needs no associative array (`map_set`, `map_get`, `map_has`, `map_keys`) |
 | `text` | Text processing (`text_grep`, `text_replace`, `text_count_matches`) |
 | `json` | JSON parsing (`json_get`, `json_set`, `json_valid`, `json_pretty`) |
 | `http` | HTTP requests (`http_get`, `http_post`, `http_download`) |

--- a/benches/array-api/bench.sh
+++ b/benches/array-api/bench.sh
@@ -53,18 +53,37 @@ a newline in it' ;;
 # The arms. Each appends ELEMS elements, walks all of them accumulating a
 # checksum, indexes LOOKUPS of them, and reports the length, so nothing can be
 # optimised away by going unused and a mangled element shows up in the sum.
+#
+# The checksum is a rolling one rather than a total, because a total is
+# order-blind: an arm that stores the list backwards and never notices reports
+# the same sum of lengths as one that gets it right. `sum * 31 + len` does not,
+# which matters here because one arm below builds the list by prepending and
+# has to undo that to be correct.
 # -----------------------------------------------------------------------------
+
+CHUNK=64   # elements per rope chunk
+
+_ck() { _SUM=$(( (_SUM * 31 + ${#1}) & 0x3fffffff )); }
 
 # A: bash indexed array. The thing being given up.
 arm_bash_array() {
     local -a a=()
-    local i sum=0 e
+    local i e; _SUM=0
     for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; a+=("$_E"); done
-    for e in "${a[@]}"; do sum=$(( sum + ${#e} )); done
-    for (( i = 0; i < LOOKUPS; i++ )); do
-        e="${a[$(( i * ELEMS / LOOKUPS ))]}"; sum=$(( sum + ${#e} ))
-    done
-    printf '%s|%s' "$sum" "${#a[@]}"
+    for e in "${a[@]}"; do _ck "$e"; done
+    for (( i = 0; i < LOOKUPS; i++ )); do _ck "${a[$(( i * ELEMS / LOOKUPS ))]}"; done
+    printf '%s|%s' "$_SUM" "${#a[@]}"
+}
+
+# A2: the same, assigning by index rather than appending. Whether bash's `+=`
+#     is its own fast path or the same operation spelled shorter.
+arm_bash_by_index() {
+    local -a a=()
+    local i e; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; a[i]="$_E"; done
+    for e in "${a[@]}"; do _ck "$e"; done
+    for (( i = 0; i < LOOKUPS; i++ )); do _ck "${a[$(( i * ELEMS / LOOKUPS ))]}"; done
+    printf '%s|%s' "$_SUM" "${#a[@]}"
 }
 
 # B: one variable per slot, addressed by number through eval.
@@ -74,15 +93,61 @@ arm_bash_array() {
 #    roughly 1.3x for reads under the name `slots by index`; what it costs for
 #    an append and a walk is what this arm is for.
 arm_slots() {
-    local i sum=0 e n=0
+    local i e n=0; _SUM=0
     for (( i = 0; i < ELEMS; i++ )); do
         _elem "$i"; eval "_ba_${i}=\"\$_E\""; n=$(( n + 1 ))
     done
-    for (( i = 0; i < n; i++ )); do eval "e=\"\$_ba_${i}\""; sum=$(( sum + ${#e} )); done
+    for (( i = 0; i < n; i++ )); do eval "e=\"\$_ba_${i}\""; _ck "$e"; done
     for (( i = 0; i < LOOKUPS; i++ )); do
-        eval "e=\"\$_ba_$(( i * ELEMS / LOOKUPS ))\""; sum=$(( sum + ${#e} ))
+        eval "e=\"\$_ba_$(( i * ELEMS / LOOKUPS ))\""; _ck "$e"
     done
-    printf '%s|%s' "$sum" "$n"
+    printf '%s|%s' "$_SUM" "$n"
+}
+
+# B2: the same slots, with the appends batched into one `eval` per block.
+#
+#     If `eval` itself is the cost rather than the assignment, batching is the
+#     lever, and this says by how much. The value has to be baked into the
+#     program text, which means quoting it, and the quoting here uses bash's
+#     `//` substitution: **this arm is bash-only and is a diagnostic, not a
+#     candidate.** POSIX sh has no bulk substitution and escaping a value
+#     character by character would cost more than the `eval` it saves.
+arm_slots_batched() {
+    local i e n=0 prog="" q; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do
+        _elem "$i"
+        q="${_E//\'/\'\\\'\'}"
+        prog="${prog}_bb_${i}='${q}';"
+        n=$(( n + 1 ))
+        if (( n % CHUNK == 0 )); then eval "$prog"; prog=""; fi
+    done
+    [[ -n "$prog" ]] && eval "$prog"
+    for (( i = 0; i < n; i++ )); do eval "e=\"\$_bb_${i}\""; _ck "$e"; done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        eval "e=\"\$_bb_$(( i * ELEMS / LOOKUPS ))\""; _ck "$e"
+    done
+    printf '%s|%s' "$_SUM" "$n"
+}
+
+# B3: the same list, with one extra `eval` per append.
+#
+#     The gap between this and B is one `eval` per element and nothing else, so
+#     it prices the call itself rather than the assignment through it. That is
+#     the number B2 needs to be read against: if batching wins by roughly this
+#     much, `eval` is the cost; if it wins by more or less, something else is.
+#
+#     It builds the same list and answers the same string, so it competes
+#     honestly rather than sitting outside the comparison.
+arm_slots_double_eval() {
+    local i e n=0; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do
+        _elem "$i"; eval "_bd_${i}=\"\$_E\""; eval ":"; n=$(( n + 1 ))
+    done
+    for (( i = 0; i < n; i++ )); do eval "e=\"\$_bd_${i}\""; _ck "$e"; done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        eval "e=\"\$_bd_$(( i * ELEMS / LOOKUPS ))\""; _ck "$e"
+    done
+    printf '%s|%s' "$_SUM" "$n"
 }
 
 # C: one string, elements separated by a unit separator.
@@ -94,19 +159,79 @@ arm_slots() {
 #    The separator is `\037` rather than a newline or a space because an
 #    element holds arbitrary text and two of the elements here prove it.
 arm_one_string() {
-    local s="" i sum=0 e n=0 rest
+    local s="" i e n=0 rest; _SUM=0
     for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; s+="$_E"$'\037'; n=$(( n + 1 )); done
     rest="$s"
     while [[ -n "$rest" ]]; do
-        e="${rest%%$'\037'*}"; rest="${rest#*$'\037'}"; sum=$(( sum + ${#e} ))
+        e="${rest%%$'\037'*}"; rest="${rest#*$'\037'}"; _ck "$e"
     done
     for (( i = 0; i < LOOKUPS; i++ )); do
         local want=$(( i * ELEMS / LOOKUPS )) j=0
         rest="$s"
         while (( j < want )); do rest="${rest#*$'\037'}"; j=$(( j + 1 )); done
-        e="${rest%%$'\037'*}"; sum=$(( sum + ${#e} ))
+        e="${rest%%$'\037'*}"; _ck "$e"
     done
-    printf '%s|%s' "$sum" "$n"
+    printf '%s|%s' "$_SUM" "$n"
+}
+
+# C2: a rope. Several strings, each holding at most CHUNK elements, with the
+#     chunks themselves in slots.
+#
+#     Appending is a concatenation onto the last chunk and walking is one pass
+#     per chunk, so both keep what the single string had. Indexing divides to
+#     find the chunk and then scans inside it, so the scan is bounded by the
+#     chunk size instead of by the length of the list. That is the one thing
+#     the single string gets catastrophically wrong.
+arm_rope() {
+    local i e n=0 c=0 cur="" rest; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do
+        _elem "$i"; cur+="$_E"$'\037'; n=$(( n + 1 ))
+        if (( n % CHUNK == 0 )); then eval "_rp_${c}=\"\$cur\""; c=$(( c + 1 )); cur=""; fi
+    done
+    [[ -n "$cur" ]] && { eval "_rp_${c}=\"\$cur\""; c=$(( c + 1 )); }
+    local k
+    for (( k = 0; k < c; k++ )); do
+        eval "rest=\"\$_rp_${k}\""
+        while [[ -n "$rest" ]]; do
+            e="${rest%%$'\037'*}"; rest="${rest#*$'\037'}"; _ck "$e"
+        done
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        local want=$(( i * ELEMS / LOOKUPS )) j=0
+        eval "rest=\"\$_rp_$(( want / CHUNK ))\""
+        while (( j < want % CHUNK )); do rest="${rest#*$'\037'}"; j=$(( j + 1 )); done
+        e="${rest%%$'\037'*}"; _ck "$e"
+    done
+    printf '%s|%s' "$_SUM" "$n"
+}
+
+# C3: a string while it is being built, split into slots the first time
+#     somebody indexes it.
+#
+#     The two halves of the real use pattern want opposite things: appending
+#     wants a string and indexing wants slots. This pays the string's cheap
+#     append, then converts once, on the first index, and every index after
+#     that is a slot read. A list that is only ever appended to and walked
+#     never pays the conversion at all.
+arm_hybrid() {
+    local s="" i e n=0 rest split=0; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; s+="$_E"$'\037'; n=$(( n + 1 )); done
+    rest="$s"
+    while [[ -n "$rest" ]]; do
+        e="${rest%%$'\037'*}"; rest="${rest#*$'\037'}"; _ck "$e"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        if (( split == 0 )); then
+            local j=0; rest="$s"
+            while [[ -n "$rest" ]]; do
+                eval "_hy_${j}=\"\${rest%%\$'\037'*}\""
+                rest="${rest#*$'\037'}"; j=$(( j + 1 ))
+            done
+            split=1
+        fi
+        eval "e=\"\$_hy_$(( i * ELEMS / LOOKUPS ))\""; _ck "$e"
+    done
+    printf '%s|%s' "$_SUM" "$n"
 }
 
 # D: the positional parameters.
@@ -116,14 +241,162 @@ arm_one_string() {
 #    it cannot also read its own arguments, and there is exactly one per scope.
 #    Whether that is affordable is a design question; what it costs is this.
 arm_positional() {
-    local i sum=0 e
+    local i e; _SUM=0
     set --
     for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; set -- "$@" "$_E"; done
-    for e in "$@"; do sum=$(( sum + ${#e} )); done
+    for e in "$@"; do _ck "$e"; done
     for (( i = 0; i < LOOKUPS; i++ )); do
-        eval "e=\"\${$(( i * ELEMS / LOOKUPS + 1 ))}\""; sum=$(( sum + ${#e} ))
+        eval "e=\"\${$(( i * ELEMS / LOOKUPS + 1 ))}\""; _ck "$e"
     done
-    printf '%s|%s' "$sum" "$#"
+    printf '%s|%s' "$_SUM" "$#"
+}
+
+# C4: a string while it is being built, split by the shell itself on read.
+#
+#     Every string arm above splits in a shell loop, one parameter expansion
+#     per element, and every one of them loses badly for it. The shell will do
+#     that split in C: setting `IFS` to the separator and writing `set -- $s`
+#     is field splitting, which is what the shell does to every unquoted
+#     expansion anyway.
+#
+#     So appending is a concatenation, splitting is one native pass, indexing
+#     is a positional parameter, and the length is `$#`. Nothing is evaluated
+#     and nothing is scanned.
+#
+#     Two things it needs and they are both one line. `set -f` because field
+#     splitting is followed by pathname expansion and an element holding `*`
+#     would otherwise become the directory listing. And `IFS` set to the
+#     separator alone, not left at its default, or every space and newline in
+#     an element splits it further, which the two awkward elements here would
+#     catch immediately.
+arm_native_split() {
+    local s="" i e n=0; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; s+="$_E"$'\037'; n=$(( n + 1 )); done
+    local oldifs="$IFS"
+    set -f; IFS=$'\037'
+    set -- $s
+    IFS="$oldifs"; set +f
+    for e in "$@"; do _ck "$e"; done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        eval "e=\"\${$(( i * ELEMS / LOOKUPS + 1 ))}\""; _ck "$e"
+    done
+    printf '%s|%s' "$_SUM" "$#"
+}
+
+# C5: the same native split, walked by shifting rather than by `for`.
+#
+#     `shift` is how POSIX sh consumes a list it cannot index, and it needs no
+#     `eval` at all: `$1` is always the next element. What it costs is the list,
+#     since consuming it destroys it, so this is a walk mechanism rather than an
+#     access one and the indexing below still splits again to get its element.
+arm_native_shift() {
+    local s="" i e n=0; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; s+="$_E"$'\037'; n=$(( n + 1 )); done
+    local oldifs="$IFS"
+    set -f; IFS=$'\037'
+    set -- $s
+    IFS="$oldifs"; set +f
+    n=$#
+    while [[ $# -gt 0 ]]; do _ck "$1"; shift; done
+    set -f; IFS=$'\037'
+    set -- $s
+    IFS="$oldifs"; set +f
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        eval "e=\"\${$(( i * ELEMS / LOOKUPS + 1 ))}\""; _ck "$e"
+    done
+    printf '%s|%s' "$_SUM" "$n"
+}
+
+# D2: one string, built by prepending, walked in the order it was appended.
+#
+#     Whether a shell's string concatenation is asymmetric. If a prepend copies
+#     where an append extends in place, this loses badly; if both copy, they
+#     match and the reversal is the only difference. The reversal is real work
+#     and is done rather than skipped, which is what the order-sensitive
+#     checksum is there to enforce.
+arm_prepend() {
+    local s="" i e n=0 rest; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; s=$'\037'"$_E$s"; n=$(( n + 1 )); done
+    # The last element appended sits at the front, so taking from the tail
+    # yields the list in the order it was built and no reversal pass is needed.
+    # An earlier version of this arm collected into a bash array to reverse,
+    # which is the thing being given up, and it got the order backwards as
+    # well. The rolling checksum refused the run, which is what it is for.
+    rest="$s"
+    while [[ -n "$rest" ]]; do
+        e="${rest##*$'\037'}"; rest="${rest%$'\037'*}"; _ck "$e"
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        local want=$(( i * ELEMS / LOOKUPS )) j=0
+        rest="$s"
+        while (( j < want )); do rest="${rest%$'\037'*}"; j=$(( j + 1 )); done
+        e="${rest##*$'\037'}"; _ck "$e"
+    done
+    printf '%s|%s' "$_SUM" "$n"
+}
+
+
+
+# -----------------------------------------------------------------------------
+# The walk-only arms. Append, then walk once. No indexing.
+# -----------------------------------------------------------------------------
+
+arm_w_bash() {
+    local -a a=(); local i e; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; a+=("$_E"); done
+    for e in "${a[@]}"; do _ck "$e"; done
+    printf '%s|%s' "$_SUM" "${#a[@]}"
+}
+
+arm_w_slots() {
+    local i e n=0; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; eval "_we_${i}=\"\$_E\""; n=$(( n + 1 )); done
+    for (( i = 0; i < n; i++ )); do eval "e=\"\$_we_${i}\""; _ck "$e"; done
+    printf '%s|%s' "$_SUM" "$n"
+}
+
+# The one that needs no positional parameters at all.
+#
+# `for e in $s` field-splits exactly the way `set -- $s` does, in C, and never
+# touches `$@`. So the one-list-per-scope objection that the positional
+# parameters carry does not apply to walking, only to indexing, and walking is
+# what most of the real uses do.
+arm_w_forin() {
+    local s="" i e n=0; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; s+="$_E"$'\037'; n=$(( n + 1 )); done
+    local oldifs="$IFS"
+    # `IFS` and `set -f` are restored once, after the loop, not on every
+    # iteration. An earlier version of this arm restored them inside the body
+    # and paid for it: the body does not word-split anything, so it does not
+    # care what `IFS` holds. A loop body that does call something splitting an
+    # unquoted expansion would have to, and that is a real constraint on the
+    # shape rather than an artefact of this bench.
+    set -f; IFS=$'\037'
+    for e in $s; do _ck "$e"; done
+    IFS="$oldifs"; set +f
+    printf '%s|%s' "$_SUM" "$n"
+}
+
+arm_w_shift() {
+    local s="" i n=0; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; s+="$_E"$'\037'; n=$(( n + 1 )); done
+    local oldifs="$IFS"
+    set -f; IFS=$'\037'
+    set -- $s
+    IFS="$oldifs"; set +f
+    n=$#
+    while [[ $# -gt 0 ]]; do _ck "$1"; shift; done
+    printf '%s|%s' "$_SUM" "$n"
+}
+
+arm_w_scan() {
+    local s="" i e n=0 rest; _SUM=0
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; s+="$_E"$'\037'; n=$(( n + 1 )); done
+    rest="$s"
+    while [[ -n "$rest" ]]; do
+        e="${rest%%$'\037'*}"; rest="${rest#*$'\037'}"; _ck "$e"
+    done
+    printf '%s|%s' "$_SUM" "$n"
 }
 
 # -----------------------------------------------------------------------------
@@ -139,10 +412,37 @@ bench_case "What an indexed array costs without declare -a"
 bench_size "$ELEMS"
 bench_verify _answer_of
 
-bench_arm "bash declare -a"          arm_bash_array
-bench_arm "slots by index"           arm_slots
-bench_arm "one string, unit-separated" arm_one_string  2000
-bench_arm "positional parameters"    arm_positional
+bench_arm "bash declare -a, append"      arm_bash_array
+bench_arm "bash declare -a, by index"   arm_bash_by_index
+bench_arm "slots by index"              arm_slots
+bench_arm "slots, appends batched"      arm_slots_batched
+bench_arm "slots, one extra eval"        arm_slots_double_eval
+bench_arm "rope, chunked strings"       arm_rope
+bench_arm "string then split on index"  arm_hybrid
+bench_arm "string, split by the shell"   arm_native_split
+bench_arm "string, split then shifted"   arm_native_shift
+bench_arm "one string, unit-separated"  arm_one_string  1000
+bench_arm "one string, prepended"       arm_prepend     1000
+bench_arm "positional parameters"       arm_positional  4000
+
+bench_run || exit 1
+
+# A second case, because indexing and walking want opposite things and the
+# table above mixes them. Reading the real uses, most lists are appended to and
+# then walked once and never indexed at all: `_BENCH_LABEL`, `seen`, the toml
+# accumulators. This is that shape on its own, and it is the one the floor
+# actually has to serve well.
+bench_reset
+
+bench_case "The same list, appended to and walked, never indexed"
+bench_size "$ELEMS"
+bench_verify _answer_of
+
+bench_arm "bash declare -a"             arm_w_bash
+bench_arm "slots by index"              arm_w_slots
+bench_arm "string, for over the split"  arm_w_forin
+bench_arm "string, split then shifted"  arm_w_shift
+bench_arm "one string, scanned"         arm_w_scan   4000
 
 bench_run || exit 1
 

--- a/benches/array-api/bench.sh
+++ b/benches/array-api/bench.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/benches/array-api - What an indexed array costs without declare -a
+# =============================================================================
+#
+# `benches/maps` answered the associative half. This is the other half, and it
+# is the larger one: counting every construct rather than the first error dash
+# prints, indexed arrays appear in thirteen of the twenty files that cannot yet
+# be read, against nine for associative arrays.
+#
+# **The workload is the shape the real uses have.** Reading them, the dominant
+# pattern is append and then walk, with random access second and rarer:
+# `_BENCH_LABEL+=("$1")` then `${_BENCH_LABEL[i]}`, `seen+=("$child")` then a
+# membership test. So the arms append, walk the whole thing, index a sample,
+# and take a length, in that proportion.
+#
+# **Elements hold arbitrary text**, which rules out the obvious answer before
+# any measurement. `_BENCH_NOTE+=("${4:-}")` holds prose with spaces in it and
+# a toml value can hold anything at all, so a space-delimited string is not a
+# candidate and is not benched. The verify function below includes an element
+# with spaces and an element with a newline, and an arm that mangles either
+# answers differently and gets the whole run refused.
+#
+# Usage:
+#   ./bench array-api [elements] [lookups]
+# =============================================================================
+
+use bench
+
+ELEMS="${1:-400}"
+LOOKUPS="${2:-200}"
+
+# The input. Two of these are the reason a delimiter has to be chosen with care
+# rather than assumed, and they sit at the front so every arm meets them.
+#
+# It leaves the element in `_E` rather than printing it. Printed and read back
+# through a substitution it is a fork per element, and at four hundred elements
+# that fork was the entire measurement: the first run of this bench had every
+# arm within noise of bash and what it had measured was four hundred subshells
+# with the array technique underneath too small to see. Every arm paid it
+# equally, so no control could catch it, which is the reason it is written down
+# here rather than quietly fixed.
+_elem() {
+    case "$1" in
+        0) _E='an element with spaces in it' ;;
+        1) _E='an element with
+a newline in it' ;;
+        *) _E="element number $1" ;;
+    esac
+}
+
+# -----------------------------------------------------------------------------
+# The arms. Each appends ELEMS elements, walks all of them accumulating a
+# checksum, indexes LOOKUPS of them, and reports the length, so nothing can be
+# optimised away by going unused and a mangled element shows up in the sum.
+# -----------------------------------------------------------------------------
+
+# A: bash indexed array. The thing being given up.
+arm_bash_array() {
+    local -a a=()
+    local i sum=0 e
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; a+=("$_E"); done
+    for e in "${a[@]}"; do sum=$(( sum + ${#e} )); done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        e="${a[$(( i * ELEMS / LOOKUPS ))]}"; sum=$(( sum + ${#e} ))
+    done
+    printf '%s|%s' "$sum" "${#a[@]}"
+}
+
+# B: one variable per slot, addressed by number through eval.
+#
+#    Random access without a scan, and no encoding anywhere because an index is
+#    already a legal part of a name. `benches/maps` prices this shape at
+#    roughly 1.3x for reads under the name `slots by index`; what it costs for
+#    an append and a walk is what this arm is for.
+arm_slots() {
+    local i sum=0 e n=0
+    for (( i = 0; i < ELEMS; i++ )); do
+        _elem "$i"; eval "_ba_${i}=\"\$_E\""; n=$(( n + 1 ))
+    done
+    for (( i = 0; i < n; i++ )); do eval "e=\"\$_ba_${i}\""; sum=$(( sum + ${#e} )); done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        eval "e=\"\$_ba_$(( i * ELEMS / LOOKUPS ))\""; sum=$(( sum + ${#e} ))
+    done
+    printf '%s|%s' "$sum" "$n"
+}
+
+# C: one string, elements separated by a unit separator.
+#
+#    Appending is a concatenation and walking is one pass, which is the shape
+#    the real uses have. Indexing is a scan, so this arm is expected to lose
+#    exactly where the uses are rarest, and the question is by how much.
+#
+#    The separator is `\037` rather than a newline or a space because an
+#    element holds arbitrary text and two of the elements here prove it.
+arm_one_string() {
+    local s="" i sum=0 e n=0 rest
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; s+="$_E"$'\037'; n=$(( n + 1 )); done
+    rest="$s"
+    while [[ -n "$rest" ]]; do
+        e="${rest%%$'\037'*}"; rest="${rest#*$'\037'}"; sum=$(( sum + ${#e} ))
+    done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        local want=$(( i * ELEMS / LOOKUPS )) j=0
+        rest="$s"
+        while (( j < want )); do rest="${rest#*$'\037'}"; j=$(( j + 1 )); done
+        e="${rest%%$'\037'*}"; sum=$(( sum + ${#e} ))
+    done
+    printf '%s|%s' "$sum" "$n"
+}
+
+# D: the positional parameters.
+#
+#    The one list POSIX sh has natively, and the only arm here that needs no
+#    eval and no scan. It costs the parameters themselves, so a function using
+#    it cannot also read its own arguments, and there is exactly one per scope.
+#    Whether that is affordable is a design question; what it costs is this.
+arm_positional() {
+    local i sum=0 e
+    set --
+    for (( i = 0; i < ELEMS; i++ )); do _elem "$i"; set -- "$@" "$_E"; done
+    for e in "$@"; do sum=$(( sum + ${#e} )); done
+    for (( i = 0; i < LOOKUPS; i++ )); do
+        eval "e=\"\${$(( i * ELEMS / LOOKUPS + 1 ))}\""; sum=$(( sum + ${#e} ))
+    done
+    printf '%s|%s' "$sum" "$#"
+}
+
+# -----------------------------------------------------------------------------
+# The bench
+# -----------------------------------------------------------------------------
+
+# Every arm reports the same checksum and the same length. An arm that split on
+# the wrong character loses or gains a byte on the two awkward elements and the
+# harness refuses the run rather than reporting it as the fastest.
+_answer_of() { "$1"; }
+
+bench_case "What an indexed array costs without declare -a"
+bench_size "$ELEMS"
+bench_verify _answer_of
+
+bench_arm "bash declare -a"          arm_bash_array
+bench_arm "slots by index"           arm_slots
+bench_arm "one string, unit-separated" arm_one_string  2000
+bench_arm "positional parameters"    arm_positional
+
+bench_run || exit 1
+
+printf '\n'
+printf 'Indexed arrays are in thirteen of the twenty files that cannot yet be\n'
+printf 'read, against nine for associative arrays. This is the larger half.\n'

--- a/benches/array-api/findings.md
+++ b/benches/array-api/findings.md
@@ -5,7 +5,23 @@ the larger one: counting every construct rather than the first error `dash`
 prints, indexed arrays appear in thirteen of the twenty files that cannot yet be
 read, against nine for associative arrays.
 
-## The result
+## This answer was overturned by the bench above it
+
+**`benches/list-api` retires the conclusion below.** Read that first.
+
+The finding here is about a list held in a **local** variable, where appending
+is `s+=` and bash extends the string in place. A list with a **name** cannot
+use `+=`: the assignment goes through `eval`, which rebuilds the whole string on
+every push, so appending becomes quadratic and the headline number stops
+applying. The shipped container stores one variable per position for that
+reason.
+
+What still stands here is everything about the techniques themselves, which is
+most of the file: why the shell splitting beats a shell loop, why positional
+parameters append quadratically, why batching `eval` calls loses, and why a rope
+is slots with extra steps.
+
+## The result, for a list held in a local
 
 **Keep the list as a string and let the shell split it.** `IFS` set to the
 separator and `set -- $s`, or `for e in $s`, is field splitting, which the shell

--- a/benches/array-api/findings.md
+++ b/benches/array-api/findings.md
@@ -1,0 +1,66 @@
+# What an indexed array costs without `declare -a`
+
+`benches/maps` answered the associative half. This is the other half and it is
+the larger one: counting every construct rather than the first error `dash`
+prints, indexed arrays appear in thirteen of the twenty files that cannot yet be
+read, against nine for associative arrays.
+
+## The result
+
+One variable per slot, addressed by number. It is the only candidate that stays
+usable as the list grows.
+
+| arm | at 400 | at 4000 |
+|---|---|---|
+| `declare -a` | the baseline | the baseline |
+| slots by index | 137% | 170% |
+| positional parameters | 462% | 7229% |
+| one string, unit-separated | 36650% | over the ceiling |
+
+## Why the two losers lose
+
+**Positional parameters look native and append quadratically.** `set -- "$@" "$x"`
+rebuilds the entire list on every append, so a list built one element at a time
+costs the square of its length. At four hundred elements that is 4.6x and looks
+survivable; at four thousand it is 72x. They also cost the parameters
+themselves, so a function using them cannot read its own arguments, and there is
+one per scope. Building a list once from a splat is a different operation and is
+not what the real uses do.
+
+**A delimited string indexes by scanning.** Appending is a concatenation and
+walking is one pass, which are the two things the real uses do most, but
+reaching element n means skipping n separators and the scan swamps everything
+else.
+
+**Slots need no encoding**, which is why they cost so much less here than the
+same technique costs in `benches/maps`. An index is already a legal part of a
+variable name, so there is nothing to encode and nothing to fork for. The
+associative case pays for turning `lib/some-module.sh:412` into a name; the
+indexed case does not.
+
+## The first run of this bench was wrong, and the controls could not catch it
+
+Every arm built its elements through `$(_elem "$i")`, a fork per element. At four
+hundred elements that fork was the entire measurement: bash came out at 192ms
+where it actually takes 8, slots read as within the noise of bash where they are
+137%, and positional parameters read as 118% where they are 462%.
+
+Every arm paid the fork equally, so the agreement control saw agreement and the
+spread control saw a steady baseline. Both were working. **A cost every arm
+shares is invisible to a control that compares arms**, and the only thing that
+catches it is asking what the baseline number should be and noticing it is two
+orders of magnitude too large.
+
+The elements are built into a variable now.
+
+## What is not established here
+
+Whether 170% matters anywhere it is paid, which is a question about nutshell's
+own hot paths and needs a bench per path.
+
+The growth of the slots arm between the two sizes, 137% to 170%, is real and
+unexplained. The shell's symbol table is the obvious suspect and nobody has
+looked.
+
+Every number here is single-threaded, on one host, at the sizes stated, under
+bash. What any of this costs under a real POSIX shell is a different question.

--- a/benches/array-api/findings.md
+++ b/benches/array-api/findings.md
@@ -7,60 +7,115 @@ read, against nine for associative arrays.
 
 ## The result
 
-One variable per slot, addressed by number. It is the only candidate that stays
-usable as the list grows.
+**Keep the list as a string and let the shell split it.** `IFS` set to the
+separator and `set -- $s`, or `for e in $s`, is field splitting, which the shell
+does in C to every unquoted expansion anyway.
 
-| arm | at 400 | at 4000 |
-|---|---|---|
-| `declare -a` | the baseline | the baseline |
-| slots by index | 137% | 170% |
-| positional parameters | 462% | 7229% |
-| one string, unit-separated | 36650% | over the ceiling |
+At 400 elements and at 4000, against bash's own `declare -a`:
 
-## Why the two losers lose
+| arm | 400, indexed | 4000, indexed | 400, walked | 4000, walked |
+|---|---|---|---|---|
+| `declare -a` | the baseline | the baseline | the baseline | the baseline |
+| string, split by the shell | within the noise | 117% | within the noise | within the noise |
+| string, split then shifted | 122% | 126% | within the noise | 116% |
+| slots by index | 144% | 153% | 137% | 158% |
+| positional parameters | 433% | 5420% | | |
+| rope, chunked strings | 1300% | 1076% | | |
+| string then split on index | 1244% | 16171% | | |
+| one string, scanned | 32622% | over the ceiling | 725% | 9261% |
 
-**Positional parameters look native and append quadratically.** `set -- "$@" "$x"`
-rebuilds the entire list on every append, so a list built one element at a time
-costs the square of its length. At four hundred elements that is 4.6x and looks
-survivable; at four thousand it is 72x. They also cost the parameters
-themselves, so a function using them cannot read its own arguments, and there is
-one per scope. Building a list once from a splat is a different operation and is
-not what the real uses do.
+Two tables because indexing and walking want opposite things and one table
+mixing them hides that. Most of the real uses never index at all: `_BENCH_LABEL`,
+`seen`, the toml accumulators are all appended to and then walked once.
 
-**A delimited string indexes by scanning.** Appending is a concatenation and
-walking is one pass, which are the two things the real uses do most, but
-reaching element n means skipping n separators and the scan swamps everything
-else.
+## Why the shell splitting wins
 
-**Slots need no encoding**, which is why they cost so much less here than the
-same technique costs in `benches/maps`. An index is already a legal part of a
-variable name, so there is nothing to encode and nothing to fork for. The
-associative case pays for turning `lib/some-module.sh:412` into a name; the
-indexed case does not.
+Every other string arm splits in a shell loop, one parameter expansion per
+element, and every one of them loses by orders of magnitude. `${rest#*sep}`
+copies the whole remainder each time, so a walk is quadratic in the length of
+the list and an index is quadratic again on top.
 
-## The first run of this bench was wrong, and the controls could not catch it
+The shell already has that loop written in C. Handing it the string and letting
+it do what it does to every unquoted expansion costs one pass.
+
+**It needs two lines and both are easy to leave out.** `set -f`, because field
+splitting is followed by pathname expansion and an element holding `*` would
+otherwise become a directory listing. And `IFS` set to the separator alone, or
+every space and newline inside an element splits it further.
+
+**Walking needs no positional parameters at all.** `for e in $s` field-splits
+exactly as `set -- $s` does and never touches `$@`, so the one-list-per-scope
+objection applies only to indexing. That is the cheaper half of the problem and
+the rarer one.
+
+## The first answer was wrong, and it was wrong by being narrow
+
+This bench first carried four arms and concluded that slots by index, one shell
+variable per element addressed through `eval`, was the answer at 137% and 170%.
+That number was right and the conclusion was not: the string family had been
+represented by its worst member, a single string scanned in a shell loop, which
+lost by four orders of magnitude and took the whole family down with it.
+
+Widening it to seventeen arms across four families put the same string family at
+the top, at 117%, beating slots at both sizes.
+
+The lesson is about the shape of the comparison rather than about arrays. **One
+bad member is enough to retire a family**, and the arms that got added later
+were not more clever than the ones that were there, they were the same family
+done properly.
+
+## What else the arms settled
+
+**Batching the `eval` calls makes it worse**, 188% against 144%. The diagnostic
+arm beside it does one extra `eval` per append and costs 155%, so a whole `eval`
+is about 8% and there was never enough there to win. What batching adds is
+quoting the value into the program text, and that costs more than the call it
+saves.
+
+**`declare -a`'s `+=` is not a special fast path.** Appending and assigning by
+index measure identically at both sizes.
+
+**Positional parameters append quadratically.** `set -- "$@" "$x"` rebuilds the
+whole list every time: 433% at four hundred elements, 5420% at four thousand.
+They look native and they are the wrong native thing. Splitting into them once is
+the right one.
+
+**A rope is slots with extra steps.** Chunking the string bounds the scan to the
+chunk size, and its limit as the chunk approaches one element is exactly slots,
+which it never beats.
+
+**Splitting lazily on first index is the worst arm here**, 16171% at four
+thousand, because the conversion is the same quadratic shell loop and it runs
+inside the timed region.
+
+## The first run of this bench was wrong in a way no control could catch
 
 Every arm built its elements through `$(_elem "$i")`, a fork per element. At four
 hundred elements that fork was the entire measurement: bash came out at 192ms
 where it actually takes 8, slots read as within the noise of bash where they are
-137%, and positional parameters read as 118% where they are 462%.
+137%, and positional parameters read as 118% where they are 433%.
 
-Every arm paid the fork equally, so the agreement control saw agreement and the
-spread control saw a steady baseline. Both were working. **A cost every arm
-shares is invisible to a control that compares arms**, and the only thing that
-catches it is asking what the baseline number should be and noticing it is two
-orders of magnitude too large.
-
-The elements are built into a variable now.
+Every arm paid it equally, so the agreement control saw agreement and the spread
+control saw a steady baseline. Both were working. **A cost every arm shares is
+invisible to a control that compares arms**, and the only thing that caught it
+was asking what the baseline number should be and noticing it was two orders of
+magnitude too large.
 
 ## What is not established here
 
-Whether 170% matters anywhere it is paid, which is a question about nutshell's
-own hot paths and needs a bench per path.
+**Whether the ceremony is affordable at the call site.** A function's `set --` is
+local to that function, so nothing can split on the caller's behalf: the caller
+writes `set -f; IFS=...; set -- $l` itself. That is three lines per use, which is
+either unacceptable or exactly what lowering is for, and this bench does not say
+which.
 
-The growth of the slots arm between the two sizes, 137% to 170%, is real and
-unexplained. The shell's symbol table is the obvious suspect and nobody has
-looked.
+**Elements cannot contain the separator.** `\037` is not a character nutshell's
+own lists carry, and that is an observation rather than a guarantee. Encoding it
+on push costs a `case` test per element, which is unmeasured.
 
-Every number here is single-threaded, on one host, at the sizes stated, under
-bash. What any of this costs under a real POSIX shell is a different question.
+**The growth of the slots arm between sizes**, 144% to 153%, is real and
+unexplained. The shell's symbol table is the obvious suspect and nobody looked,
+which matters less now that slots are not the answer.
+
+Every number is single-threaded, on one host, under bash, at the sizes stated.
+What any of it costs under a real POSIX shell is a different question.

--- a/benches/array-api/results/20260827083322.csv
+++ b/benches/array-api/results/20260827083322.csv
@@ -1,0 +1,5 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash declare -a,192,197,within the noise,yes
+slots by index,193,212,within the noise,yes
+one string  unit-separated,3116,3173,1622%,yes
+positional parameters,227,259,118%,yes

--- a/benches/array-api/results/20260827083322.meta
+++ b/benches/array-api/results/20260827083322.meta
@@ -1,0 +1,7 @@
+case      What an indexed array costs without declare -a
+size      400
+repeats   7
+baseline  bash declare -a
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:33:22Z

--- a/benches/array-api/results/20260827083410.csv
+++ b/benches/array-api/results/20260827083410.csv
@@ -1,0 +1,5 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash declare -a,8,9,within the noise,yes
+slots by index,11,13,137%,yes
+one string  unit-separated,2932,2964,36650%,yes
+positional parameters,37,39,462%,yes

--- a/benches/array-api/results/20260827083410.meta
+++ b/benches/array-api/results/20260827083410.meta
@@ -1,0 +1,7 @@
+case      What an indexed array costs without declare -a
+size      400
+repeats   7
+baseline  bash declare -a
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:34:10Z

--- a/benches/array-api/results/20260827083451.csv
+++ b/benches/array-api/results/20260827083451.csv
@@ -1,0 +1,5 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash declare -a,47,49,within the noise,yes
+slots by index,80,82,170%,yes
+one string  unit-separated,-,-,-,no
+positional parameters,3398,3442,7229%,yes

--- a/benches/array-api/results/20260827083451.meta
+++ b/benches/array-api/results/20260827083451.meta
@@ -1,0 +1,7 @@
+case      What an indexed array costs without declare -a
+size      4000
+repeats   7
+baseline  bash declare -a
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:34:51Z

--- a/benches/array-api/results/20260827084010.csv
+++ b/benches/array-api/results/20260827084010.csv
@@ -1,0 +1,11 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash declare -a  append,9,11,within the noise,yes
+bash declare -a  by index,9,10,within the noise,yes
+slots by index,13,14,144%,yes
+slots  appends batched,17,18,188%,yes
+slots  one extra eval,14,15,155%,yes
+rope  chunked strings,117,121,1300%,yes
+string then split on index,112,115,1244%,yes
+one string  unit-separated,2957,3007,32855%,yes
+one string  prepended,3002,3044,33355%,yes
+positional parameters,39,42,433%,yes

--- a/benches/array-api/results/20260827084010.meta
+++ b/benches/array-api/results/20260827084010.meta
@@ -1,0 +1,7 @@
+case      What an indexed array costs without declare -a
+size      400
+repeats   7
+baseline  bash declare -a, append
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:40:10Z

--- a/benches/array-api/results/20260827084145.csv
+++ b/benches/array-api/results/20260827084145.csv
@@ -1,0 +1,12 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash declare -a  append,9,11,within the noise,yes
+bash declare -a  by index,9,11,within the noise,yes
+slots by index,13,15,144%,yes
+slots  appends batched,17,18,188%,yes
+slots  one extra eval,14,15,155%,yes
+rope  chunked strings,118,126,1311%,yes
+string then split on index,112,116,1244%,yes
+string  split by the shell,10,11,within the noise,yes
+one string  unit-separated,2935,2948,32611%,yes
+one string  prepended,3003,3028,33366%,yes
+positional parameters,40,49,444%,yes

--- a/benches/array-api/results/20260827084145.meta
+++ b/benches/array-api/results/20260827084145.meta
@@ -1,0 +1,7 @@
+case      What an indexed array costs without declare -a
+size      400
+repeats   7
+baseline  bash declare -a, append
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:41:45Z

--- a/benches/array-api/results/20260827085458.csv
+++ b/benches/array-api/results/20260827085458.csv
@@ -1,0 +1,13 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash declare -a  append,9,10,within the noise,yes
+bash declare -a  by index,9,10,within the noise,yes
+slots by index,13,14,144%,yes
+slots  appends batched,17,17,188%,yes
+slots  one extra eval,14,15,155%,yes
+rope  chunked strings,117,121,1300%,yes
+string then split on index,112,114,1244%,yes
+string  split by the shell,10,11,within the noise,yes
+string  split then shifted,11,12,122%,yes
+one string  unit-separated,2936,2959,32622%,yes
+one string  prepended,3002,3017,33355%,yes
+positional parameters,39,41,433%,yes

--- a/benches/array-api/results/20260827085458.meta
+++ b/benches/array-api/results/20260827085458.meta
@@ -1,0 +1,7 @@
+case      What an indexed array costs without declare -a
+size      400
+repeats   7
+baseline  bash declare -a, append
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:54:58Z

--- a/benches/array-api/results/20260827085459.csv
+++ b/benches/array-api/results/20260827085459.csv
@@ -1,0 +1,6 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash declare -a,8,8,within the noise,yes
+slots by index,11,11,137%,yes
+string  for over the split,10,12,125%,yes
+string  split then shifted,8,9,within the noise,yes
+one string  scanned,58,70,725%,yes

--- a/benches/array-api/results/20260827085459.meta
+++ b/benches/array-api/results/20260827085459.meta
@@ -1,0 +1,7 @@
+case      The same list, appended to and walked, never indexed
+size      400
+repeats   7
+baseline  bash declare -a
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:54:59Z

--- a/benches/array-api/results/20260827085608.csv
+++ b/benches/array-api/results/20260827085608.csv
@@ -1,0 +1,13 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash declare -a  append,9,10,within the noise,yes
+bash declare -a  by index,9,10,within the noise,yes
+slots by index,13,14,144%,yes
+slots  appends batched,17,18,188%,yes
+slots  one extra eval,14,15,155%,yes
+rope  chunked strings,117,120,1300%,yes
+string then split on index,112,114,1244%,yes
+string  split by the shell,10,11,within the noise,yes
+string  split then shifted,11,12,122%,yes
+one string  unit-separated,2934,2970,32600%,yes
+one string  prepended,3010,3049,33444%,yes
+positional parameters,39,40,433%,yes

--- a/benches/array-api/results/20260827085608.meta
+++ b/benches/array-api/results/20260827085608.meta
@@ -1,0 +1,7 @@
+case      What an indexed array costs without declare -a
+size      400
+repeats   7
+baseline  bash declare -a, append
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:56:08Z

--- a/benches/array-api/results/20260827085609.csv
+++ b/benches/array-api/results/20260827085609.csv
@@ -1,0 +1,6 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash declare -a,8,9,within the noise,yes
+slots by index,11,12,137%,yes
+string  for over the split,8,9,within the noise,yes
+string  split then shifted,9,9,within the noise,yes
+one string  scanned,58,87,725%,yes

--- a/benches/array-api/results/20260827085609.meta
+++ b/benches/array-api/results/20260827085609.meta
@@ -1,0 +1,7 @@
+case      The same list, appended to and walked, never indexed
+size      400
+repeats   7
+baseline  bash declare -a
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:56:09Z

--- a/benches/array-api/results/20260827085820.csv
+++ b/benches/array-api/results/20260827085820.csv
@@ -1,0 +1,13 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash declare -a  append,63,65,within the noise,yes
+bash declare -a  by index,62,65,within the noise,yes
+slots by index,97,98,153%,yes
+slots  appends batched,137,139,217%,yes
+slots  one extra eval,109,113,173%,yes
+rope  chunked strings,678,681,1076%,yes
+string then split on index,10188,10301,16171%,yes
+string  split by the shell,74,81,117%,yes
+string  split then shifted,80,91,126%,yes
+one string  unit-separated,-,-,-,no
+one string  prepended,-,-,-,no
+positional parameters,3415,3433,5420%,yes

--- a/benches/array-api/results/20260827085820.meta
+++ b/benches/array-api/results/20260827085820.meta
@@ -1,0 +1,7 @@
+case      What an indexed array costs without declare -a
+size      4000
+repeats   7
+baseline  bash declare -a, append
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:58:20Z

--- a/benches/array-api/results/20260827085903.csv
+++ b/benches/array-api/results/20260827085903.csv
@@ -1,0 +1,6 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash declare -a,55,58,within the noise,yes
+slots by index,87,90,158%,yes
+string  for over the split,58,61,within the noise,yes
+string  split then shifted,64,66,116%,yes
+one string  scanned,5094,5275,9261%,yes

--- a/benches/array-api/results/20260827085903.meta
+++ b/benches/array-api/results/20260827085903.meta
@@ -1,0 +1,7 @@
+case      The same list, appended to and walked, never indexed
+size      4000
+repeats   7
+baseline  bash declare -a
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:59:03Z

--- a/benches/list-api/bench.sh
+++ b/benches/list-api/bench.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/benches/list-api - What the shipped list costs, floor against bash
+# =============================================================================
+#
+# `benches/array-api` priced the techniques and picked one: keep the list as a
+# string and let the shell field-split it. This prices what got built on top of
+# that, both arms driving the shipped surface so the number carries the
+# function boundary and the `eval` that a named list needs and a local variable
+# does not.
+#
+# It also settles the question `benches/array-api` left open. A function's
+# `set --` is local to that function, so nothing can split on the caller's
+# behalf, and there are two ways out: `list_each`, which takes a function and
+# calls it once per element, or `list_ref`, which hands back the raw string and
+# leaves the caller to write `set -f`, `IFS` and the loop. The first is three
+# lines shorter at every use and costs a function call per element. Whether
+# that is affordable is what the second case below measures.
+#
+# **Both arms fork once to load their module**, because the two files define
+# the same nine names and one shell cannot hold both. Identical on both sides,
+# so it cancels. **Both run under bash**, so the technique is the variable and
+# not the shell.
+#
+# Usage:
+#   ./bench list-api [elements] [lookups]
+# =============================================================================
+
+use bench
+
+ELEMS="${1:-400}"
+LOOKUPS="${2:-200}"
+
+ROOT="$(cd "${BASH_SOURCE[0]%/*}/../.." && pwd)"
+POSIXFILE="$ROOT/lib/list.sh"
+BASHFILE="$ROOT/lib/list.bash.sh"
+
+# Push, walk with `list_each`, index a sample, take a length. The elements
+# include the three that break a naive split, so an arm that gets `IFS` or
+# `set -f` wrong reports a different checksum and the run is refused.
+read -r -d '' WORKLOAD <<'BODY' || true
+    _SUM=0
+    ck() { _SUM=$(( (_SUM * 31 + ${#1}) & 0x3fffffff )); }
+    elem() {
+        case "$1" in
+            0) _E='an element with spaces' ;;
+            1) _E='star * and ? here' ;;
+            2) _E='one
+two' ;;
+            *) _E="element number $1" ;;
+        esac
+    }
+    list_new a
+    i=0
+    while [ "$i" -lt "$ELEMS" ]; do elem "$i"; list_push a "$_E"; i=$(( i + 1 )); done
+    list_each a ck
+    i=0
+    while [ "$i" -lt "$LOOKUPS" ]; do
+        list_read v a "$(( i * ELEMS / LOOKUPS ))"; ck "$v"; i=$(( i + 1 ))
+    done
+    printf '%s|%s' "$_SUM" "$(list_len a)"
+BODY
+
+# The same, walked by the caller over `list_ref` instead of through
+# `list_each`. Everything else is identical, so the gap is the function call
+# per element and nothing else.
+read -r -d '' DIRECT_WORKLOAD <<'BODY' || true
+    _SUM=0
+    ck() { _SUM=$(( (_SUM * 31 + ${#1}) & 0x3fffffff )); }
+    elem() {
+        case "$1" in
+            0) _E='an element with spaces' ;;
+            1) _E='star * and ? here' ;;
+            2) _E='one
+two' ;;
+            *) _E="element number $1" ;;
+        esac
+    }
+    list_new a
+    i=0
+    while [ "$i" -lt "$ELEMS" ]; do elem "$i"; list_push a "$_E"; i=$(( i + 1 )); done
+    list_ref s a
+    oldifs="$IFS"
+    set -f; IFS="$LIST_SEP"
+    for e in $s; do IFS="$oldifs"; set +f; ck "$e"; set -f; IFS="$LIST_SEP"; done
+    IFS="$oldifs"; set +f
+    i=0
+    while [ "$i" -lt "$LOOKUPS" ]; do
+        list_read v a "$(( i * ELEMS / LOOKUPS ))"; ck "$v"; i=$(( i + 1 ))
+    done
+    printf '%s|%s' "$_SUM" "$(list_len a)"
+BODY
+
+_run_against() {
+    bash -c '
+        nut_once() { return 0; }
+        . "$1" || exit 1
+        ELEMS="$2"; LOOKUPS="$3"
+        eval "$4"
+    ' _ "$1" "$ELEMS" "$LOOKUPS" "${2:-$WORKLOAD}"
+}
+
+arm_bash_list()    { _run_against "$BASHFILE"; }
+arm_posix_list()   { _run_against "$POSIXFILE"; }
+arm_bash_direct()  { _run_against "$BASHFILE"  "$DIRECT_WORKLOAD"; }
+arm_posix_direct() { _run_against "$POSIXFILE" "$DIRECT_WORKLOAD"; }
+
+_answer_of() { "$1"; }
+
+bench_case "What the shipped list costs, floor against bash"
+bench_size "$ELEMS"
+bench_verify _answer_of
+
+bench_arm "bash, one associative array"     arm_bash_list
+bench_arm "posix floor, one string"         arm_posix_list
+
+bench_run || exit 1
+
+bench_reset
+
+bench_case "The same list, walked by the caller instead of through list_each"
+bench_size "$ELEMS"
+bench_verify _answer_of
+
+bench_arm "bash, caller walks list_ref"     arm_bash_direct
+bench_arm "posix floor, caller walks list_ref" arm_posix_direct
+
+bench_run || exit 1
+
+printf '\n'
+printf 'Both arms fork once to load their module, and both run under bash.\n'
+printf 'The two cases are two questions and only the gap inside each means\n'
+printf 'anything. `benches/array-api` prices the techniques underneath.\n'

--- a/benches/list-api/bench.sh
+++ b/benches/list-api/bench.sh
@@ -112,7 +112,7 @@ bench_size "$ELEMS"
 bench_verify _answer_of
 
 bench_arm "bash, one associative array"     arm_bash_list
-bench_arm "posix floor, one string"         arm_posix_list
+bench_arm "posix floor, one per position"  arm_posix_list
 
 bench_run || exit 1
 

--- a/benches/list-api/findings.md
+++ b/benches/list-api/findings.md
@@ -1,0 +1,80 @@
+# What the shipped list costs, floor against bash
+
+`benches/array-api` priced the techniques. This prices what got built on top of
+one, both arms driving the shipped surface so the number carries the function
+boundary and the `eval` a named list needs.
+
+## The result
+
+| load | floor against bash, 400 | at 2000 |
+|---|---|---|
+| walked with `list_each` | 128% | 141% |
+| walked by the caller over `list_ref` | 161% | 423% |
+
+**Use `list_each`.** It is cheaper at both sizes and the gap widens with the
+list, which is the opposite of what was expected when the surface was designed.
+
+## The bench overturned the technique bench, and the reason is worth keeping
+
+`benches/array-api` concluded that the list should be one string with the shell
+field-splitting it, at 117% of bash's own `declare -a`. Built that way, the
+shipped floor measured **165% at four hundred elements and 468% at two
+thousand**: superlinear, on code whose technique had measured flat.
+
+The cause is one thing that bench could not see. It measured a list held in a
+**local variable**, where appending is `s+=` and bash extends the string in
+place. A list with a **name** cannot use `+=`, because the assignment has to go
+through `eval`, and that rebuilds the whole string on every push. Appending
+becomes quadratic and the technique's headline number stops applying.
+
+So the storage was inverted: one variable per position, with the string built on
+demand for a caller that wants to walk it. Push, index and length are each one
+operation regardless of length, and the same code then measured **128% and
+141%**, roughly flat.
+
+**A technique measured on a local does not transfer to the same technique on a
+named thing**, and the name is not a detail: it is what forces the `eval`, and
+the `eval` is what changes the complexity.
+
+## What is still quadratic, and why it stays
+
+`list_ref` builds the string by concatenating, which is the same O(n) copy per
+element the string storage had. Measured directly under `dash`, appending to a
+plain variable takes 7ms at 500 elements, 13 at 1000, 37 at 2000 and 123 at
+4000, roughly quadrupling per doubling.
+
+There is no POSIX way around it. `+=` is bash, and every route that would build
+the string in one pass needs the elements in the positional parameters first,
+which is itself quadratic to fill one at a time.
+
+So the string is the interchange form and not the walking form, and the surface
+says so: `list_each` walks the slots directly and builds no string at all.
+
+## An earlier fix, kept because it is the same lesson one rung down
+
+Before the storage was inverted, `list_read` re-split the whole list on every
+call. Two hundred reads over four hundred elements is eighty thousand field
+splits to answer two hundred questions, and it was the entire gap between the
+technique's 117% and the shipped 282%. Splitting once and fanning out into
+slots took it to 165%.
+
+That fix is gone, because inverting the storage made the fan-out the storage.
+It is recorded here because it is the same mistake in miniature: work that does
+not change between calls, done at every call.
+
+## What is not established here
+
+**Whether any of this matters where it is paid**, which is a question about
+nutshell's own hot paths and needs a bench per path.
+
+**What it costs under a real POSIX shell.** Both arms run under bash, so the
+technique is the variable rather than the shell. The concat measurement above is
+the one number here taken under `dash`, and it is a fact about the shell rather
+than about the surface.
+
+**The separator limit.** A value holding `\037` is refused rather than escaped,
+on both halves, so a caller that needs one has no route. Escaping costs a pass
+over every element in each direction and nobody has measured it, because no list
+in nutshell has ever carried that character.
+
+Every number is single-threaded, on one host, at the sizes stated.

--- a/benches/list-api/findings.md
+++ b/benches/list-api/findings.md
@@ -8,8 +8,8 @@ boundary and the `eval` a named list needs.
 
 | load | floor against bash, 400 | at 2000 |
 |---|---|---|
-| walked with `list_each` | 128% | 141% |
-| walked by the caller over `list_ref` | 161% | 423% |
+| walked with `list_each` | 123% | 132% |
+| walked by the caller over `list_ref` | 148% | 357% |
 
 **Use `list_each`.** It is cheaper at both sizes and the gap widens with the
 list, which is the opposite of what was expected when the surface was designed.
@@ -29,8 +29,8 @@ becomes quadratic and the technique's headline number stops applying.
 
 So the storage was inverted: one variable per position, with the string built on
 demand for a caller that wants to walk it. Push, index and length are each one
-operation regardless of length, and the same code then measured **128% and
-141%**, roughly flat.
+operation regardless of length, and the same code then measured **123% and
+132%**, roughly flat.
 
 **A technique measured on a local does not transfer to the same technique on a
 named thing**, and the name is not a detail: it is what forces the `eval`, and
@@ -61,6 +61,13 @@ slots took it to 165%.
 That fix is gone, because inverting the storage made the fan-out the storage.
 It is recorded here because it is the same mistake in miniature: work that does
 not change between calls, done at every call.
+
+## These numbers were re-taken
+
+A name check was later added to every entry point of both halves, and the
+tables above are from after it. The earlier ones, 128% and 141%, measured code
+that no longer exists. A number without its conditions does not travel, and the
+code it was taken against is one of its conditions.
 
 ## What is not established here
 

--- a/benches/list-api/results/20260827093443.csv
+++ b/benches/list-api/results/20260827093443.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,28,29,within the noise,yes
+posix floor  one string,79,83,282%,yes

--- a/benches/list-api/results/20260827093443.meta
+++ b/benches/list-api/results/20260827093443.meta
@@ -1,0 +1,7 @@
+case      What the shipped list costs, floor against bash
+size      400
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T06:34:43Z

--- a/benches/list-api/results/20260827093444.csv
+++ b/benches/list-api/results/20260827093444.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  caller walks list_ref,30,32,within the noise,yes
+posix floor  caller walks list_ref,79,82,263%,yes

--- a/benches/list-api/results/20260827093444.meta
+++ b/benches/list-api/results/20260827093444.meta
@@ -1,0 +1,7 @@
+case      The same list, walked by the caller instead of through list_each
+size      400
+repeats   7
+baseline  bash, caller walks list_ref
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T06:34:44Z

--- a/benches/list-api/results/20260827093523.csv
+++ b/benches/list-api/results/20260827093523.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,29,33,within the noise,yes
+posix floor  one string,48,51,165%,yes

--- a/benches/list-api/results/20260827093523.meta
+++ b/benches/list-api/results/20260827093523.meta
@@ -1,0 +1,7 @@
+case      What the shipped list costs, floor against bash
+size      400
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T06:35:23Z

--- a/benches/list-api/results/20260827093524.csv
+++ b/benches/list-api/results/20260827093524.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  caller walks list_ref,30,31,within the noise,yes
+posix floor  caller walks list_ref,48,51,160%,yes

--- a/benches/list-api/results/20260827093524.meta
+++ b/benches/list-api/results/20260827093524.meta
@@ -1,0 +1,7 @@
+case      The same list, walked by the caller instead of through list_each
+size      400
+repeats   7
+baseline  bash, caller walks list_ref
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T06:35:24Z

--- a/benches/list-api/results/20260827093544.csv
+++ b/benches/list-api/results/20260827093544.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,88,91,within the noise,yes
+posix floor  one string,412,425,468%,yes

--- a/benches/list-api/results/20260827093544.meta
+++ b/benches/list-api/results/20260827093544.meta
@@ -1,0 +1,7 @@
+case      What the shipped list costs, floor against bash
+size      2000
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T06:35:44Z

--- a/benches/list-api/results/20260827093548.csv
+++ b/benches/list-api/results/20260827093548.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  caller walks list_ref,99,101,within the noise,yes
+posix floor  caller walks list_ref,412,420,416%,yes

--- a/benches/list-api/results/20260827093548.meta
+++ b/benches/list-api/results/20260827093548.meta
@@ -1,0 +1,7 @@
+case      The same list, walked by the caller instead of through list_each
+size      2000
+repeats   7
+baseline  bash, caller walks list_ref
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T06:35:48Z

--- a/benches/list-api/results/20260827093648.csv
+++ b/benches/list-api/results/20260827093648.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,28,30,within the noise,yes
+posix floor  one string,36,37,128%,yes

--- a/benches/list-api/results/20260827093648.meta
+++ b/benches/list-api/results/20260827093648.meta
@@ -1,0 +1,7 @@
+case      What the shipped list costs, floor against bash
+size      400
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T06:36:48Z

--- a/benches/list-api/results/20260827093649.csv
+++ b/benches/list-api/results/20260827093649.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  caller walks list_ref,31,34,within the noise,yes
+posix floor  caller walks list_ref,50,50,161%,yes

--- a/benches/list-api/results/20260827093649.meta
+++ b/benches/list-api/results/20260827093649.meta
@@ -1,0 +1,7 @@
+case      The same list, walked by the caller instead of through list_each
+size      400
+repeats   7
+baseline  bash, caller walks list_ref
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T06:36:49Z

--- a/benches/list-api/results/20260827093651.csv
+++ b/benches/list-api/results/20260827093651.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,87,91,within the noise,yes
+posix floor  one string,123,127,141%,yes

--- a/benches/list-api/results/20260827093651.meta
+++ b/benches/list-api/results/20260827093651.meta
@@ -1,0 +1,7 @@
+case      What the shipped list costs, floor against bash
+size      2000
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T06:36:51Z

--- a/benches/list-api/results/20260827093655.csv
+++ b/benches/list-api/results/20260827093655.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  caller walks list_ref,99,102,within the noise,yes
+posix floor  caller walks list_ref,419,425,423%,yes

--- a/benches/list-api/results/20260827093655.meta
+++ b/benches/list-api/results/20260827093655.meta
@@ -1,0 +1,7 @@
+case      The same list, walked by the caller instead of through list_each
+size      2000
+repeats   7
+baseline  bash, caller walks list_ref
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T06:36:55Z

--- a/benches/list-api/results/20260827104735.csv
+++ b/benches/list-api/results/20260827104735.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,34,35,within the noise,yes
+posix floor  one per position,42,44,123%,yes

--- a/benches/list-api/results/20260827104735.meta
+++ b/benches/list-api/results/20260827104735.meta
@@ -1,0 +1,7 @@
+case      What the shipped list costs, floor against bash
+size      400
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T07:47:35Z

--- a/benches/list-api/results/20260827104736.csv
+++ b/benches/list-api/results/20260827104736.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  caller walks list_ref,37,39,within the noise,yes
+posix floor  caller walks list_ref,55,59,148%,yes

--- a/benches/list-api/results/20260827104736.meta
+++ b/benches/list-api/results/20260827104736.meta
@@ -1,0 +1,7 @@
+case      The same list, walked by the caller instead of through list_each
+size      400
+repeats   7
+baseline  bash, caller walks list_ref
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T07:47:36Z

--- a/benches/list-api/results/20260827104738.csv
+++ b/benches/list-api/results/20260827104738.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,114,116,within the noise,yes
+posix floor  one per position,151,159,132%,yes

--- a/benches/list-api/results/20260827104738.meta
+++ b/benches/list-api/results/20260827104738.meta
@@ -1,0 +1,7 @@
+case      What the shipped list costs, floor against bash
+size      2000
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T07:47:38Z

--- a/benches/list-api/results/20260827104743.csv
+++ b/benches/list-api/results/20260827104743.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  caller walks list_ref,126,129,within the noise,yes
+posix floor  caller walks list_ref,451,457,357%,yes

--- a/benches/list-api/results/20260827104743.meta
+++ b/benches/list-api/results/20260827104743.meta
@@ -1,0 +1,7 @@
+case      The same list, walked by the caller instead of through list_each
+size      2000
+repeats   7
+baseline  bash, caller walks list_ref
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T07:47:43Z

--- a/benches/map-api/bench.sh
+++ b/benches/map-api/bench.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/benches/map-api - What the shipped map costs, floor against bash
+# =============================================================================
+#
+# `benches/maps` priced the techniques: a bare `declare -A` against a bare
+# `eval` on an encoded name, with no function boundary and nothing tracking
+# insertion order. It answered which technique to build on and said nothing
+# about what got built.
+#
+# This prices what got built. Both arms drive the shipped surface, `map_new`
+# through `map_keys`, over the same operations, and the difference between them
+# is what a caller pays for the floor: a function call per operation either way,
+# an encoding pass per key on one side, a hash lookup on the other, and an order
+# string that both maintain because `map_keys` promises insertion order.
+#
+# **Both arms fork a subshell to load their module**, because the two files
+# define the same eight names and one shell cannot hold both. That fork is
+# identical on both sides and cancels out of the comparison. It does mean these
+# numbers do not compare to `benches/maps`, which forks nothing, and they are
+# not put next to those.
+#
+# **Both run under bash**, including the floor. That is deliberate: the question
+# is what the technique costs, and running one arm under `dash` would answer a
+# different question with the shell as the variable. What the floor costs under
+# a real POSIX shell is worth measuring and is not this.
+#
+# The keys are nutshell's own shape, `<path>:<n>`, because that shape is what
+# forced an encoding at all.
+#
+# Usage:
+#   ./bench map-api [entries] [lookups]
+# =============================================================================
+
+use bench
+
+ENTRIES="${1:-400}"
+LOOKUPS="${2:-200}"
+
+ROOT="$(cd "${BASH_SOURCE[0]%/*}/../.." && pwd)"
+POSIXFILE="$ROOT/lib/map.sh"
+BASHFILE="$ROOT/lib/map.bash.sh"
+
+# The workload, written once and run against whichever module was loaded.
+#
+# Every operation the surface has, in a shape a caller would actually write:
+# fill, read back, miss, ask what is present, take the length, walk the keys,
+# delete a slice, walk them again. An arm that only set and got would price the
+# two cheapest operations and call it the API.
+read -r -d '' WORKLOAD <<'BODY' || true
+    map_new m
+    i=0
+    while [ "$i" -lt "$ENTRIES" ]; do
+        map_set m "lib/some-module.sh:$i" "value number $i"
+        i=$(( i + 1 ))
+    done
+    last=""
+    i=0
+    while [ "$i" -lt "$LOOKUPS" ]; do
+        last="$(map_get m "lib/some-module.sh:$(( i * ENTRIES / LOOKUPS ))")"
+        i=$(( i + 1 ))
+    done
+    i=0
+    while [ "$i" -lt "$LOOKUPS" ]; do
+        map_get m "no/such-key.sh:$i" >/dev/null 2>&1 || last="MISS"
+        i=$(( i + 1 ))
+    done
+    i=0
+    while [ "$i" -lt "$LOOKUPS" ]; do
+        map_has m "lib/some-module.sh:$i" && last="present"
+        i=$(( i + 1 ))
+    done
+    len="$(map_len m)"
+    keys="$(map_keys m | wc -l)"
+    i=0
+    while [ "$i" -lt "$LOOKUPS" ]; do
+        map_del m "lib/some-module.sh:$i"
+        i=$(( i + 1 ))
+    done
+    printf '%s|%s|%s|%s' "$last" "$len" "$keys" "$(map_len m)"
+BODY
+
+# The same workload with the one line that reads a value changed to the
+# out-variable form. Everything else is identical, so the gap between a
+# `$(map_get ...)` arm and its `map_read` twin is the caller's fork and nothing
+# else.
+READ_WORKLOAD="${WORKLOAD/last=\"\$(map_get m \"lib\/some-module.sh:\$(( i * ENTRIES \/ LOOKUPS ))\")\"/map_read last m \"lib\/some-module.sh:\$(( i * ENTRIES \/ LOOKUPS ))\"}"
+
+# A read-dominated workload, which is the shape nutshell's own tables have: a
+# config cache or an attribute table is filled once and then read from on every
+# lookup for the rest of the run. The workload above is a fifth reads, so it
+# prices a fill more than a use, and the two answer different questions.
+#
+# Ten reads per entry, no deletes, and the reads go through the out-variable
+# form because the point here is what the table costs in use.
+read -r -d '' HOT_WORKLOAD <<'BODY' || true
+    map_new m
+    i=0
+    while [ "$i" -lt "$ENTRIES" ]; do
+        map_set m "lib/some-module.sh:$i" "value number $i"
+        i=$(( i + 1 ))
+    done
+    last=""; r=0
+    while [ "$r" -lt 10 ]; do
+        i=0
+        while [ "$i" -lt "$ENTRIES" ]; do
+            map_read last m "lib/some-module.sh:$i"
+            i=$(( i + 1 ))
+        done
+        r=$(( r + 1 ))
+    done
+    printf '%s|%s' "$last" "$(map_len m)"
+BODY
+
+# -----------------------------------------------------------------------------
+# The arms
+# -----------------------------------------------------------------------------
+
+_run_against() {
+    bash -c '
+        nut_once() { return 0; }
+        . "$1" || exit 1
+        ENTRIES="$2"; LOOKUPS="$3"
+        eval "$4"
+    ' _ "$1" "$ENTRIES" "$LOOKUPS" "${2:-$WORKLOAD}"
+}
+
+# A: the bash module, one associative array keyed by name and key.
+arm_bash_map() { _run_against "$BASHFILE"; }
+
+# B: the POSIX floor, one shell variable per entry, key encoded into the name.
+arm_posix_map() { _run_against "$POSIXFILE"; }
+
+# C and D: the same two, reading through `map_read` rather than through a
+#          command substitution on `map_get`.
+arm_bash_read()  { _run_against "$BASHFILE"  "$READ_WORKLOAD"; }
+arm_posix_read() { _run_against "$POSIXFILE" "$READ_WORKLOAD"; }
+
+# E and F: the read-dominated shape, which is what a cache actually does.
+#          These two answer separately from the four above and are not a
+#          continuation of them: a different workload is a different question,
+#          and only the gap between this pair means anything.
+arm_bash_hot()  { _run_against "$BASHFILE"  "$HOT_WORKLOAD"; }
+arm_posix_hot() { _run_against "$POSIXFILE" "$HOT_WORKLOAD"; }
+
+# -----------------------------------------------------------------------------
+# The bench
+# -----------------------------------------------------------------------------
+
+# Both arms print the same four numbers, so an encoding that collided two keys,
+# or an order string that dropped its last field, shows up as a disagreement
+# and the harness refuses the run rather than reporting a winner. The last of
+# the four is the length after deleting a slice, which is the field that caught
+# the dropped-field defect in the bash arm's own order string.
+_answer_of() { "$1"; }
+
+bench_case "What the shipped map costs, floor against bash"
+bench_size "$ENTRIES"
+bench_verify _answer_of
+
+bench_arm "bash, one associative array"  arm_bash_map
+bench_arm "posix floor, encoded names"   arm_posix_map
+bench_arm "bash, read into a variable"   arm_bash_read
+bench_arm "posix floor, read into a variable" arm_posix_read
+
+bench_run || exit 1
+
+# A second case rather than two more arms, because the read-heavy workload
+# answers a different string and the agreement control is right to refuse it as
+# one comparison. It is a different question and it gets its own table.
+bench_reset
+
+bench_case "The same map under a read-heavy load"
+bench_size "$ENTRIES"
+bench_verify _answer_of
+bench_arm "bash, read-heavy"        arm_bash_hot
+bench_arm "posix floor, read-heavy" arm_posix_hot
+
+bench_run || exit 1
+
+printf '\n'
+printf 'Both arms fork once to load their module, and both run under bash.\n'
+printf 'Neither number compares to benches/maps, which forks nothing.\n'

--- a/benches/map-api/bench.sh
+++ b/benches/map-api/bench.sh
@@ -86,6 +86,18 @@ BODY
 # else.
 READ_WORKLOAD="${WORKLOAD/last=\"\$(map_get m \"lib\/some-module.sh:\$(( i * ENTRIES \/ LOOKUPS ))\")\"/map_read last m \"lib\/some-module.sh:\$(( i * ENTRIES \/ LOOKUPS ))\"}"
 
+# The substitution above is a pattern over a long escaped literal and nothing
+# else would notice if it stopped matching. If it did, arms C and D would be
+# byte-identical to A and B, the agreement control would pass by construction,
+# and the gap the findings quote for `map_read` would be noise reported as a
+# result.
+if [[ "$READ_WORKLOAD" == "$WORKLOAD" ]]; then
+    printf 'bench: the read-workload substitution did not apply, so arms C and D\n' >&2
+    printf '  would measure the same thing as A and B. Refusing rather than\n' >&2
+    printf '  reporting a number that means nothing.\n' >&2
+    exit 1
+fi
+
 # A read-dominated workload, which is the shape nutshell's own tables have: a
 # config cache or an attribute table is filled once and then read from on every
 # lookup for the rest of the run. The workload above is a fifth reads, so it

--- a/benches/map-api/findings.md
+++ b/benches/map-api/findings.md
@@ -15,16 +15,16 @@ The floor is roughly twice bash, and the shape of the load moves it.
 
 | load | floor against bash |
 |---|---|
-| fill-heavy, reading through `map_get` | 208% |
-| fill-heavy, reading through `map_read` | 202% |
-| read-heavy | 188% |
+| fill-heavy, reading through `map_get` | 131% |
+| fill-heavy, reading through `map_read` | 126% |
+| read-heavy | 173% |
 
 Read-heavy is cheaper because the encoding is the cost and a read pays it once,
 where a set pays it and then maintains the key list.
 
 ## Getting there
 
-It started at 360% and three changes took it to 208%, each one an instance of a
+It started at 360% and four changes took it to 131%, each one an instance of a
 finding `benches/maps` had already recorded and the first implementation had
 then gone on to violate.
 
@@ -40,6 +40,12 @@ encoder already left its answer in a variable and the call sites read it now.
 one character per iteration. It takes the whole leading run of safe characters
 in one expansion instead, so a twenty-two character key is six passes rather
 than twenty-two, and a key needing no encoding leaves on the first.
+
+**A fork per character on the way back out, 208% to 131%.** The decoder ran two
+command substitutions per encoded character, which for keys of this shape is
+about ten forks per key. It was found by review, after the three above had been
+fixed and written up, in the same file that opens by saying the encoding must
+not fork.
 
 The lesson is not about maps. It is that `benches/maps` already said the
 encoding must not fork, in those words, and the implementation written against

--- a/benches/map-api/findings.md
+++ b/benches/map-api/findings.md
@@ -1,0 +1,74 @@
+# What the shipped map costs, floor against bash
+
+`benches/maps` priced the techniques and said which one to build on. This
+prices what got built: both arms drive the shipped surface, `map_new` through
+`map_keys`, so the number includes the function boundary, the encoding, and the
+insertion order both implementations promise.
+
+Every run leaves a record under `results/` carrying the host and the bash
+version, because a millisecond count without them cannot be compared to
+anybody else's.
+
+## The result
+
+The floor is roughly twice bash, and the shape of the load moves it.
+
+| load | floor against bash |
+|---|---|
+| fill-heavy, reading through `map_get` | 208% |
+| fill-heavy, reading through `map_read` | 202% |
+| read-heavy | 188% |
+
+Read-heavy is cheaper because the encoding is the cost and a read pays it once,
+where a set pays it and then maintains the key list.
+
+## Getting there
+
+It started at 360% and three changes took it to 208%, each one an instance of a
+finding `benches/maps` had already recorded and the first implementation had
+then gone on to violate.
+
+**A fork per unsafe character, 360% to 239%.** The hex lookup returned by
+printing, so encoding one key forked once per slash, dot, dash and colon in it.
+It returns through a variable now.
+
+**A fork per operation, 239% to 208%.** Every one of `map_set`, `map_get`,
+`map_has` and `map_del` called the encoder through a command substitution. The
+encoder already left its answer in a variable and the call sites read it now.
+
+**A character-at-a-time scan, folded into the first change.** The encoder walked
+one character per iteration. It takes the whole leading run of safe characters
+in one expansion instead, so a twenty-two character key is six passes rather
+than twenty-two, and a key needing no encoding leaves on the first.
+
+The lesson is not about maps. It is that `benches/maps` already said the
+encoding must not fork, in those words, and the implementation written against
+that finding forked twice per character anyway. A finding in a document does not
+enforce itself.
+
+## `map_read` against `map_get`
+
+`map_get` prints, so a caller reading one value pays a fork. `map_read` leaves
+it in a variable of the caller's naming.
+
+On the floor the difference is about 3%, which is small and outside the spreads,
+so it is real. On bash the two overlap and nothing is established. Both are
+smaller than expected because reads are a fifth of the fill-heavy workload; the
+read-heavy case is where the form is worth reaching for.
+
+## What is not established here
+
+**What the floor costs under a real POSIX shell.** Both arms run under bash,
+deliberately, so the technique is the variable rather than the shell. `dash`
+against `bash` on the same file is a different question and nobody has asked it.
+
+**Whether twice bash matters anywhere it is paid.** That is a question about
+nutshell's own hot paths and needs a bench per path.
+
+**What a handle would buy.** The remaining cost is the encoding, and the only
+way past it is a caller holding the encoded name rather than the key.
+`benches/maps` already prices that ceiling at roughly 1.3x under the name
+`slots by index`, so the shape of the answer is known and the API for it is not
+built.
+
+Every number here is single-threaded, on one host, at 400 entries.

--- a/benches/map-api/results/20260827081057.csv
+++ b/benches/map-api/results/20260827081057.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,2080,2291,within the noise,yes
+posix floor  encoded names,7494,7619,360%,yes

--- a/benches/map-api/results/20260827081057.meta
+++ b/benches/map-api/results/20260827081057.meta
@@ -1,0 +1,7 @@
+case      What the shipped map costs, floor against bash
+size      400
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:10:57Z

--- a/benches/map-api/results/20260827081239.csv
+++ b/benches/map-api/results/20260827081239.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,2127,2173,within the noise,yes
+posix floor  encoded names,5094,5208,239%,yes

--- a/benches/map-api/results/20260827081239.meta
+++ b/benches/map-api/results/20260827081239.meta
@@ -1,0 +1,7 @@
+case      What the shipped map costs, floor against bash
+size      400
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:12:39Z

--- a/benches/map-api/results/20260827081356.csv
+++ b/benches/map-api/results/20260827081356.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,2114,2146,within the noise,yes
+posix floor  encoded names,4367,4437,206%,yes

--- a/benches/map-api/results/20260827081356.meta
+++ b/benches/map-api/results/20260827081356.meta
@@ -1,0 +1,7 @@
+case      What the shipped map costs, floor against bash
+size      400
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:13:56Z

--- a/benches/map-api/results/20260827081634.csv
+++ b/benches/map-api/results/20260827081634.csv
@@ -1,0 +1,5 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,2124,4199,within the noise,yes
+posix floor  encoded names,4397,4730,207%,yes
+bash  read into a variable,1902,1956,89%,yes
+posix floor  read into a variable,4229,4322,199%,yes

--- a/benches/map-api/results/20260827081634.meta
+++ b/benches/map-api/results/20260827081634.meta
@@ -1,0 +1,7 @@
+case      What the shipped map costs, floor against bash
+size      400
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:16:34Z

--- a/benches/map-api/results/20260827082303.csv
+++ b/benches/map-api/results/20260827082303.csv
@@ -1,0 +1,5 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,2101,2175,within the noise,yes
+posix floor  encoded names,4383,4446,208%,yes
+bash  read into a variable,1948,1992,92%,yes
+posix floor  read into a variable,4257,4404,202%,yes

--- a/benches/map-api/results/20260827082303.meta
+++ b/benches/map-api/results/20260827082303.meta
@@ -1,0 +1,7 @@
+case      What the shipped map costs, floor against bash
+size      400
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:23:03Z

--- a/benches/map-api/results/20260827082310.csv
+++ b/benches/map-api/results/20260827082310.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  read-heavy,287,318,within the noise,yes
+posix floor  read-heavy,541,567,188%,yes

--- a/benches/map-api/results/20260827082310.meta
+++ b/benches/map-api/results/20260827082310.meta
@@ -1,0 +1,7 @@
+case      The same map under a read-heavy load
+size      400
+repeats   7
+baseline  bash, read-heavy
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T05:23:10Z

--- a/benches/map-api/results/20260827102301.csv
+++ b/benches/map-api/results/20260827102301.csv
@@ -1,0 +1,5 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,373,397,within the noise,yes
+posix floor  encoded names,531,550,142%,yes
+bash  read into a variable,322,352,86%,yes
+posix floor  read into a variable,502,520,134%,yes

--- a/benches/map-api/results/20260827102301.meta
+++ b/benches/map-api/results/20260827102301.meta
@@ -1,0 +1,7 @@
+case      What the shipped map costs, floor against bash
+size      100
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T07:23:01Z

--- a/benches/map-api/results/20260827102303.csv
+++ b/benches/map-api/results/20260827102303.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  read-heavy,79,83,within the noise,yes
+posix floor  read-heavy,151,156,191%,yes

--- a/benches/map-api/results/20260827102303.meta
+++ b/benches/map-api/results/20260827102303.meta
@@ -1,0 +1,7 @@
+case      The same map under a read-heavy load
+size      100
+repeats   7
+baseline  bash, read-heavy
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T07:23:03Z

--- a/benches/map-api/results/20260827104902.csv
+++ b/benches/map-api/results/20260827104902.csv
@@ -1,0 +1,5 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  one associative array,2158,2428,within the noise,yes
+posix floor  encoded names,2842,2922,131%,yes
+bash  read into a variable,1960,2147,90%,yes
+posix floor  read into a variable,2725,2782,126%,yes

--- a/benches/map-api/results/20260827104902.meta
+++ b/benches/map-api/results/20260827104902.meta
@@ -1,0 +1,7 @@
+case      What the shipped map costs, floor against bash
+size      400
+repeats   7
+baseline  bash, one associative array
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T07:49:02Z

--- a/benches/map-api/results/20260827104909.csv
+++ b/benches/map-api/results/20260827104909.csv
@@ -1,0 +1,3 @@
+arm,best_ms,worst_ms,ratio_to_baseline,ran
+bash  read-heavy,332,342,within the noise,yes
+posix floor  read-heavy,577,588,173%,yes

--- a/benches/map-api/results/20260827104909.meta
+++ b/benches/map-api/results/20260827104909.meta
@@ -1,0 +1,7 @@
+case      The same map under a read-heavy load
+size      400
+repeats   7
+baseline  bash, read-heavy
+bash      5.3.15(1)-release
+host      Darwin arm64
+taken     2026-08-27T07:49:09Z

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -39,6 +39,27 @@ not by name from outside. The implementations under `impl/` are the case: the
 module above them picks one at runtime by what the machine has, and a consumer
 naming one directly is reaching past the thing whose job is to choose.
 
+### Gating a module
+
+An attribute line above a declaration gates it. The attributes attach downward
+and accumulate, and they stop at the declaration they precede.
+
+```
+#[shell(bash4)]
+tui::key                 libs/tui/key.sh
+```
+
+`#[shell(<name>)]` says the module needs that shell. It has to sit here rather
+than inside the file, because the file it gates is the file that fails to
+parse.
+
+`#[has(bin(<name>))]` says the module needs that binary on the path, and
+`#[has(env(<NAME>))]` that it needs that variable set. Those can also sit inline
+in the file, since a file needing `grep` still parses without it.
+
+A module whose gate does not hold resolves to absent rather than to an error.
+
+
 ## Why a declaration and not a search
 
 A module used to be found by trying `lib/<name>.sh`, then `libs/<name>.sh`,

--- a/lib.nut
+++ b/lib.nut
@@ -25,6 +25,9 @@ json::impl::perl         lib/json/impl/perl.sh        internal
 json::impl::python       lib/json/impl/python.sh      internal
 log                      lib/log.sh
 #[shell(bash4)]
+list                     lib/list.bash.sh
+list                     lib/list.sh
+#[shell(bash4)]
 map                      lib/map.bash.sh
 map                      lib/map.sh
 modgraph                 lib/modgraph.sh

--- a/lib.nut
+++ b/lib.nut
@@ -24,6 +24,9 @@ json::impl::jq           lib/json/impl/jq.sh          internal
 json::impl::perl         lib/json/impl/perl.sh        internal
 json::impl::python       lib/json/impl/python.sh      internal
 log                      lib/log.sh
+#[shell(bash4)]
+map                      lib/map.bash.sh
+map                      lib/map.sh
 modgraph                 lib/modgraph.sh
 nutshell                 nutshell.sh
 os                       lib/os.sh

--- a/lib/array.sh
+++ b/lib/array.sh
@@ -1,141 +1,231 @@
 #!/usr/bin/env bash
 # =============================================================================
-# nutshell/core/array.sh - Array manipulation primitives
+# nutshell/lib/array.sh - Operations over a list of arguments
 # =============================================================================
 # Part of nutshell - Everything you need, in a nutshell.
 # https://github.com/orgrinrt/nutshell
 #
-# Layer 0 (Core): No dependencies on other modules
+# Layer 0. Everything here works on `"$@"`, so it needs no container and reads
+# under any POSIX sh.
+#
+# The three functions that used to rewrite a bash array in place through a
+# nameref take a `list` name now. A nameref is bash 4.3, an array is bash at
+# all, and neither reads on the floor. Operating on the container the library
+# ships means one implementation serves both halves of it.
+#
+# Usage:
+#   use array
+#
+#   arr_contains "b" a b c        # returns 0
+#   arr_index    "b" a b c        # 1
+#   arr_filter   "a*" apple bat   # apple
+#
+#   list_new l; list_push l b; list_push l a; list_push l b
+#   arr_unique l                  # l is now b, a
 # =============================================================================
 
-# Prevent multiple inclusion
 nut_once || return 0
 
+use list
+
 # -----------------------------------------------------------------------------
-# Public API
+# Over the arguments
 # -----------------------------------------------------------------------------
 
 #[pub]
-# Check if array contains element
-# Usage: arr_contains "needle" "${haystack[@]}" -> returns 0 (true) or 1 (false)
+# Whether the list of arguments holds an element.
+# Usage: arr_contains "needle" "$@" -> returns 0 when present
 arr_contains() {
-    local needle="${1:-}"
-    shift
-    
-    local item
-    for item in "$@"; do
-        [[ "$item" == "$needle" ]] && return 0
+    _ac_needle="${1:-}"
+    shift || return 1
+    for _ac_item in "$@"; do
+        [ "$_ac_item" = "$_ac_needle" ] && return 0
     done
     return 1
 }
 
 #[pub]
-# Find index of element in array (returns 255 if not found)
-# Usage: arr_index "needle" "${haystack[@]}" -> prints index or 255
+# Where an element sits, counting from zero, or 255 and a non-zero status.
+# Usage: arr_index "needle" "$@" -> prints the index or 255
 arr_index() {
-    local needle="${1:-}"
-    shift
-    
-    local i=0
-    local item
-    for item in "$@"; do
-        [[ "$item" == "$needle" ]] && { echo "$i"; return 0; }
-        ((i++))
+    _ai_needle="${1:-}"
+    shift || return 1
+    _ai_i=0
+    for _ai_item in "$@"; do
+        [ "$_ai_item" = "$_ai_needle" ] && { printf '%s\n' "$_ai_i"; return 0; }
+        _ai_i=$(( _ai_i + 1 ))
     done
-    echo "255"
+    printf '255\n'
     return 1
 }
 
 #[pub]
-# Remove duplicates from array (preserves order)
-# Usage: arr_unique arr -> prints nothing; rewrites the named array in place, order preserved
-arr_unique() {
-    local -n _arr="$1"
-    local -A seen=()
-    local result=()
-    
-    local item
-    for item in "${_arr[@]}"; do
-        if [[ -z "${seen[$item]:-}" ]]; then
-            seen[$item]=1
-            result+=("$item")
-        fi
-    done
-    
-    _arr=("${result[@]}")
-}
-
-#[pub]
-# Reverse array in place
-# Usage: arr_reverse arr -> prints nothing; rewrites the named array in place
-arr_reverse() {
-    local -n _arr="$1"
-    local len=${#_arr[@]}
-    
-    [[ $len -le 1 ]] && return 0
-    
-    local i j temp
-    for ((i=0, j=len-1; i<j; i++, j--)); do
-        temp="${_arr[$i]}"
-        _arr[$i]="${_arr[$j]}"
-        _arr[$j]="$temp"
-    done
-}
-
 #[allow(trivial_wrapper)]
-# Get array length
-# Usage: arr_length "${arr[@]}" -> prints count
-#[pub]
+# How many arguments there are.
+# Usage: arr_length "$@" -> prints the count
 arr_length() {
-    echo "$#"
+    printf '%s\n' "$#"
 }
 
 #[pub]
 #[allow(trivial_wrapper)]
-# Check if array is empty
-# Usage: arr_is_empty "${arr[@]}" -> returns 0 (true) if empty
+# Whether there are none.
+# Usage: arr_is_empty "$@" -> returns 0 when empty
 arr_is_empty() {
-    [[ $# -eq 0 ]]
+    [ $# -eq 0 ]
 }
 
 #[pub]
 #[allow(trivial_wrapper)]
-# Get first element of array
-# Usage: arr_first "${arr[@]}" -> prints first element
+# The first argument.
+# Usage: arr_first "$@" -> prints it
 arr_first() {
-    [[ $# -gt 0 ]] && echo "$1"
+    [ $# -gt 0 ] && printf '%s\n' "$1"
 }
 
 #[pub]
-#[allow(trivial_wrapper)]
-# Get last element of array
-# Usage: arr_last "${arr[@]}" -> prints last element
+# The last argument.
+#
+# Walked to rather than reached with `${!#}`, which is bash's indirect
+# expansion. A loop that keeps the value it last saw is the POSIX way and is
+# not slower for any list a shell would hold.
+#
+# Usage: arr_last "$@" -> prints it
 arr_last() {
-    [[ $# -gt 0 ]] && echo "${!#}"
+    [ $# -gt 0 ] || return 1
+    for _al_item in "$@"; do :; done
+    printf '%s\n' "$_al_item"
 }
 
 #[pub]
-# Sort array in place (lexicographic)
-# Usage: arr_sort arr -> prints nothing; rewrites the named array in place, lexicographic
-arr_sort() {
-    local -n _arr="$1"
-    local -a sorted
-    
-    [[ ${#_arr[@]} -le 1 ]] && return 0
-    
-    readarray -t sorted < <(printf '%s\n' "${_arr[@]}" | sort)
-    _arr=("${sorted[@]}")
-}
-
-#[pub]
-# Filter array by pattern
-# Usage: arr_filter "pattern" "${arr[@]}" -> prints matching elements
+# The arguments matching a glob, one per line.
+# Usage: arr_filter "a*" apple bat -> apple
 arr_filter() {
-    local pattern="${1:-}"
-    shift
-    
-    local item
-    for item in "$@"; do
-        [[ "$item" == $pattern ]] && echo "$item"
+    _af_pattern="${1:-}"
+    shift || return 1
+    for _af_item in "$@"; do
+        # Unquoted on the right so it is a pattern rather than a literal, which
+        # is the whole point of the function.
+        # shellcheck disable=SC2254
+        case "$_af_item" in
+            $_af_pattern) printf '%s\n' "$_af_item" ;;
+        esac
     done
+}
+
+# -----------------------------------------------------------------------------
+# Over a list, rewritten in place
+# -----------------------------------------------------------------------------
+
+#[pub]
+# Drop repeats, keeping the first of each and the order of what is left.
+# Usage: arr_unique l
+arr_unique() {
+    [ -n "${1:-}" ] || return 1
+    _au_n="$(list_len "$1")"
+    [ "$_au_n" -le 1 ] && return 0
+    _au_seen=""
+    list_new _arr_scratch
+    _au_i=0
+    while [ "$_au_i" -lt "$_au_n" ]; do
+        list_read _au_e "$1" "$_au_i"
+        # The seen-set is a string, so every element in it is fenced by a
+        # separator on both sides. `ab` then does not match inside `cab`, and a
+        # value equal to another's suffix stays its own element. The list
+        # refuses an element holding the separator, so the fencing is
+        # unambiguous.
+        #
+        # One separator is prefixed at the check and one appended at the store,
+        # rather than one at each end of both. Fencing both sides of an empty
+        # seen-set produces two adjacent separators, which is exactly the
+        # pattern an empty element searches for, so the first empty element
+        # ever seen was reported as a repeat and dropped.
+        case "${LIST_SEP}${_au_seen}" in
+            *"${LIST_SEP}${_au_e}${LIST_SEP}"*) : ;;
+            *)
+                _au_seen="${_au_seen}${_au_e}${LIST_SEP}"
+                list_push _arr_scratch "$_au_e"
+                ;;
+        esac
+        _au_i=$(( _au_i + 1 ))
+    done
+    _arr_copy_over _arr_scratch "$1"
+}
+
+#[pub]
+# Reverse it.
+# Usage: arr_reverse l
+arr_reverse() {
+    [ -n "${1:-}" ] || return 1
+    _ar_n="$(list_len "$1")"
+    [ "$_ar_n" -le 1 ] && return 0
+    list_new _arr_scratch
+    _ar_i=$(( _ar_n - 1 ))
+    while [ "$_ar_i" -ge 0 ]; do
+        list_read _ar_e "$1" "$_ar_i"
+        list_push _arr_scratch "$_ar_e"
+        _ar_i=$(( _ar_i - 1 ))
+    done
+    _arr_copy_over _arr_scratch "$1"
+}
+
+#[pub]
+# Sort it, the way `sort` does.
+#
+# Through a file rather than a pipe, because a pipe puts the read in a subshell
+# and the list it writes there does not survive. An element holding a newline
+# cannot go through `sort` at all and is refused rather than silently split
+# into two, since a sort that loses an element is worse than one that says it
+# cannot.
+#
+# Usage: arr_sort l
+arr_sort() {
+    [ -n "${1:-}" ] || return 1
+    _as_n="$(list_len "$1")"
+    [ "$_as_n" -le 1 ] && return 0
+
+    # A literal newline, because `$(printf '\n')` is the empty string: command
+    # substitution strips trailing newlines, so the pattern became `*""*`, which
+    # matches everything, and the guard refused every list including the ones it
+    # should have sorted. It returned 2 and the caller saw its list unchanged.
+    _as_nl='
+'
+    _as_i=0
+    while [ "$_as_i" -lt "$_as_n" ]; do
+        list_read _as_e "$1" "$_as_i"
+        case "$_as_e" in
+            *"$_as_nl"*) return 2 ;;
+        esac
+        _as_i=$(( _as_i + 1 ))
+    done
+
+    _as_f="$(mktemp "${TMPDIR:-/tmp}/nut-sort.XXXXXX")" || return 1
+    _as_i=0
+    while [ "$_as_i" -lt "$_as_n" ]; do
+        list_read _as_e "$1" "$_as_i"
+        printf '%s\n' "$_as_e"
+        _as_i=$(( _as_i + 1 ))
+    done | sort > "$_as_f"
+
+    list_new "$1"
+    while IFS= read -r _as_e || [ -n "$_as_e" ]; do
+        list_push "$1" "$_as_e"
+    done < "$_as_f"
+    rm -f "$_as_f"
+}
+
+# Move one list's contents over another and empty the source.
+#
+# The three above all build their answer somewhere else and then have to put it
+# back, and doing that by hand three times is how the three drift apart.
+_arr_copy_over() {
+    _ao_n="$(list_len "$1")"
+    list_new "$2"
+    _ao_i=0
+    while [ "$_ao_i" -lt "$_ao_n" ]; do
+        list_read _ao_e "$1" "$_ao_i"
+        list_push "$2" "$_ao_e"
+        _ao_i=$(( _ao_i + 1 ))
+    done
+    list_new "$1"
 }

--- a/lib/array.sh
+++ b/lib/array.sh
@@ -24,9 +24,25 @@
 #   arr_unique l                  # l is now b, a
 # =============================================================================
 
-nut_once || return 0
+# A guard of its own rather than `nut_once`, which reads `BASH_SOURCE` and uses
+# `printf -v`. A file on the floor cannot depend on a bash-only function to
+# decide whether it has been loaded: under a POSIX shell `nut_once` is not
+# found, the `|| return 0` returns from the whole file, and the module then
+# defines nothing while reporting success. That is worse than failing, because
+# the caller has no way to tell.
+[ -n "${_NUTSHELL_ARRAY_SH:-}" ] && return 0
+_NUTSHELL_ARRAY_SH=1
 
-use list
+# `use` where nutshell is loaded, and a plain source where it is not, because
+# this file is on the floor and `use` is not. A POSIX shell sourcing this
+# directly gets the list beside it rather than an error and a half-defined
+# module.
+if command -v use >/dev/null 2>&1; then
+    use list
+elif [ -z "${_NUTSHELL_LIST_SH:-}" ]; then
+    . "${_NUT_ARRAY_DIR:-$(dirname -- "$0")}/list.sh" 2>/dev/null \
+        || . "$(dirname -- "${BASH_SOURCE[0]:-lib/array.sh}")/list.sh"
+fi
 
 # -----------------------------------------------------------------------------
 # Over the arguments
@@ -117,15 +133,41 @@ arr_filter() {
 # Over a list, rewritten in place
 # -----------------------------------------------------------------------------
 
+# A scratch list name for one of the rewrites below, and the refusal that makes
+# it safe.
+#
+# The scratch was a hardcoded global. A list actually called that was silently
+# emptied and the function returned zero, because the copy back did
+# `list_new "$2"` on what was also `$1`. Deriving it from the caller's name
+# removes the collision for every name except one shaped like the derivation
+# itself, and that one is refused.
+#
+# The refusal also catches the other way this is called wrongly. These three
+# used to take a bash array through a nameref, and that call shape now names a
+# list that does not exist: without a check it would report success and leave
+# the array untouched, which is the worst failure available to a consumer
+# upgrading. A name with no list behind it is refused instead.
+_arr_scratch_for() {
+    case "${1:-}" in
+        '' | _arrtmp_* ) return 1 ;;
+    esac
+    # Through the public API, because the two halves of `list` store their
+    # counter in different places and reaching for either one directly makes
+    # this work under one shell and refuse every real list under the other.
+    list_exists "$1" || return 1
+    _as_tmp="_arrtmp_$1"
+    return 0
+}
+
 #[pub]
 # Drop repeats, keeping the first of each and the order of what is left.
 # Usage: arr_unique l
 arr_unique() {
-    [ -n "${1:-}" ] || return 1
+    _arr_scratch_for "${1:-}" || return 1
     _au_n="$(list_len "$1")"
     [ "$_au_n" -le 1 ] && return 0
     _au_seen=""
-    list_new _arr_scratch
+    list_new "$_as_tmp"
     _au_i=0
     while [ "$_au_i" -lt "$_au_n" ]; do
         list_read _au_e "$1" "$_au_i"
@@ -144,29 +186,29 @@ arr_unique() {
             *"${LIST_SEP}${_au_e}${LIST_SEP}"*) : ;;
             *)
                 _au_seen="${_au_seen}${_au_e}${LIST_SEP}"
-                list_push _arr_scratch "$_au_e"
+                list_push "$_as_tmp" "$_au_e"
                 ;;
         esac
         _au_i=$(( _au_i + 1 ))
     done
-    _arr_copy_over _arr_scratch "$1"
+    _arr_copy_over "$_as_tmp" "$1"
 }
 
 #[pub]
 # Reverse it.
 # Usage: arr_reverse l
 arr_reverse() {
-    [ -n "${1:-}" ] || return 1
+    _arr_scratch_for "${1:-}" || return 1
     _ar_n="$(list_len "$1")"
     [ "$_ar_n" -le 1 ] && return 0
-    list_new _arr_scratch
+    list_new "$_as_tmp"
     _ar_i=$(( _ar_n - 1 ))
     while [ "$_ar_i" -ge 0 ]; do
         list_read _ar_e "$1" "$_ar_i"
-        list_push _arr_scratch "$_ar_e"
+        list_push "$_as_tmp" "$_ar_e"
         _ar_i=$(( _ar_i - 1 ))
     done
-    _arr_copy_over _arr_scratch "$1"
+    _arr_copy_over "$_as_tmp" "$1"
 }
 
 #[pub]
@@ -180,7 +222,7 @@ arr_reverse() {
 #
 # Usage: arr_sort l
 arr_sort() {
-    [ -n "${1:-}" ] || return 1
+    _arr_scratch_for "${1:-}" || return 1
     _as_n="$(list_len "$1")"
     [ "$_as_n" -le 1 ] && return 0
 

--- a/lib/array.sh
+++ b/lib/array.sh
@@ -33,15 +33,25 @@
 [ -n "${_NUTSHELL_ARRAY_SH:-}" ] && return 0
 _NUTSHELL_ARRAY_SH=1
 
-# `use` where nutshell is loaded, and a plain source where it is not, because
-# this file is on the floor and `use` is not. A POSIX shell sourcing this
-# directly gets the list beside it rather than an error and a half-defined
-# module.
+# `list` is required and is not resolved from here.
+#
+# The fallback that stood here reached for `BASH_SOURCE` inside the branch that
+# only runs when the shell is not bash, and in dash that is a fatal expansion
+# error rather than a fallback: sourcing this file aborted the caller with
+# status 2 and no message, which is worse than the silent no-op it replaced,
+# in exactly the shell it was written for. `dash -n` does not catch it, because
+# it is a runtime expansion rather than a parse error.
+#
+# There is no fix, only a different design: POSIX gives a sourced file no way to
+# find its own path, and `$0` is the caller. So this refuses instead. `map.sh`
+# and `list.sh` both demonstrate that a floor file is cleanest with nothing to
+# resolve, and this one has a real dependency, so it says so.
 if command -v use >/dev/null 2>&1; then
     use list
-elif [ -z "${_NUTSHELL_LIST_SH:-}" ]; then
-    . "${_NUT_ARRAY_DIR:-$(dirname -- "$0")}/list.sh" 2>/dev/null \
-        || . "$(dirname -- "${BASH_SOURCE[0]:-lib/array.sh}")/list.sh"
+elif ! command -v list_new >/dev/null 2>&1; then
+    printf 'array: needs `list`. Source lib/list.sh before this file, or use\n' >&2
+    printf '  nutshell, which resolves it.\n' >&2
+    return 1
 fi
 
 # -----------------------------------------------------------------------------
@@ -133,41 +143,30 @@ arr_filter() {
 # Over a list, rewritten in place
 # -----------------------------------------------------------------------------
 
-# A scratch list name for one of the rewrites below, and the refusal that makes
-# it safe.
+# The check that a caller passed a list, and not something else.
 #
-# The scratch was a hardcoded global. A list actually called that was silently
-# emptied and the function returned zero, because the copy back did
-# `list_new "$2"` on what was also `$1`. Deriving it from the caller's name
-# removes the collision for every name except one shaped like the derivation
-# itself, and that one is refused.
+# These three used to take a bash array through a nameref. That call shape now
+# names a list that does not exist, and without this they would treat it as an
+# empty list, report success, and leave the array untouched, which is the worst
+# outcome for a consumer upgrading: silent, and rc 0.
 #
-# The refusal also catches the other way this is called wrongly. These three
-# used to take a bash array through a nameref, and that call shape now names a
-# list that does not exist: without a check it would report success and leave
-# the array untouched, which is the worst failure available to a consumer
-# upgrading. A name with no list behind it is refused instead.
-_arr_scratch_for() {
-    case "${1:-}" in
-        '' | _arrtmp_* ) return 1 ;;
-    esac
-    # Through the public API, because the two halves of `list` store their
-    # counter in different places and reaching for either one directly makes
-    # this work under one shell and refuse every real list under the other.
-    list_exists "$1" || return 1
-    _as_tmp="_arrtmp_$1"
-    return 0
+# `list_exists` rather than reaching for either half's storage directly: the
+# two keep their counter in different places, and reaching for one makes this
+# work under one shell and refuse every real list under the other.
+_arr_is_list() {
+    [ -n "${1:-}" ] || return 1
+    list_exists "$1"
 }
 
 #[pub]
 # Drop repeats, keeping the first of each and the order of what is left.
 # Usage: arr_unique l
 arr_unique() {
-    _arr_scratch_for "${1:-}" || return 1
+    _arr_is_list "${1:-}" || return 1
     _au_n="$(list_len "$1")"
     [ "$_au_n" -le 1 ] && return 0
     _au_seen=""
-    list_new "$_as_tmp"
+    _au_keep=""
     _au_i=0
     while [ "$_au_i" -lt "$_au_n" ]; do
         list_read _au_e "$1" "$_au_i"
@@ -186,29 +185,29 @@ arr_unique() {
             *"${LIST_SEP}${_au_e}${LIST_SEP}"*) : ;;
             *)
                 _au_seen="${_au_seen}${_au_e}${LIST_SEP}"
-                list_push "$_as_tmp" "$_au_e"
+                _au_keep="${_au_keep}${_au_e}${LIST_SEP}"
                 ;;
         esac
         _au_i=$(( _au_i + 1 ))
     done
-    _arr_copy_over "$_as_tmp" "$1"
+    _arr_refill "$1" "$_au_keep"
 }
 
 #[pub]
 # Reverse it.
 # Usage: arr_reverse l
 arr_reverse() {
-    _arr_scratch_for "${1:-}" || return 1
+    _arr_is_list "${1:-}" || return 1
     _ar_n="$(list_len "$1")"
     [ "$_ar_n" -le 1 ] && return 0
-    list_new "$_as_tmp"
+    _ar_keep=""
     _ar_i=$(( _ar_n - 1 ))
     while [ "$_ar_i" -ge 0 ]; do
         list_read _ar_e "$1" "$_ar_i"
-        list_push "$_as_tmp" "$_ar_e"
+        _ar_keep="${_ar_keep}${_ar_e}${LIST_SEP}"
         _ar_i=$(( _ar_i - 1 ))
     done
-    _arr_copy_over "$_as_tmp" "$1"
+    _arr_refill "$1" "$_ar_keep"
 }
 
 #[pub]
@@ -222,7 +221,7 @@ arr_reverse() {
 #
 # Usage: arr_sort l
 arr_sort() {
-    _arr_scratch_for "${1:-}" || return 1
+    _arr_is_list "${1:-}" || return 1
     _as_n="$(list_len "$1")"
     [ "$_as_n" -le 1 ] && return 0
 
@@ -256,18 +255,27 @@ arr_sort() {
     rm -f "$_as_f"
 }
 
-# Move one list's contents over another and empty the source.
+# Empty a list and fill it from a separated string.
 #
-# The three above all build their answer somewhere else and then have to put it
-# back, and doing that by hand three times is how the three drift apart.
-_arr_copy_over() {
-    _ao_n="$(list_len "$1")"
-    list_new "$2"
-    _ao_i=0
-    while [ "$_ao_i" -lt "$_ao_n" ]; do
-        list_read _ao_e "$1" "$_ao_i"
-        list_push "$2" "$_ao_e"
-        _ao_i=$(( _ao_i + 1 ))
+# The answer is built in a local string rather than in a second list. A scratch
+# list needed a name, and any name it could have was one a caller might hold:
+# a hardcoded one ate a list called that, and one derived from the caller's ate
+# a list called the derivation. Closing that properly meant reserving the
+# scratch space in `list.sh`, at which point `array.sh` could not use it either,
+# which is the honest signal that the scratch should not have existed.
+#
+# The list refuses an element holding the separator, so splitting on it here
+# cannot break an element apart.
+_arr_refill() {
+    _ao_name="$1"; _ao_str="$2"
+    list_new "$_ao_name"
+    [ -n "$_ao_str" ] || return 0
+    _ao_ifs="$IFS"
+    set -f; IFS="$LIST_SEP"
+    # shellcheck disable=SC2086
+    set -- $_ao_str
+    IFS="$_ao_ifs"; set +f
+    for _ao_e in "$@"; do
+        list_push "$_ao_name" "$_ao_e"
     done
-    list_new "$1"
 }

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -90,6 +90,21 @@ bench_arm() {
     _BENCH_NOTE+=("${4:-}")
 }
 
+#[pub]
+# Clear the arms so a second case can be declared in the same file.
+#
+# Two workloads are two questions, and the agreement control is right to refuse
+# them as one comparison: arms that answer different strings are not competing.
+# A file that wants to ask both declares its arms, runs, resets, and declares
+# the next set. Nothing carries over, the title and the verify function
+# included, so the second case has to name its own and cannot inherit a
+# baseline from the first by accident.
+# Usage: bench_run; bench_reset; bench_case "the next question"
+bench_reset() {
+    _BENCH_LABEL=(); _BENCH_FN=(); _BENCH_CEIL=(); _BENCH_NOTE=()
+    BENCH_TITLE=""; BENCH_VERIFY=""; BENCH_SIZE=0
+}
+
 # One run of one arm, in milliseconds.
 _bench_once() {
     local fn="$1" start end

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -96,9 +96,15 @@ bench_arm() {
 # Two workloads are two questions, and the agreement control is right to refuse
 # them as one comparison: arms that answer different strings are not competing.
 # A file that wants to ask both declares its arms, runs, resets, and declares
-# the next set. Nothing carries over, the title and the verify function
-# included, so the second case has to name its own and cannot inherit a
-# baseline from the first by accident.
+# the next set.
+#
+# Cleared: the arms, their labels, ceilings and notes, the title, the verify
+# function and the size. So a second case has to name its own question and
+# cannot inherit a baseline from the first by accident.
+#
+# Not cleared: `BENCH_REPEATS` and `BENCH_RESULTS`, which describe how the run
+# is taken rather than what it asks. Naming what is cleared beats saying
+# nothing carries over, which was the earlier wording and was false.
 # Usage: bench_run; bench_reset; bench_case "the next question"
 bench_reset() {
     _BENCH_LABEL=(); _BENCH_FN=(); _BENCH_CEIL=(); _BENCH_NOTE=()

--- a/lib/deps.sh
+++ b/lib/deps.sh
@@ -125,18 +125,67 @@ _deps_toml_get() {
 # Use -g for global scope when sourced from within a function (like use())
 declare -g _TOOLS_AVAILABLE=""
 
-# Associative array: tool name -> path
-declare -gA _TOOL_PATH=() 2>/dev/null || declare -A _TOOL_PATH=()
+# One variable per entry rather than four associative arrays.
+#
+# `_TOOL_PATH_sed` holds sed's path, `_TOOL_VARIANT_sed` its variant,
+# `_TOOL_CAN_sed_inplace` whether that capability is present, and
+# `_TOOL_MISSING_jq` marks a tool looked for and not found.
+#
+# Every read of these outside this module names the tool literally:
+# `${_TOOL_PATH_jq}`, `${_TOOL_PATH_curl}`. A literal name is a plain
+# expansion, so the fifteen modules reading them pay nothing at all for the
+# change, and four files' worth of array syntax leaves the floor.
+#
+# Writing needs an `eval`, once per tool at resolution and never on a read.
+# Names go through `_deps_name_ok` first, because `deps_has` takes whatever a
+# caller hands it and that value now reaches `eval`.
+#
+# Capability names are kept in a list because `deps_caps` has to report what is
+# set, and there is no `${!table[@]}` to ask any more.
+declare -g _TOOL_CAN_NAMES=""
 
-# Associative array: tool name -> variant (gnu/bsd/gawk/mawk/nawk/unknown)
-declare -gA _TOOL_VARIANT=() 2>/dev/null || declare -A _TOOL_VARIANT=()
+# A name safe to build a variable out of. Refused rather than encoded: every
+# tool and capability this module has ever had is already `[a-z0-9_]`, so an
+# encoding would be machinery for a case that does not arise, and refusing
+# leaves the `eval` below unable to see anything that is not a name.
+_deps_name_ok() {
+    case "${1:-}" in
+        "" | *[!A-Za-z0-9_]* ) return 1 ;;
+        [0-9]* ) return 1 ;;
+    esac
+    return 0
+}
 
-# Associative array: capability -> 1 (present) or 0 (absent)
-# Capabilities are named as tool_capability, e.g., sed_inplace, grep_pcre
-declare -gA _TOOL_CAN=() 2>/dev/null || declare -A _TOOL_CAN=()
+# _deps_get <destvar> <table> <name>
+#
+# Reads one entry into a variable rather than printing it, so a read costs no
+# subshell. Callers outside this module skip it entirely where the name is a
+# literal and expand `${_TOOL_PATH_jq}` directly.
+_deps_get() {
+    if ! _deps_name_ok "$3"; then eval "$1=''"; return 1; fi
+    eval "$1=\"\${_TOOL_$2_$3:-}\""
+}
 
-# Tools looked for and not found, so a miss is paid for once.
-declare -gA _TOOL_MISSING=() 2>/dev/null || declare -A _TOOL_MISSING=()
+# _deps_set <table> <name> <value>
+_deps_set() {
+    _deps_name_ok "$2" || return 1
+    eval "_TOOL_$1_$2=\$3"
+}
+
+# _deps_can_set <capability> <0|1>
+#
+# Records the name as well as the value. A fixed list of every capability this
+# module knows would report the unset ones as zero, which is a different answer
+# than `deps_caps` used to give: it listed what had been set, and an absent
+# capability was absent rather than false.
+_deps_can_set() {
+    _deps_name_ok "$1" || return 1
+    case " $_TOOL_CAN_NAMES " in
+        *" $1 "*) : ;;
+        *) _TOOL_CAN_NAMES="${_TOOL_CAN_NAMES} $1" ;;
+    esac
+    eval "_TOOL_CAN_$1=\$2"
+}
 
 # The config file, found once at init rather than on every lookup.
 declare -g _DEPS_CONFIG=""
@@ -292,122 +341,122 @@ _deps_detect_find_variant() {
 
 _deps_detect_capabilities() {
     # sed capabilities
-    if [[ -n "${_TOOL_PATH[sed]:-}" ]]; then
-        local sed_cmd="${_TOOL_PATH[sed]}"
-        local variant="${_TOOL_VARIANT[sed]:-unknown}"
+    if [[ -n "${_TOOL_PATH_sed:-}" ]]; then
+        local sed_cmd="${_TOOL_PATH_sed}"
+        local variant="${_TOOL_VARIANT_sed:-unknown}"
         
         # In-place editing
         # GNU: sed -i 'cmd' file
         # BSD: sed -i '' 'cmd' file
-        _TOOL_CAN[sed_inplace]=1
+        _deps_can_set sed_inplace 1
         
         # Extended regex (-E)
         # Both GNU and BSD support -E now
         if "$sed_cmd" -E 's/a/b/' /dev/null 2>/dev/null; then
-            _TOOL_CAN[sed_extended]=1
+            _deps_can_set sed_extended 1
         else
-            _TOOL_CAN[sed_extended]=0
+            _deps_can_set sed_extended 0
         fi
         
         # GNU-specific -r (same as -E but older)
         if [[ "$variant" == "gnu" ]]; then
-            _TOOL_CAN[sed_regex_r]=1
+            _deps_can_set sed_regex_r 1
         else
-            _TOOL_CAN[sed_regex_r]=0
+            _deps_can_set sed_regex_r 0
         fi
     fi
     
     # grep capabilities
-    if [[ -n "${_TOOL_PATH[grep]:-}" ]]; then
-        local grep_cmd="${_TOOL_PATH[grep]}"
+    if [[ -n "${_TOOL_PATH_grep:-}" ]]; then
+        local grep_cmd="${_TOOL_PATH_grep}"
         
         # Extended regex (-E)
-        _TOOL_CAN[grep_extended]=1
+        _deps_can_set grep_extended 1
         
         # PCRE (-P) - mainly GNU grep
         if echo "test" | "$grep_cmd" -P "t.st" &>/dev/null; then
-            _TOOL_CAN[grep_pcre]=1
+            _deps_can_set grep_pcre 1
         else
-            _TOOL_CAN[grep_pcre]=0
+            _deps_can_set grep_pcre 0
         fi
         
         # --include/--exclude for recursive searches
         if "$grep_cmd" --help 2>&1 | grep -q -- '--include'; then
-            _TOOL_CAN[grep_include]=1
+            _deps_can_set grep_include 1
         else
-            _TOOL_CAN[grep_include]=0
+            _deps_can_set grep_include 0
         fi
         
         # -o (only matching)
         if echo "test" | "$grep_cmd" -o "es" &>/dev/null; then
-            _TOOL_CAN[grep_only_matching]=1
+            _deps_can_set grep_only_matching 1
         else
-            _TOOL_CAN[grep_only_matching]=0
+            _deps_can_set grep_only_matching 0
         fi
     fi
     
     # awk capabilities
-    if [[ -n "${_TOOL_PATH[awk]:-}" ]]; then
-        local awk_cmd="${_TOOL_PATH[awk]}"
-        local variant="${_TOOL_VARIANT[awk]:-unknown}"
+    if [[ -n "${_TOOL_PATH_awk:-}" ]]; then
+        local awk_cmd="${_TOOL_PATH_awk}"
+        local variant="${_TOOL_VARIANT_awk:-unknown}"
         
         # Regex matching (all awks have this)
-        _TOOL_CAN[awk_regex]=1
+        _deps_can_set awk_regex 1
         
         # gawk-specific features
         if [[ "$variant" == "gawk" ]]; then
-            _TOOL_CAN[awk_nextfile]=1
-            _TOOL_CAN[awk_strftime]=1
-            _TOOL_CAN[awk_gensub]=1
+            _deps_can_set awk_nextfile 1
+            _deps_can_set awk_strftime 1
+            _deps_can_set awk_gensub 1
         else
-            _TOOL_CAN[awk_nextfile]=0
-            _TOOL_CAN[awk_strftime]=0
-            _TOOL_CAN[awk_gensub]=0
+            _deps_can_set awk_nextfile 0
+            _deps_can_set awk_strftime 0
+            _deps_can_set awk_gensub 0
         fi
     fi
     
     # stat capabilities
-    if [[ -n "${_TOOL_PATH[stat]:-}" ]]; then
-        local stat_cmd="${_TOOL_PATH[stat]}"
-        local variant="${_TOOL_VARIANT[stat]:-unknown}"
+    if [[ -n "${_TOOL_PATH_stat:-}" ]]; then
+        local stat_cmd="${_TOOL_PATH_stat}"
+        local variant="${_TOOL_VARIANT_stat:-unknown}"
         
         # Format strings
         if [[ "$variant" == "gnu" ]] || [[ "$variant" == "bsd" ]]; then
-            _TOOL_CAN[stat_format]=1
+            _deps_can_set stat_format 1
         else
-            _TOOL_CAN[stat_format]=0
+            _deps_can_set stat_format 0
         fi
     fi
     
     # perl capabilities
-    if [[ -n "${_TOOL_PATH[perl]:-}" ]]; then
-        local perl_cmd="${_TOOL_PATH[perl]}"
+    if [[ -n "${_TOOL_PATH_perl:-}" ]]; then
+        local perl_cmd="${_TOOL_PATH_perl}"
         
         # Basic perl is always capable
-        _TOOL_CAN[perl_regex]=1
-        _TOOL_CAN[perl_inplace]=1
+        _deps_can_set perl_regex 1
+        _deps_can_set perl_inplace 1
         
         # Check for common modules (optional)
         if "$perl_cmd" -MJSON -e '1' 2>/dev/null; then
-            _TOOL_CAN[perl_json]=1
+            _deps_can_set perl_json 1
         else
-            _TOOL_CAN[perl_json]=0
+            _deps_can_set perl_json 0
         fi
     fi
     
     # find capabilities
-    if [[ -n "${_TOOL_PATH[find]:-}" ]]; then
-        local find_cmd="${_TOOL_PATH[find]}"
-        local variant="${_TOOL_VARIANT[find]:-unknown}"
+    if [[ -n "${_TOOL_PATH_find:-}" ]]; then
+        local find_cmd="${_TOOL_PATH_find}"
+        local variant="${_TOOL_VARIANT_find:-unknown}"
         
         # -maxdepth (both have it now)
-        _TOOL_CAN[find_maxdepth]=1
+        _deps_can_set find_maxdepth 1
         
         # -printf (GNU only)
         if [[ "$variant" == "gnu" ]]; then
-            _TOOL_CAN[find_printf]=1
+            _deps_can_set find_printf 1
         else
-            _TOOL_CAN[find_printf]=0
+            _deps_can_set find_printf 0
         fi
     fi
 }
@@ -432,17 +481,17 @@ _deps_init() {
     
     for tool in "${tools[@]}"; do
         if path="$(_deps_find_tool "$tool" "$config_file")"; then
-            _TOOL_PATH[$tool]="$path"
+            _deps_set PATH "$tool" "$path"
             available+=("$tool")
             
             # Detect variant for tools that have meaningful variants
             case "$tool" in
-                sed)  _TOOL_VARIANT[$tool]="$(_deps_detect_sed_variant "$path")" ;;
-                awk)  _TOOL_VARIANT[$tool]="$(_deps_detect_awk_variant "$path")" ;;
-                grep) _TOOL_VARIANT[$tool]="$(_deps_detect_grep_variant "$path")" ;;
-                stat) _TOOL_VARIANT[$tool]="$(_deps_detect_stat_variant "$path")" ;;
-                find) _TOOL_VARIANT[$tool]="$(_deps_detect_find_variant "$path")" ;;
-                *)    _TOOL_VARIANT[$tool]="standard" ;;
+                sed)  _deps_set VARIANT "$tool" "$(_deps_detect_sed_variant "$path")" ;;
+                awk)  _deps_set VARIANT "$tool" "$(_deps_detect_awk_variant "$path")" ;;
+                grep) _deps_set VARIANT "$tool" "$(_deps_detect_grep_variant "$path")" ;;
+                stat) _deps_set VARIANT "$tool" "$(_deps_detect_stat_variant "$path")" ;;
+                find) _deps_set VARIANT "$tool" "$(_deps_detect_find_variant "$path")" ;;
+                *)    _deps_set VARIANT "$tool" standard ;;
             esac
         fi
     done
@@ -477,8 +526,9 @@ _deps_init
 deps_has() {
     local tool="${1:-}"
     [[ -z "$tool" ]] && return 1
-    [[ -n "${_TOOL_PATH[$tool]:-}" ]] && return 0
-    [[ -n "${_TOOL_MISSING[$tool]:-}" ]] && return 1
+    local _hit
+    _deps_get _hit PATH "$tool"    && [[ -n "$_hit" ]] && return 0
+    _deps_get _hit MISSING "$tool" && [[ -n "$_hit" ]] && return 1
 
     # Anything not in the eager list is looked for now, once, and remembered.
     #
@@ -491,11 +541,11 @@ deps_has() {
     # wrong to ask. The answer was.
     local path
     if path="$(_deps_find_tool "$tool" "$_DEPS_CONFIG")"; then
-        _TOOL_PATH[$tool]="$path"
+        _deps_set PATH "$tool" "$path"
         _TOOLS_AVAILABLE="${_TOOLS_AVAILABLE} ${tool}"
         return 0
     fi
-    _TOOL_MISSING[$tool]=1
+    _deps_set MISSING "$tool" 1
     return 1
 }
 
@@ -546,7 +596,8 @@ deps_path() {
     # asking where it was did not, because only the first had been taught to
     # look.
     deps_has "$tool" || return 1
-    printf '%s\n' "${_TOOL_PATH[$tool]}"
+    local _p; _deps_get _p PATH "$tool"
+    printf '%s\n' "$_p"
 }
 
 #[pub]
@@ -554,7 +605,8 @@ deps_path() {
 # Usage: deps_variant "sed" -> "gnu" or "bsd"
 deps_variant() {
     local tool="${1:-}"
-    echo "${_TOOL_VARIANT[$tool]:-unknown}"
+    local _v; _deps_get _v VARIANT "$tool"
+    echo "${_v:-unknown}"
 }
 
 #[pub]
@@ -562,7 +614,7 @@ deps_variant() {
 # Usage: deps_is_gnu "sed" -> returns 0 or 1
 deps_is_gnu() {
     local tool="${1:-}"
-    local variant="${_TOOL_VARIANT[$tool]:-}"
+    local variant; _deps_get variant VARIANT "$tool"
     [[ "$variant" == "gnu" ]] || [[ "$variant" == "gawk" ]]
 }
 
@@ -571,7 +623,7 @@ deps_is_gnu() {
 # Usage: deps_is_bsd "sed" -> returns 0 or 1
 deps_is_bsd() {
     local tool="${1:-}"
-    local variant="${_TOOL_VARIANT[$tool]:-}"
+    local variant; _deps_get variant VARIANT "$tool"
     [[ "$variant" == "bsd" ]]
 }
 
@@ -584,7 +636,8 @@ deps_is_bsd() {
 # Usage: deps_can "grep_pcre" -> returns 0 or 1
 deps_can() {
     local cap="${1:-}"
-    [[ "${_TOOL_CAN[$cap]:-0}" == "1" ]]
+    local _c; _deps_get _c CAN "$cap"
+    [[ "${_c:-0}" == "1" ]]
 }
 
 #[pub]
@@ -592,16 +645,18 @@ deps_can() {
 # Usage: deps_cap "grep_pcre" -> "1" or "0"
 deps_cap() {
     local cap="${1:-}"
-    echo "${_TOOL_CAN[$cap]:-0}"
+    local _c; _deps_get _c CAN "$cap"
+    echo "${_c:-0}"
 }
 
 #[pub]
 # List all capabilities (one per line: cap=value)
 # Usage: deps_caps -> "sed_inplace=1\ngrep_pcre=1\n..."
 deps_caps() {
-    local cap
-    for cap in "${!_TOOL_CAN[@]}"; do
-        echo "${cap}=${_TOOL_CAN[$cap]}"
+    local cap _c
+    for cap in $_TOOL_CAN_NAMES; do
+        _deps_get _c CAN "$cap"
+        echo "${cap}=${_c}"
     done | sort
 }
 
@@ -670,8 +725,8 @@ deps_info() {
     
     local tool path variant
     for tool in sed awk grep perl stat mktemp find sort wc tr head tail cut tee xargs; do
-        path="${_TOOL_PATH[$tool]:-}"
-        variant="${_TOOL_VARIANT[$tool]:-}"
+        _deps_get path PATH "$tool"
+        _deps_get variant VARIANT "$tool"
         
         if [[ -n "$path" ]]; then
             printf "  %-10s %s" "$tool:" "$path"
@@ -741,7 +796,7 @@ deps_run() {
 deps_sed_inplace() {
     local pattern="$1"
     local file="$2"
-    local sed_path="${_TOOL_PATH[sed]:-sed}"
+    local sed_path="${_TOOL_PATH_sed:-sed}"
     
     if deps_is_gnu "sed"; then
         "$sed_path" -i "$pattern" "$file"
@@ -756,7 +811,7 @@ deps_sed_inplace() {
 # Usage: deps_stat_size "file" -> "12345"
 deps_stat_size() {
     local file="$1"
-    local stat_path="${_TOOL_PATH[stat]:-stat}"
+    local stat_path="${_TOOL_PATH_stat:-stat}"
     
     if deps_is_gnu "stat"; then
         "$stat_path" -c%s "$file"
@@ -770,7 +825,7 @@ deps_stat_size() {
 # Usage: deps_stat_mtime "file" -> "1234567890"
 deps_stat_mtime() {
     local file="$1"
-    local stat_path="${_TOOL_PATH[stat]:-stat}"
+    local stat_path="${_TOOL_PATH_stat:-stat}"
     
     if deps_is_gnu "stat"; then
         "$stat_path" -c%Y "$file"

--- a/lib/deps.sh
+++ b/lib/deps.sh
@@ -168,14 +168,42 @@ _deps_key() {
         *[!A-Za-z0-9_]* ) : ;;
         * ) _dk="$1"; return 0 ;;
     esac
+    # Bytes, not characters, and that is what `LC_ALL=C` is for.
+    #
+    # `printf '%d' "'c"` gives a codepoint and `%02x` is a minimum width rather
+    # than a fixed one, so a character above U+00FF produces four hex digits
+    # and the concatenation stops being prefix-free. `€` is `20ac`; so is a
+    # space followed by `¬`. Two names, one variable, and the second reads the
+    # first's path. Under `LC_ALL=C` both the character walk and the numeric
+    # conversion go byte-wise, every byte is exactly two digits, and the
+    # property holds.
+    _dk_loc="${LC_ALL:-}"
+    LC_ALL=C
     _dk="enc_"
     _dk_in="$1"
     while [ -n "$_dk_in" ]; do
         _dk_c="${_dk_in%"${_dk_in#?}"}"
         _dk_in="${_dk_in#?}"
-        _dk="${_dk}$(printf '%02x' "$(printf '%d' "'$_dk_c")")"
+        _deps_hex "$_dk_c"
+        _dk="${_dk}${_dh}"
     done
+    LC_ALL="$_dk_loc"
+    [ -n "$_dk_loc" ] || unset LC_ALL
     return 0
+}
+
+# One byte as two hex digits, without a fork.
+#
+# It ran two command substitutions per byte, which is the pattern taken out of
+# `lib/map.sh` in the same branch. The table covers what a tool name actually
+# holds; anything else falls back to the fork and is rare enough not to matter.
+_deps_hex() {
+    case "$1" in
+        -) _dh=2d ;;  .) _dh=2e ;;  +) _dh=2b ;;  '~') _dh=7e ;;
+        0) _dh=30 ;;  1) _dh=31 ;;  2) _dh=32 ;;  3) _dh=33 ;;  4) _dh=34 ;;
+        5) _dh=35 ;;  6) _dh=36 ;;  7) _dh=37 ;;  8) _dh=38 ;;  9) _dh=39 ;;
+        *) _dh="$(printf '%02x' "$(printf '%d' "'$1")")" ;;
+    esac
 }
 
 # _deps_get <destvar> <table> <name>
@@ -201,7 +229,17 @@ _deps_set() {
 # than `deps_caps` used to give: it listed what had been set, and an absent
 # capability was absent rather than false.
 _deps_can_set() {
-    _deps_key "$1" || return 1
+    # A capability name has to be a variable name already, and every one this
+    # module has is an internal literal like `grep_pcre`. It is not encoded,
+    # because `_TOOL_CAN_NAMES` is a space-separated list and `deps_caps`
+    # splits it: an encoded name and a raw one in the same list disagree the
+    # moment either holds a space, and `deps_caps` then emits two rows with
+    # empty values. Tools are caller-supplied and get encoded; capabilities are
+    # ours and get refused.
+    case "${1:-}" in
+        "" | *[!A-Za-z0-9_]* | [0-9]* ) return 1 ;;
+    esac
+    _dk="$1"
     case " $_TOOL_CAN_NAMES " in
         *" $1 "*) : ;;
         *) _TOOL_CAN_NAMES="${_TOOL_CAN_NAMES} $1" ;;

--- a/lib/deps.sh
+++ b/lib/deps.sh
@@ -144,15 +144,37 @@ declare -g _TOOLS_AVAILABLE=""
 # set, and there is no `${!table[@]}` to ask any more.
 declare -g _TOOL_CAN_NAMES=""
 
-# A name safe to build a variable out of. Refused rather than encoded: every
-# tool and capability this module has ever had is already `[a-z0-9_]`, so an
-# encoding would be machinery for a case that does not arise, and refusing
-# leaves the `eval` below unable to see anything that is not a name.
-_deps_name_ok() {
+# A tool or capability name, as the tail of a variable name. One-to-one.
+#
+# A name that is already `[A-Za-z0-9_]` and does not begin `enc_` is used as
+# itself, so `${_TOOL_PATH_jq}` and `${_TOOL_PATH_grep_pcre}` stay plain
+# expansions and the sixteen modules reading them literally pay nothing.
+#
+# Anything else is hex-encoded whole, behind `enc_`. A name that is safe but
+# begins `enc_` takes the encoded path too, which is what makes the mapping
+# one-to-one: without that, a tool genuinely called `enc_706b67` would collide
+# with `pkg` and one of them would read the other's path.
+#
+# Refusing instead was tried and was wrong. `deps_has` is documented to look up
+# anything not in the eager list, and half the binaries worth asking about have
+# a hyphen or a digit in them: `pkg-config`, `git-lfs`, `7z`. Refusing made
+# `deps_has pkg-config` answer yes with an empty path, which is the one outcome
+# that is worse than either alternative.
+_deps_key() {
     case "${1:-}" in
-        "" | *[!A-Za-z0-9_]* ) return 1 ;;
-        [0-9]* ) return 1 ;;
+        "" ) _dk=""; return 1 ;;
+        enc_* ) : ;;
+        [0-9]* ) : ;;
+        *[!A-Za-z0-9_]* ) : ;;
+        * ) _dk="$1"; return 0 ;;
     esac
+    _dk="enc_"
+    _dk_in="$1"
+    while [ -n "$_dk_in" ]; do
+        _dk_c="${_dk_in%"${_dk_in#?}"}"
+        _dk_in="${_dk_in#?}"
+        _dk="${_dk}$(printf '%02x' "$(printf '%d' "'$_dk_c")")"
+    done
     return 0
 }
 
@@ -162,14 +184,14 @@ _deps_name_ok() {
 # subshell. Callers outside this module skip it entirely where the name is a
 # literal and expand `${_TOOL_PATH_jq}` directly.
 _deps_get() {
-    if ! _deps_name_ok "$3"; then eval "$1=''"; return 1; fi
-    eval "$1=\"\${_TOOL_$2_$3:-}\""
+    _deps_key "$3" || { eval "$1=''"; return 1; }
+    eval "$1=\"\${_TOOL_$2_${_dk}:-}\""
 }
 
 # _deps_set <table> <name> <value>
 _deps_set() {
-    _deps_name_ok "$2" || return 1
-    eval "_TOOL_$1_$2=\$3"
+    _deps_key "$2" || return 1
+    eval "_TOOL_$1_${_dk}=\$3"
 }
 
 # _deps_can_set <capability> <0|1>
@@ -179,12 +201,12 @@ _deps_set() {
 # than `deps_caps` used to give: it listed what had been set, and an absent
 # capability was absent rather than false.
 _deps_can_set() {
-    _deps_name_ok "$1" || return 1
+    _deps_key "$1" || return 1
     case " $_TOOL_CAN_NAMES " in
         *" $1 "*) : ;;
         *) _TOOL_CAN_NAMES="${_TOOL_CAN_NAMES} $1" ;;
     esac
-    eval "_TOOL_CAN_$1=\$2"
+    eval "_TOOL_CAN_${_dk}=\$2"
 }
 
 # The config file, found once at init rather than on every lookup.

--- a/lib/fs.sh
+++ b/lib/fs.sh
@@ -256,7 +256,7 @@ fs_size() {
     local impl=""
     
     if deps_has "stat"; then
-        local variant="${_TOOL_VARIANT[stat]:-unknown}"
+        local variant="${_TOOL_VARIANT_stat:-unknown}"
         case "$variant" in
             gnu)     impl="stat_gnu" ;;
             bsd)     impl="stat_bsd" ;;
@@ -319,7 +319,7 @@ fs_mtime() {
     local impl=""
     
     if deps_has "stat"; then
-        local variant="${_TOOL_VARIANT[stat]:-unknown}"
+        local variant="${_TOOL_VARIANT_stat:-unknown}"
         case "$variant" in
             gnu)     impl="stat_gnu" ;;
             bsd)     impl="stat_bsd" ;;
@@ -381,7 +381,7 @@ fs_temp_file() {
     local prefix="${1:-tmp}"
     
     if deps_has "mktemp"; then
-        "${_TOOL_PATH[mktemp]}" "${TMPDIR:-/tmp}/${prefix}.XXXXXX"
+        "${_TOOL_PATH_mktemp}" "${TMPDIR:-/tmp}/${prefix}.XXXXXX"
     else
         # Fallback using $$ and RANDOM
         local path="${TMPDIR:-/tmp}/${prefix}.${$}.${RANDOM}"
@@ -396,7 +396,7 @@ fs_temp_dir() {
     local prefix="${1:-tmp}"
     
     if deps_has "mktemp"; then
-        "${_TOOL_PATH[mktemp]}" -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX"
+        "${_TOOL_PATH_mktemp}" -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX"
     else
         # Fallback using $$ and RANDOM
         local path="${TMPDIR:-/tmp}/${prefix}.${$}.${RANDOM}"

--- a/lib/fs/impl/perl_stat.sh
+++ b/lib/fs/impl/perl_stat.sh
@@ -18,7 +18,7 @@ _fs_size_perl_impl() {
     local path="${1:-}"
     [[ ! -f "$path" ]] && return 1
     
-    local perl_path="${_TOOL_PATH[perl]:-perl}"
+    local perl_path="${_TOOL_PATH_perl:-perl}"
     
     # perl stat returns list: (dev, ino, mode, nlink, uid, gid, rdev, size, ...)
     # Index 7 is size
@@ -30,7 +30,7 @@ _fs_mtime_perl_impl() {
     local path="${1:-}"
     [[ ! -e "$path" ]] && return 1
     
-    local perl_path="${_TOOL_PATH[perl]:-perl}"
+    local perl_path="${_TOOL_PATH_perl:-perl}"
     
     # perl stat returns list: (..., atime, mtime, ctime)
     # Index 9 is mtime

--- a/lib/fs/impl/stat_bsd.sh
+++ b/lib/fs/impl/stat_bsd.sh
@@ -17,7 +17,7 @@ _fs_size_stat_bsd_impl() {
     local path="${1:-}"
     [[ ! -f "$path" ]] && return 1
     
-    local stat_path="${_TOOL_PATH[stat]:-stat}"
+    local stat_path="${_TOOL_PATH_stat:-stat}"
     
     # BSD stat uses -f for format, %z for size in bytes
     "$stat_path" -f%z "$path"
@@ -28,7 +28,7 @@ _fs_mtime_stat_bsd_impl() {
     local path="${1:-}"
     [[ ! -e "$path" ]] && return 1
     
-    local stat_path="${_TOOL_PATH[stat]:-stat}"
+    local stat_path="${_TOOL_PATH_stat:-stat}"
     
     # BSD stat uses -f for format, %m for mtime as epoch seconds
     "$stat_path" -f%m "$path"

--- a/lib/fs/impl/stat_gnu.sh
+++ b/lib/fs/impl/stat_gnu.sh
@@ -15,7 +15,7 @@ _fs_size_stat_gnu_impl() {
     local path="${1:-}"
     [[ ! -f "$path" ]] && return 1
     
-    local stat_path="${_TOOL_PATH[stat]:-stat}"
+    local stat_path="${_TOOL_PATH_stat:-stat}"
     
     # GNU stat uses -c for format, %s for size in bytes
     "$stat_path" -c%s "$path"
@@ -26,7 +26,7 @@ _fs_mtime_stat_gnu_impl() {
     local path="${1:-}"
     [[ ! -e "$path" ]] && return 1
     
-    local stat_path="${_TOOL_PATH[stat]:-stat}"
+    local stat_path="${_TOOL_PATH_stat:-stat}"
     
     # GNU stat uses -c for format, %Y for mtime as epoch seconds
     "$stat_path" -c%Y "$path"

--- a/lib/http.sh
+++ b/lib/http.sh
@@ -81,7 +81,7 @@ _http_request_curl() {
     shift 3
     local -a extra_args=("$@")
     
-    local curl_cmd="${_TOOL_PATH[curl]}"
+    local curl_cmd="${_TOOL_PATH_curl}"
     local -a curl_args=(
         -s                              # Silent
         -S                              # Show errors
@@ -154,7 +154,7 @@ _http_request_wget() {
     shift 3
     local -a extra_args=("$@")
     
-    local wget_cmd="${_TOOL_PATH[wget]}"
+    local wget_cmd="${_TOOL_PATH_wget}"
     local -a wget_args=(
         -q                              # Quiet
         -O -                            # Output to stdout
@@ -468,12 +468,12 @@ http_download() {
     [[ "$_HTTP_READY" != "1" ]] && return 1
     
     if [[ "$_HTTP_IMPL" == "curl" ]]; then
-        "${_TOOL_PATH[curl]}" -sS -L -o "$output" \
+        "${_TOOL_PATH_curl}" -sS -L -o "$output" \
             --max-time "$HTTP_TIMEOUT" \
             -A "$HTTP_USER_AGENT" \
             "$url"
     else
-        "${_TOOL_PATH[wget]}" -q -O "$output" \
+        "${_TOOL_PATH_wget}" -q -O "$output" \
             --timeout="$HTTP_TIMEOUT" \
             --user-agent="$HTTP_USER_AGENT" \
             "$url"
@@ -496,7 +496,7 @@ http_upload() {
     
     if [[ "$_HTTP_IMPL" == "curl" ]]; then
         local output
-        output=$("${_TOOL_PATH[curl]}" -sS -w '\n%{http_code}' \
+        output=$("${_TOOL_PATH_curl}" -sS -w '\n%{http_code}' \
             -X POST \
             -F "${field}=@${file}" \
             --max-time "$HTTP_TIMEOUT" \

--- a/lib/json/impl/jq.sh
+++ b/lib/json/impl/jq.sh
@@ -62,7 +62,7 @@ _jq_present() {
         parent="$(_jq_path "${dotted%.*}")"
     fi
 
-    answer="$(printf '%s' "$json" | "${_TOOL_PATH[jq]}" -r \
+    answer="$(printf '%s' "$json" | "${_TOOL_PATH_jq}" -r \
         "${parent} | if type == \"object\" then has(\"${last}\")
          elif type == \"array\" then ((\"${last}\" | tonumber? // -1) as \$i
               | \$i >= 0 and \$i < length)
@@ -76,7 +76,7 @@ _json_get_jq() {
     _jq_present "$json" "$path" || return 1
 
     expr="$(_jq_path "$path")"
-    printf '%s\n' "$json" | "${_TOOL_PATH[jq]}" -c -S -r "$expr" 2>/dev/null
+    printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -c -S -r "$expr" 2>/dev/null
 }
 
 _json_set_jq() {
@@ -87,45 +87,45 @@ _json_set_jq() {
     if [[ "$value" == "true" || "$value" == "false" || "$value" == "null" || \
           "$value" =~ ^-?[0-9]+(\.[0-9]+)?$ || \
           "$value" == "["* || "$value" == "{"* ]]; then
-        printf '%s\n' "$json" | "${_TOOL_PATH[jq]}" -c -S "$expr = $value" 2>/dev/null
+        printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -c -S "$expr = $value" 2>/dev/null
     else
-        printf '%s\n' "$json" | "${_TOOL_PATH[jq]}" -c -S --arg v "$value" "$expr = \$v" 2>/dev/null
+        printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -c -S --arg v "$value" "$expr = \$v" 2>/dev/null
     fi
 }
 
 _json_keys_jq() {
     local json="${1:-}" path="${2:-}" expr
     expr="$(_jq_path "$path")"
-    printf '%s\n' "$json" | "${_TOOL_PATH[jq]}" -r "$expr | if type == \"array\" then range(length) else keys[] end" 2>/dev/null
+    printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -r "$expr | if type == \"array\" then range(length) else keys[] end" 2>/dev/null
 }
 
 _json_valid_jq() {
     local json="${1:-}"
-    printf '%s\n' "$json" | "${_TOOL_PATH[jq]}" -e . >/dev/null 2>&1
+    printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -e . >/dev/null 2>&1
 }
 
 _json_pretty_jq() {
     local json="${1:-}"
-    printf '%s\n' "$json" | "${_TOOL_PATH[jq]}" -S '.' 2>/dev/null
+    printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -S '.' 2>/dev/null
 }
 
 _json_compact_jq() {
     local json="${1:-}"
-    printf '%s\n' "$json" | "${_TOOL_PATH[jq]}" -c -S '.' 2>/dev/null
+    printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -c -S '.' 2>/dev/null
 }
 
 _json_type_jq() {
     local json="${1:-}" path="${2:-}" expr
     _jq_present "$json" "$path" || return 1
     expr="$(_jq_path "$path")"
-    printf '%s\n' "$json" | "${_TOOL_PATH[jq]}" -r "$expr | type" 2>/dev/null
+    printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -r "$expr | type" 2>/dev/null
 }
 
 _json_length_jq() {
     local json="${1:-}" path="${2:-}" expr
     _jq_present "$json" "$path" || return 1
     expr="$(_jq_path "$path")"
-    printf '%s\n' "$json" | "${_TOOL_PATH[jq]}" -r "$expr | length" 2>/dev/null
+    printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -r "$expr | length" 2>/dev/null
 }
 
 # `*` recurses into objects where python's `update` and perl's slice assignment
@@ -134,12 +134,12 @@ _json_length_jq() {
 # into it.
 _json_merge_jq() {
     local json1="$1" json2="$2"
-    printf '%s\n' "$json1" | "${_TOOL_PATH[jq]}" -c -S ". + $json2" 2>/dev/null
+    printf '%s\n' "$json1" | "${_TOOL_PATH_jq}" -c -S ". + $json2" 2>/dev/null
 }
 
 # `del` printed its result formatted while python and perl printed it compact.
 _json_delete_jq() {
     local json="$1" path="$2" expr
     expr="$(_jq_path "$path")"
-    printf '%s\n' "$json" | "${_TOOL_PATH[jq]}" -c -S "del($expr)" 2>/dev/null
+    printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -c -S "del($expr)" 2>/dev/null
 }

--- a/lib/json/impl/jq.sh
+++ b/lib/json/impl/jq.sh
@@ -29,15 +29,20 @@ nut_once || return 0
 # answered `0.1`. Bracket form for both kinds, and a name is quoted so a key
 # holding a dash or a space stays one segment.
 _jq_path() {
-    local dotted="${1:-}" expr="." seg oldifs
+    local dotted="${1:-}" expr="." seg oldifs oldf
     case "$dotted" in .*) dotted="${dotted#.}" ;; esac
     [ -z "$dotted" ] && { printf '.'; return 0; }
 
     oldifs="$IFS"
+    # `set -f` is restored to what it was rather than turned off. A caller that
+    # had globbing disabled got it back on, which is a change this function has
+    # no business making. The `dev` version used `local IFS` and touched
+    # neither.
+    case "$-" in *f*) oldf=1 ;; *) oldf=0 ;; esac
     set -f; IFS='.'
     # shellcheck disable=SC2086
     for seg in $dotted; do
-        IFS="$oldifs"; set +f
+        IFS="$oldifs"; [ "$oldf" = 1 ] || set +f
         if [ -n "$seg" ]; then
             case "$seg" in
                 *[!0-9]*) expr="${expr}[\"${seg}\"]" ;;
@@ -46,7 +51,7 @@ _jq_path() {
         fi
         set -f; IFS='.'
     done
-    IFS="$oldifs"; set +f
+    IFS="$oldifs"; [ "$oldf" = 1 ] || set +f
     printf '%s' "$expr"
 }
 

--- a/lib/json/impl/jq.sh
+++ b/lib/json/impl/jq.sh
@@ -29,20 +29,41 @@ nut_once || return 0
 # answered `0.1`. Bracket form for both kinds, and a name is quoted so a key
 # holding a dash or a space stays one segment.
 _jq_path() {
-    local dotted="${1:-}" expr="." seg
-    [[ "$dotted" == .* ]] && dotted="${dotted#.}"
-    [[ -z "$dotted" ]] && { printf '.'; return 0; }
+    local dotted="${1:-}" expr="." seg oldifs
+    case "$dotted" in .*) dotted="${dotted#.}" ;; esac
+    [ -z "$dotted" ] && { printf '.'; return 0; }
 
-    local IFS='.'
+    oldifs="$IFS"
+    set -f; IFS='.'
+    # shellcheck disable=SC2086
     for seg in $dotted; do
-        [[ -z "$seg" ]] && continue
-        if [[ "$seg" =~ ^[0-9]+$ ]]; then
-            expr+="[${seg}]"
-        else
-            expr+="[\"${seg}\"]"
+        IFS="$oldifs"; set +f
+        if [ -n "$seg" ]; then
+            case "$seg" in
+                *[!0-9]*) expr="${expr}[\"${seg}\"]" ;;
+                *)        expr="${expr}[${seg}]" ;;
+            esac
         fi
+        set -f; IFS='.'
     done
+    IFS="$oldifs"; set +f
     printf '%s' "$expr"
+}
+
+# Whether a jq value is a number rather than a string, so `_json_set_jq` knows
+# whether to quote it. Written as `case` because the shape it recognises is a
+# glob's worth of work and `[[ =~ ]]` is bash.
+_jq_is_number() {
+    local n="${1:-}"
+    case "$n" in -*) n="${n#-}" ;; esac
+    case "$n" in
+        '' | *[!0-9.]* ) return 1 ;;   # empty, or a character that is neither
+        .* | *. )        return 1 ;;   # a dot at either end
+    esac
+    case "${n#*.}" in
+        *.* ) return 1 ;;              # more than one dot
+    esac
+    return 0
 }
 
 # _jq_present <json> <dotted-path> -> 0 when the path leads somewhere
@@ -52,11 +73,11 @@ _jq_path() {
 # apart, and `json_get_or` has to.
 _jq_present() {
     local json="$1" dotted="${2:-}" parent last answer
-    [[ "$dotted" == .* ]] && dotted="${dotted#.}"
-    [[ -z "$dotted" ]] && return 0
+    case "$dotted" in .*) dotted="${dotted#.}" ;; esac
+    [ -z "$dotted" ] && return 0
 
     last="${dotted##*.}"
-    if [[ "$last" == "$dotted" ]]; then
+    if [ "$last" = "$dotted" ]; then
         parent="."
     else
         parent="$(_jq_path "${dotted%.*}")"
@@ -67,7 +88,7 @@ _jq_present() {
          elif type == \"array\" then ((\"${last}\" | tonumber? // -1) as \$i
               | \$i >= 0 and \$i < length)
          else false end" 2>/dev/null)"
-    [[ "$answer" == "true" ]]
+    [ "$answer" = "true" ]
 }
 
 _json_get_jq() {
@@ -79,14 +100,23 @@ _json_get_jq() {
     printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -c -S -r "$expr" 2>/dev/null
 }
 
+# Whether the value is already a JSON literal: a keyword, a number, an array or
+# an object. Everything else is a string.
+_jq_is_json_literal() {
+    case "${1:-}" in
+        true | false | null ) return 0 ;;
+        '['* | '{'* )         return 0 ;;
+    esac
+    _jq_is_number "${1:-}"
+}
+
 _json_set_jq() {
     local json="${1:-}" path="${2:-}" value="${3:-}" expr
     expr="$(_jq_path "$path")"
 
-    # Determine if value is a string or other JSON type
-    if [[ "$value" == "true" || "$value" == "false" || "$value" == "null" || \
-          "$value" =~ ^-?[0-9]+(\.[0-9]+)?$ || \
-          "$value" == "["* || "$value" == "{"* ]]; then
+    # A value that is already JSON goes in unquoted; anything else is a string
+    # and goes through `--arg` so jq quotes it.
+    if _jq_is_json_literal "$value"; then
         printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -c -S "$expr = $value" 2>/dev/null
     else
         printf '%s\n' "$json" | "${_TOOL_PATH_jq}" -c -S --arg v "$value" "$expr = \$v" 2>/dev/null

--- a/lib/json/impl/perl.sh
+++ b/lib/json/impl/perl.sh
@@ -31,7 +31,7 @@ nut_once || return 0
 
 # _json_pl <operation> <arguments...>
 _json_pl() {
-    "${_TOOL_PATH[perl]}" -MJSON::PP -e '
+    "${_TOOL_PATH_perl}" -MJSON::PP -e '
         use strict;
         use warnings;
 

--- a/lib/json/impl/python.sh
+++ b/lib/json/impl/python.sh
@@ -33,9 +33,9 @@ nut_once || return 0
 # Get python command (python3 preferred)
 _json_python_cmd() {
     if deps_has "python3"; then
-        echo "${_TOOL_PATH[python3]}"
+        echo "${_TOOL_PATH_python3}"
     else
-        echo "${_TOOL_PATH[python]}"
+        echo "${_TOOL_PATH_python}"
     fi
 }
 

--- a/lib/list.bash.sh
+++ b/lib/list.bash.sh
@@ -27,6 +27,22 @@ nut_once || return 0
 LIST_SEP=$'\037'
 export LIST_SEP
 
+
+# The same name check the floor makes, so both halves accept and refuse exactly
+# the same names.
+#
+# Nothing here would execute a bad name: it lands in an array subscript rather
+# than in an `eval`. It refuses anyway, because a name one half takes and the
+# other rejects is a difference a caller discovers by switching shells, which
+# is the one thing having two implementations must not cost.
+_list_name_ok() {
+    case "${1:-}" in
+        "" | *[!A-Za-z0-9_]* ) return 1 ;;
+        [0-9]* ) return 1 ;;
+    esac
+    return 0
+}
+
 declare -gA _NUT_LIST=()
 declare -gA _NUT_LIST_N=()
 
@@ -34,10 +50,28 @@ declare -gA _NUT_LIST_N=()
 # Start an empty list, or empty an existing one.
 # Usage: list_new args
 list_new() {
+    _list_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" ]] || return 1
     local k n="${_NUT_LIST_N[$1]:-0}" i
     for (( i = 0; i < n; i++ )); do unset '_NUT_LIST[$1'$'\037'"$i]"; done
     _NUT_LIST_N[$1]=0
+}
+
+#[pub]
+# Whether a list has been started, as distinct from being empty.
+#
+# `list_len` answers zero for both, so nothing could tell a list that exists
+# and holds nothing from a name that is not a list at all. `array.sh` needs
+# that difference: its three rewrites used to take a bash array through a
+# nameref, and without this check that old call shape names a list that does
+# not exist, gets treated as an empty one, and the function reports success
+# having done nothing.
+#
+# Usage: list_exists args -> returns 0 when started
+list_exists() {
+    _list_name_ok "${1:-}" || return 1
+    [[ -n "${1:-}" ]] || return 1
+    [[ -n "${_NUT_LIST_N[$1]+set}" ]]
 }
 
 #[pub]
@@ -50,6 +84,7 @@ list_new() {
 #
 # Usage: list_push args "a value"
 list_push() {
+    _list_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" && $# -ge 2 ]] || return 1
     [[ "$2" == *"$LIST_SEP"* ]] && return 2
     local n="${_NUT_LIST_N[$1]:-0}"
@@ -61,6 +96,7 @@ list_push() {
 # The raw string, separator and all.
 # Usage: list_str args
 list_str() {
+    _list_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" ]] || return 1
     local n="${_NUT_LIST_N[$1]:-0}" i out=""
     for (( i = 0; i < n; i++ )); do out+="${_NUT_LIST["$1$LIST_SEP$i"]}$LIST_SEP"; done
@@ -75,7 +111,7 @@ list_str() {
 #
 # Usage: list_ref s args
 list_ref() {
-    [[ -n "${1:-}" && -n "${2:-}" ]] || return 1
+    _list_name_ok "${1:-}" && _list_name_ok "${2:-}" || return 1
     local n="${_NUT_LIST_N[$2]:-0}" i out=""
     for (( i = 0; i < n; i++ )); do out+="${_NUT_LIST["$2$LIST_SEP$i"]}$LIST_SEP"; done
     printf -v "$1" '%s' "$out"
@@ -85,6 +121,7 @@ list_ref() {
 # How many elements are in it.
 # Usage: list_len args -> 2
 list_len() {
+    _list_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" ]] || return 1
     printf '%s' "${_NUT_LIST_N[$1]:-0}"
 }
@@ -93,6 +130,7 @@ list_len() {
 # The element at an index, counting from zero, or nothing.
 # Usage: list_get args 1 -> a value with spaces
 list_get() {
+    _list_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" && $# -ge 2 ]] || return 1
     local v; list_read v "$1" "$2" || return 1
     printf '%s' "$v"
@@ -102,7 +140,16 @@ list_get() {
 # The element at an index, into a variable of your naming.
 # Usage: list_read v args 1; printf '%s' "$v"
 list_read() {
-    [[ -n "${1:-}" && -n "${2:-}" && $# -ge 3 ]] || return 1
+    _list_name_ok "${1:-}" && _list_name_ok "${2:-}" || return 1
+    [[ $# -ge 3 ]] || return 1
+    # A non-numeric index is refused on both halves rather than one erroring
+    # and the other quietly treating it as zero. Arithmetic context turns `abc`
+    # into 0 under bash and into a fatal error under dash, which is a parity
+    # divergence in the one place a caller is most likely to pass something it
+    # did not check.
+    case "${3:-}" in
+        '' | *[!0-9-]* | -*-* ) printf -v "$1" '%s' ""; return 1 ;;
+    esac
     local n="${_NUT_LIST_N[$2]:-0}"
     if [[ "$3" -lt 0 || "$3" -ge "$n" ]]; then printf -v "$1" '%s' ""; return 1; fi
     printf -v "$1" '%s' "${_NUT_LIST["$2$LIST_SEP$3"]}"
@@ -112,6 +159,7 @@ list_read() {
 # Call a function once per element, in order.
 # Usage: list_each args printf
 list_each() {
+    _list_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" && -n "${2:-}" ]] || return 1
     local n="${_NUT_LIST_N[$1]:-0}" i rc
     for (( i = 0; i < n; i++ )); do

--- a/lib/list.bash.sh
+++ b/lib/list.bash.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/lib/list.bash.sh - An ordered list, on bash's own arrays
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# The bash half of `lib/list.sh`, same surface, picked by a `#[shell(bash4)]`
+# gate in `lib.nut`. Where the floor keeps one string and lets the shell split
+# it, this keeps one associative array with the index in the key, so a push and
+# an index are both a single lookup.
+#
+# `benches/list-api` prices the two against each other. `benches/array-api`
+# prices the techniques underneath them, and the floor's is 117% of bash's own
+# `declare -a` when indexing and inside the noise when only walking.
+#
+# The surface is `lib/list.sh`. `tests/list_parity_test.sh` drives both under
+# their own shells and compares the answers, which is the only thing that says
+# they agree: one is a hash table and the other is a string, and reading them
+# side by side establishes nothing.
+# =============================================================================
+
+nut_once || return 0
+
+# The same separator the floor uses, so a caller reaching for `list_str` gets
+# the same string from either half and does not have to ask which is loaded.
+LIST_SEP=$'\037'
+export LIST_SEP
+
+declare -gA _NUT_LIST=()
+declare -gA _NUT_LIST_N=()
+
+#[pub]
+# Start an empty list, or empty an existing one.
+# Usage: list_new args
+list_new() {
+    [[ -n "${1:-}" ]] || return 1
+    local k n="${_NUT_LIST_N[$1]:-0}" i
+    for (( i = 0; i < n; i++ )); do unset '_NUT_LIST[$1'$'\037'"$i]"; done
+    _NUT_LIST_N[$1]=0
+}
+
+#[pub]
+# Add one element to the end.
+#
+# Refuses a value containing the separator, the same as the floor does. Nothing
+# here would mangle on it, since the index is in the key rather than in the
+# text, and it refuses anyway: a value that one half takes and the other
+# rejects is worse than a limit both hold to.
+#
+# Usage: list_push args "a value"
+list_push() {
+    [[ -n "${1:-}" && $# -ge 2 ]] || return 1
+    [[ "$2" == *"$LIST_SEP"* ]] && return 2
+    local n="${_NUT_LIST_N[$1]:-0}"
+    _NUT_LIST["$1$LIST_SEP$n"]="$2"
+    _NUT_LIST_N[$1]=$(( n + 1 ))
+}
+
+#[pub]
+# The raw string, separator and all.
+# Usage: list_str args
+list_str() {
+    [[ -n "${1:-}" ]] || return 1
+    local n="${_NUT_LIST_N[$1]:-0}" i out=""
+    for (( i = 0; i < n; i++ )); do out+="${_NUT_LIST["$1$LIST_SEP$i"]}$LIST_SEP"; done
+    printf '%s' "$out"
+}
+
+#[pub]
+# The raw string, into a variable of your naming.
+#
+# `list_str` prints, so walking through it costs a fork. This is the same
+# string without one.
+#
+# Usage: list_ref s args
+list_ref() {
+    [[ -n "${1:-}" && -n "${2:-}" ]] || return 1
+    local n="${_NUT_LIST_N[$2]:-0}" i out=""
+    for (( i = 0; i < n; i++ )); do out+="${_NUT_LIST["$2$LIST_SEP$i"]}$LIST_SEP"; done
+    printf -v "$1" '%s' "$out"
+}
+
+#[pub]
+# How many elements are in it.
+# Usage: list_len args -> 2
+list_len() {
+    [[ -n "${1:-}" ]] || return 1
+    printf '%s' "${_NUT_LIST_N[$1]:-0}"
+}
+
+#[pub]
+# The element at an index, counting from zero, or nothing.
+# Usage: list_get args 1 -> a value with spaces
+list_get() {
+    [[ -n "${1:-}" && $# -ge 2 ]] || return 1
+    local v; list_read v "$1" "$2" || return 1
+    printf '%s' "$v"
+}
+
+#[pub]
+# The element at an index, into a variable of your naming.
+# Usage: list_read v args 1; printf '%s' "$v"
+list_read() {
+    [[ -n "${1:-}" && -n "${2:-}" && $# -ge 3 ]] || return 1
+    local n="${_NUT_LIST_N[$2]:-0}"
+    if [[ "$3" -lt 0 || "$3" -ge "$n" ]]; then printf -v "$1" '%s' ""; return 1; fi
+    printf -v "$1" '%s' "${_NUT_LIST["$2$LIST_SEP$3"]}"
+}
+
+#[pub]
+# Call a function once per element, in order.
+# Usage: list_each args printf
+list_each() {
+    [[ -n "${1:-}" && -n "${2:-}" ]] || return 1
+    local n="${_NUT_LIST_N[$1]:-0}" i rc
+    for (( i = 0; i < n; i++ )); do
+        "$2" "${_NUT_LIST["$1$LIST_SEP$i"]}" || { rc=$?; return "$rc"; }
+    done
+}

--- a/lib/list.bash.sh
+++ b/lib/list.bash.sh
@@ -39,9 +39,19 @@ _list_name_ok() {
     case "${1:-}" in
         "" | *[!A-Za-z0-9_]* ) return 1 ;;
         [0-9]* ) return 1 ;;
+        _NUT_LIST_* | _arrtmp_* ) return 1 ;;
     esac
     return 0
 }
+# The names this module keeps its storage under are reserved.
+#
+# `_NUT_LIST_` is the module's, and `_arrtmp_` is `array.sh`'s scratch space.
+# Refusing both as container names is what makes the scratch unreachable:
+# deriving a scratch name from the caller's closed the collision one way and
+# left it open the other, so a caller holding a list called `_arrtmp_x` was
+# still emptied when somebody sorted `x`. Closing it here makes the property
+# structural rather than a convention two files have to keep agreeing about.
+
 
 declare -gA _NUT_LIST=()
 declare -gA _NUT_LIST_N=()

--- a/lib/list.sh
+++ b/lib/list.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/lib/list.sh - An ordered list, without declare -a
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# The POSIX floor. Reads under any POSIX sh; `lib/list.bash.sh` is the same
+# surface for bash and is picked by a `#[shell(bash4)]` gate in `lib.nut`.
+#
+# The list is one variable per position, and the string form with a unit
+# separator between elements is built on demand for a caller that wants to walk
+# it itself.
+#
+# That is the opposite way round from what `benches/array-api` concluded, and
+# the reason is worth stating because it is the one thing that bench could not
+# see. It measured a list held in a local variable, where appending is `s+=`
+# and bash extends the string in place. A list with a name cannot use `+=`: the
+# assignment goes through `eval`, which rebuilds the whole string on every
+# push, so appending becomes quadratic. `benches/list-api` caught it as 165% of
+# bash at four hundred elements and 468% at two thousand, on the same code.
+#
+# Slots have no such problem. A push is one assignment, an index is one lookup,
+# and the length is a counter, all regardless of how long the list is. What
+# they cost instead is the walk, which is one `eval` per element rather than
+# one field split for the whole list, and `list_each` pays that.
+#
+# So the string is the interchange form rather than the storage form. Where a
+# caller walks it via `list_ref`, the two lines that make that correct are the
+# caller's, which is what `LIST_SEP` is exported for:
+#
+#   `set -f`, because field splitting is followed by pathname expansion, and an
+#   element holding `*` would otherwise become a directory listing.
+#
+#   `IFS` set to the separator alone, or every space and newline inside an
+#   element splits it further.
+#
+# Usage:
+#   use list
+#
+#   list_new args
+#   list_push args "--flag"
+#   list_push args "a value with spaces"
+#   list_len args                      # 2
+#   list_get args 1                    # a value with spaces
+#   list_read v args 1                 # leaves it in $v, no subshell
+#   list_each args printf              # calls printf once per element
+# =============================================================================
+
+nut_once || return 0
+
+# The separator. A unit separator, which is what it is for, and it is exported
+# because a caller walking `list_str` itself has to set `IFS` to it.
+LIST_SEP=$(printf '\037')
+export LIST_SEP
+
+#[pub]
+# Start an empty list, or empty an existing one.
+# Usage: list_new args
+list_new() {
+    [ -n "${1:-}" ] || return 1
+    eval "_lidx_${1}=0"
+}
+
+#[pub]
+# Add one element to the end.
+#
+# One assignment, whatever the length. Refuses a value containing the separator
+# rather than letting it through, because `list_str` and `list_ref` hand back a
+# string with that separator in it and an element carrying one would split into
+# two on the way out. Checked rather than documented and hoped for; the
+# alternative is escaping, which costs a pass over every element in both
+# directions to carry a character none of nutshell's own lists has held.
+#
+# Usage: list_push args "a value"
+list_push() {
+    [ -n "${1:-}" ] && [ $# -ge 2 ] || return 1
+    case "$2" in
+        *"$LIST_SEP"*) return 2 ;;
+    esac
+    eval "_lp_n=\${_lidx_${1}:-0}"
+    eval "_lst_${1}_${_lp_n}=\$2"
+    eval "_lidx_${1}=$(( _lp_n + 1 ))"
+}
+
+#[pub]
+# How many elements are in it.
+# Usage: list_len args -> 2
+list_len() {
+    [ -n "${1:-}" ] || return 1
+    eval "printf '%s' \"\${_lidx_$1:-0}\""
+}
+
+#[pub]
+# The element at an index, counting from zero, or nothing.
+# Usage: list_get args 1 -> a value with spaces
+list_get() {
+    [ -n "${1:-}" ] && [ $# -ge 2 ] || return 1
+    list_read _lg_v "$1" "$2" || return 1
+    printf '%s' "$_lg_v"
+}
+
+#[pub]
+# The element at an index, into a variable of your naming.
+#
+# `list_get` prints, so reading one element costs the caller a fork.
+# `benches/maps` measured a fork per operation as costing more than the whole
+# substitution technique does, which is why this exists beside it.
+#
+# Usage: list_read v args 1; printf '%s' "$v"
+list_read() {
+    [ -n "${1:-}" ] && [ -n "${2:-}" ] && [ $# -ge 3 ] || return 1
+    eval "_lr_n=\${_lidx_${2}:-0}"
+    [ "$3" -ge 0 ] && [ "$3" -lt "$_lr_n" ] || { eval "$1=''"; return 1; }
+    eval "$1=\"\$_lst_${2}_${3}\""
+}
+
+#[pub]
+# The raw string, separator and all.
+#
+# Built on demand, since the storage is one variable per position. For a caller
+# that wants to walk the list without a function call per element:
+#
+#   oldifs="$IFS"; set -f; IFS="$LIST_SEP"
+#   for e in $(list_str args); do ...; done
+#   IFS="$oldifs"; set +f
+#
+# `list_ref` is the same string without the fork this one costs.
+#
+# Usage: list_str args
+list_str() {
+    [ -n "${1:-}" ] || return 1
+    list_ref _ls_v "$1" || return 1
+    printf '%s' "$_ls_v"
+}
+
+#[pub]
+# The raw string, into a variable of your naming.
+#
+# Usage: list_ref s args
+list_ref() {
+    [ -n "${1:-}" ] && [ -n "${2:-}" ] || return 1
+    eval "_lf_n=\${_lidx_${2}:-0}"
+    _lf_out=""; _lf_i=0
+    while [ "$_lf_i" -lt "$_lf_n" ]; do
+        eval "_lf_e=\"\$_lst_${2}_${_lf_i}\""
+        _lf_out="${_lf_out}${_lf_e}${LIST_SEP}"
+        _lf_i=$(( _lf_i + 1 ))
+    done
+    eval "$1=\"\$_lf_out\""
+}
+
+#[pub]
+# Call a function once per element, in order.
+#
+# Walks the slots directly, so no string is built and the positional parameters
+# are untouched. A caller's own arguments survive it.
+#
+# Usage: list_each args printf
+list_each() {
+    [ -n "${1:-}" ] && [ -n "${2:-}" ] || return 1
+    eval "_le_n=\${_lidx_${1}:-0}"
+    _le_fn="$2"; _le_i=0
+    while [ "$_le_i" -lt "$_le_n" ]; do
+        eval "_le_e=\"\$_lst_${1}_${_le_i}\""
+        "$_le_fn" "$_le_e" || { _le_rc=$?; return "$_le_rc"; }
+        _le_i=$(( _le_i + 1 ))
+    done
+}

--- a/lib/list.sh
+++ b/lib/list.sh
@@ -67,9 +67,19 @@ _list_name_ok() {
     case "${1:-}" in
         "" | *[!A-Za-z0-9_]* ) return 1 ;;
         [0-9]* ) return 1 ;;
+        _NUT_LIST_* | _arrtmp_* ) return 1 ;;
     esac
     return 0
 }
+# The names this module keeps its storage under are reserved.
+#
+# `_NUT_LIST_` is the module's, and `_arrtmp_` is `array.sh`'s scratch space.
+# Refusing both as container names is what makes the scratch unreachable:
+# deriving a scratch name from the caller's closed the collision one way and
+# left it open the other, so a caller holding a list called `_arrtmp_x` was
+# still emptied when somebody sorted `x`. Closing it here makes the property
+# structural rather than a convention two files have to keep agreeing about.
+
 
 # The separator. A unit separator, which is what it is for, and it is exported
 # because a caller walking `list_str` itself has to set `IFS` to it.
@@ -82,7 +92,7 @@ export LIST_SEP
 list_new() {
     _list_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] || return 1
-    eval "_lidx_${1}=0"
+    eval "_NUT_LIST_N_${1}=0"
 }
 
 #[pub]
@@ -98,7 +108,7 @@ list_new() {
 # Usage: list_exists args -> returns 0 when started
 list_exists() {
     _list_name_ok "${1:-}" || return 1
-    eval "_le_have=\"\${_lidx_${1}:-}\""
+    eval "_le_have=\"\${_NUT_LIST_N_${1}:-}\""
     [ -n "$_le_have" ]
 }
 
@@ -119,9 +129,9 @@ list_push() {
     case "$2" in
         *"$LIST_SEP"*) return 2 ;;
     esac
-    eval "_lp_n=\${_lidx_${1}:-0}"
-    eval "_lst_${1}_${_lp_n}=\$2"
-    eval "_lidx_${1}=$(( _lp_n + 1 ))"
+    eval "_lp_n=\${_NUT_LIST_N_${1}:-0}"
+    eval "_NUT_LIST_V_${1}_${_lp_n}=\$2"
+    eval "_NUT_LIST_N_${1}=$(( _lp_n + 1 ))"
 }
 
 #[pub]
@@ -130,7 +140,7 @@ list_push() {
 list_len() {
     _list_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] || return 1
-    eval "printf '%s' \"\${_lidx_$1:-0}\""
+    eval "printf '%s' \"\${_NUT_LIST_N_$1:-0}\""
 }
 
 #[pub]
@@ -162,9 +172,9 @@ list_read() {
     case "${3:-}" in
         '' | *[!0-9-]* | -*-* ) eval "$1=''"; return 1 ;;
     esac
-    eval "_lr_n=\${_lidx_${2}:-0}"
+    eval "_lr_n=\${_NUT_LIST_N_${2}:-0}"
     [ "$3" -ge 0 ] && [ "$3" -lt "$_lr_n" ] || { eval "$1=''"; return 1; }
-    eval "$1=\"\$_lst_${2}_${3}\""
+    eval "$1=\"\$_NUT_LIST_V_${2}_${3}\""
 }
 
 #[pub]
@@ -193,10 +203,10 @@ list_str() {
 # Usage: list_ref s args
 list_ref() {
     _list_name_ok "${1:-}" && _list_name_ok "${2:-}" || return 1
-    eval "_lf_n=\${_lidx_${2}:-0}"
+    eval "_lf_n=\${_NUT_LIST_N_${2}:-0}"
     _lf_out=""; _lf_i=0
     while [ "$_lf_i" -lt "$_lf_n" ]; do
-        eval "_lf_e=\"\$_lst_${2}_${_lf_i}\""
+        eval "_lf_e=\"\$_NUT_LIST_V_${2}_${_lf_i}\""
         _lf_out="${_lf_out}${_lf_e}${LIST_SEP}"
         _lf_i=$(( _lf_i + 1 ))
     done
@@ -213,10 +223,10 @@ list_ref() {
 list_each() {
     _list_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] && [ -n "${2:-}" ] || return 1
-    eval "_le_n=\${_lidx_${1}:-0}"
+    eval "_le_n=\${_NUT_LIST_N_${1}:-0}"
     _le_fn="$2"; _le_i=0
     while [ "$_le_i" -lt "$_le_n" ]; do
-        eval "_le_e=\"\$_lst_${1}_${_le_i}\""
+        eval "_le_e=\"\$_NUT_LIST_V_${1}_${_le_i}\""
         "$_le_fn" "$_le_e" || { _le_rc=$?; return "$_le_rc"; }
         _le_i=$(( _le_i + 1 ))
     done

--- a/lib/list.sh
+++ b/lib/list.sh
@@ -47,7 +47,29 @@
 #   list_each args printf              # calls printf once per element
 # =============================================================================
 
-nut_once || return 0
+# A guard of its own rather than `nut_once`, which reads `BASH_SOURCE` and uses
+# `printf -v`. A file on the floor cannot depend on a bash-only function to
+# decide whether it has been loaded: under a POSIX shell `nut_once` is not
+# found, the `|| return 0` returns from the whole file, and the module then
+# defines nothing while reporting success. That is worse than failing, because
+# the caller has no way to tell.
+[ -n "${_NUTSHELL_LIST_SH:-}" ] && return 0
+_NUTSHELL_LIST_SH=1
+
+# A name safe to build a variable out of, and safe to assign through.
+#
+# Every function here puts its first argument into an `eval`, because that is
+# how a named container works without associative arrays. So a name that is not
+# a name is code, and `list_new "m=1; echo hi; :"` would run it. Refused rather
+# than encoded: a container name is written by the programmer, never taken from
+# data, so there is nothing here to escape and a refusal is the honest answer.
+_list_name_ok() {
+    case "${1:-}" in
+        "" | *[!A-Za-z0-9_]* ) return 1 ;;
+        [0-9]* ) return 1 ;;
+    esac
+    return 0
+}
 
 # The separator. A unit separator, which is what it is for, and it is exported
 # because a caller walking `list_str` itself has to set `IFS` to it.
@@ -58,8 +80,26 @@ export LIST_SEP
 # Start an empty list, or empty an existing one.
 # Usage: list_new args
 list_new() {
+    _list_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] || return 1
     eval "_lidx_${1}=0"
+}
+
+#[pub]
+# Whether a list has been started, as distinct from being empty.
+#
+# `list_len` answers zero for both, so nothing could tell a list that exists
+# and holds nothing from a name that is not a list at all. `array.sh` needs
+# that difference: its three rewrites used to take a bash array through a
+# nameref, and without this check that old call shape names a list that does
+# not exist, gets treated as an empty one, and the function reports success
+# having done nothing.
+#
+# Usage: list_exists args -> returns 0 when started
+list_exists() {
+    _list_name_ok "${1:-}" || return 1
+    eval "_le_have=\"\${_lidx_${1}:-}\""
+    [ -n "$_le_have" ]
 }
 
 #[pub]
@@ -74,6 +114,7 @@ list_new() {
 #
 # Usage: list_push args "a value"
 list_push() {
+    _list_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] && [ $# -ge 2 ] || return 1
     case "$2" in
         *"$LIST_SEP"*) return 2 ;;
@@ -87,6 +128,7 @@ list_push() {
 # How many elements are in it.
 # Usage: list_len args -> 2
 list_len() {
+    _list_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] || return 1
     eval "printf '%s' \"\${_lidx_$1:-0}\""
 }
@@ -95,6 +137,7 @@ list_len() {
 # The element at an index, counting from zero, or nothing.
 # Usage: list_get args 1 -> a value with spaces
 list_get() {
+    _list_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] && [ $# -ge 2 ] || return 1
     list_read _lg_v "$1" "$2" || return 1
     printf '%s' "$_lg_v"
@@ -109,7 +152,16 @@ list_get() {
 #
 # Usage: list_read v args 1; printf '%s' "$v"
 list_read() {
-    [ -n "${1:-}" ] && [ -n "${2:-}" ] && [ $# -ge 3 ] || return 1
+    _list_name_ok "${1:-}" && _list_name_ok "${2:-}" || return 1
+    [ $# -ge 3 ] || return 1
+    # A non-numeric index is refused on both halves rather than one erroring
+    # and the other quietly treating it as zero. Arithmetic context turns `abc`
+    # into 0 under bash and into a fatal error under dash, which is a parity
+    # divergence in the one place a caller is most likely to pass something it
+    # did not check.
+    case "${3:-}" in
+        '' | *[!0-9-]* | -*-* ) eval "$1=''"; return 1 ;;
+    esac
     eval "_lr_n=\${_lidx_${2}:-0}"
     [ "$3" -ge 0 ] && [ "$3" -lt "$_lr_n" ] || { eval "$1=''"; return 1; }
     eval "$1=\"\$_lst_${2}_${3}\""
@@ -129,6 +181,7 @@ list_read() {
 #
 # Usage: list_str args
 list_str() {
+    _list_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] || return 1
     list_ref _ls_v "$1" || return 1
     printf '%s' "$_ls_v"
@@ -139,7 +192,7 @@ list_str() {
 #
 # Usage: list_ref s args
 list_ref() {
-    [ -n "${1:-}" ] && [ -n "${2:-}" ] || return 1
+    _list_name_ok "${1:-}" && _list_name_ok "${2:-}" || return 1
     eval "_lf_n=\${_lidx_${2}:-0}"
     _lf_out=""; _lf_i=0
     while [ "$_lf_i" -lt "$_lf_n" ]; do
@@ -158,6 +211,7 @@ list_ref() {
 #
 # Usage: list_each args printf
 list_each() {
+    _list_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] && [ -n "${2:-}" ] || return 1
     eval "_le_n=\${_lidx_${1}:-0}"
     _le_fn="$2"; _le_i=0

--- a/lib/map.bash.sh
+++ b/lib/map.bash.sh
@@ -35,6 +35,22 @@ nut_once || return 0
 # to reach it, and a nameref is bash 4.3. The unit separator cannot appear in a
 # key that came from a path, and the alternative was inventing a delimiter that
 # could.
+
+# The same name check the floor makes, so both halves accept and refuse exactly
+# the same names.
+#
+# Nothing here would execute a bad name: it lands in an array subscript rather
+# than in an `eval`. It refuses anyway, because a name one half takes and the
+# other rejects is a difference a caller discovers by switching shells, which
+# is the one thing having two implementations must not cost.
+_map_name_ok() {
+    case "${1:-}" in
+        "" | *[!A-Za-z0-9_]* ) return 1 ;;
+        [0-9]* ) return 1 ;;
+    esac
+    return 0
+}
+
 declare -gA _NUT_MAP=()
 declare -gA _NUT_MAP_ORDER=()
 
@@ -44,6 +60,7 @@ _map_k() { printf '%s\037%s' "$1" "$2"; }
 # Start a map, or empty one that is already there.
 # Usage: map_new counts
 map_new() {
+    _map_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" ]] || return 1
     map_clear "$1"
 }
@@ -52,6 +69,7 @@ map_new() {
 # Forget every key in a map.
 # Usage: map_clear counts
 map_clear() {
+    _map_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" ]] || return 1
     local k
     for k in "${!_NUT_MAP[@]}"; do
@@ -64,6 +82,7 @@ map_clear() {
 # Put a value under a key.
 # Usage: map_set counts "lib/x.sh:1" hello
 map_set() {
+    _map_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" && $# -ge 2 ]] || return 1
     local kk; kk="$(_map_k "$1" "$2")"
     # The order list only grows when the key is new, so setting twice does not
@@ -76,6 +95,7 @@ map_set() {
 # What is under a key, or nothing.
 # Usage: map_get counts "lib/x.sh:1" -> hello
 map_get() {
+    _map_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" && $# -ge 2 ]] || return 1
     local kk; kk="$(_map_k "$1" "$2")"
     printf '%s' "${_NUT_MAP[$kk]:-}"
@@ -89,7 +109,8 @@ map_get() {
 #
 # Usage: map_read v counts "lib/x.sh:1"; printf '%s' "$v"
 map_read() {
-    [[ -n "${1:-}" && -n "${2:-}" && $# -ge 3 ]] || return 1
+    _map_name_ok "${1:-}" && _map_name_ok "${2:-}" || return 1
+    [[ $# -ge 3 ]] || return 1
     printf -v "$1" '%s' "${_NUT_MAP["$2"$'\037'"$3"]:-}"
 }
 
@@ -97,6 +118,7 @@ map_read() {
 # Is the key there at all. Distinct from an empty value.
 # Usage: map_has counts "lib/x.sh:1" -> returns 0 when set
 map_has() {
+    _map_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" && $# -ge 2 ]] || return 1
     local kk; kk="$(_map_k "$1" "$2")"
     [[ -v '_NUT_MAP[$kk]' ]]
@@ -106,6 +128,7 @@ map_has() {
 # Forget one key.
 # Usage: map_del counts "lib/x.sh:1"
 map_del() {
+    _map_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" && $# -ge 2 ]] || return 1
     local kk; kk="$(_map_k "$1" "$2")"
     [[ -v '_NUT_MAP[$kk]' ]] || return 0
@@ -126,6 +149,7 @@ map_del() {
 # How many keys are set.
 # Usage: map_len counts -> 3
 map_len() {
+    _map_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" ]] || return 1
     local n=0 k
     for k in "${!_NUT_MAP[@]}"; do
@@ -138,6 +162,7 @@ map_len() {
 # Every key, one per line, in the order they were first set.
 # Usage: map_keys counts
 map_keys() {
+    _map_name_ok "${1:-}" || return 1
     [[ -n "${1:-}" ]] || return 1
     # `|| [[ -n "$k" ]]` for the last field, which has no newline after it.
     local k

--- a/lib/map.bash.sh
+++ b/lib/map.bash.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nutshell/lib/map.bash.sh - A keyed table, over declare -A
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# The same surface as `lib/map.sh`, over bash's own associative array. This is
+# what bash 4 gets; the other is the floor, and the manifest picks between them
+# above the sourcing.
+#
+# Nothing here encodes a key. The whole cost of the POSIX version is that a key
+# has to become part of a variable name, and bash has a real table, so the key
+# is the key.
+#
+# The two are held to the same answers by `tests/map_parity_test.sh`, which
+# drives both over the same operations, the POSIX one under a real POSIX shell.
+# Reading them side by side establishes nothing: one is a hash table and the
+# other is a string of encoded names.
+#
+# Usage:
+#   use map
+#
+#   map_new counts
+#   map_set counts "lib/x.sh:1" hello
+#   map_get counts "lib/x.sh:1"      -> hello
+# =============================================================================
+
+nut_once || return 0
+
+# One table for every map, keyed by `<name>\037<key>`, rather than one
+# `declare -A` per map created at run time.
+#
+# A per-map array needs `declare -gA "$name"` and then a nameref or an `eval`
+# to reach it, and a nameref is bash 4.3. The unit separator cannot appear in a
+# key that came from a path, and the alternative was inventing a delimiter that
+# could.
+declare -gA _NUT_MAP=()
+declare -gA _NUT_MAP_ORDER=()
+
+_map_k() { printf '%s\037%s' "$1" "$2"; }
+
+#[pub]
+# Start a map, or empty one that is already there.
+# Usage: map_new counts
+map_new() {
+    [[ -n "${1:-}" ]] || return 1
+    map_clear "$1"
+}
+
+#[pub]
+# Forget every key in a map.
+# Usage: map_clear counts
+map_clear() {
+    [[ -n "${1:-}" ]] || return 1
+    local k
+    for k in "${!_NUT_MAP[@]}"; do
+        [[ "$k" == "${1}"$'\037'* ]] && unset '_NUT_MAP[$k]'
+    done
+    _NUT_MAP_ORDER["$1"]=""
+}
+
+#[pub]
+# Put a value under a key.
+# Usage: map_set counts "lib/x.sh:1" hello
+map_set() {
+    [[ -n "${1:-}" && $# -ge 2 ]] || return 1
+    local kk; kk="$(_map_k "$1" "$2")"
+    # The order list only grows when the key is new, so setting twice does not
+    # list it twice and `map_len` does not drift from what is there.
+    [[ -v '_NUT_MAP[$kk]' ]] || _NUT_MAP_ORDER["$1"]="${_NUT_MAP_ORDER[$1]:-}"$'\037'"$2"
+    _NUT_MAP["$kk"]="${3:-}"
+}
+
+#[pub]
+# What is under a key, or nothing.
+# Usage: map_get counts "lib/x.sh:1" -> hello
+map_get() {
+    [[ -n "${1:-}" && $# -ge 2 ]] || return 1
+    local kk; kk="$(_map_k "$1" "$2")"
+    printf '%s' "${_NUT_MAP[$kk]:-}"
+}
+
+#[pub]
+# What is under a key, into a variable of your naming.
+#
+# The bash counterpart of the floor's `map_read`. Reading through `map_get`
+# costs the caller a fork; this one costs an assignment.
+#
+# Usage: map_read v counts "lib/x.sh:1"; printf '%s' "$v"
+map_read() {
+    [[ -n "${1:-}" && -n "${2:-}" && $# -ge 3 ]] || return 1
+    printf -v "$1" '%s' "${_NUT_MAP["$2"$'\037'"$3"]:-}"
+}
+
+#[pub]
+# Is the key there at all. Distinct from an empty value.
+# Usage: map_has counts "lib/x.sh:1" -> returns 0 when set
+map_has() {
+    [[ -n "${1:-}" && $# -ge 2 ]] || return 1
+    local kk; kk="$(_map_k "$1" "$2")"
+    [[ -v '_NUT_MAP[$kk]' ]]
+}
+
+#[pub]
+# Forget one key.
+# Usage: map_del counts "lib/x.sh:1"
+map_del() {
+    [[ -n "${1:-}" && $# -ge 2 ]] || return 1
+    local kk; kk="$(_map_k "$1" "$2")"
+    [[ -v '_NUT_MAP[$kk]' ]] || return 0
+    unset '_NUT_MAP[$kk]'
+    # `|| [[ -n "$k" ]]`, because the last field has no newline after it and
+    # `read` returns non-zero having set it. Without that the most recently
+    # added key is dropped from the order on every delete, which is the same
+    # defect `_lib_nut_lookup` carries a note about.
+    local out="" k
+    while IFS= read -r k || [[ -n "$k" ]]; do
+        [[ -z "$k" || "$k" == "$2" ]] && continue
+        out+=$'\037'"$k"
+    done < <(printf '%s' "${_NUT_MAP_ORDER[$1]:-}" | tr $'\037' '\n')
+    _NUT_MAP_ORDER["$1"]="$out"
+}
+
+#[pub]
+# How many keys are set.
+# Usage: map_len counts -> 3
+map_len() {
+    [[ -n "${1:-}" ]] || return 1
+    local n=0 k
+    for k in "${!_NUT_MAP[@]}"; do
+        [[ "$k" == "${1}"$'\037'* ]] && n=$(( n + 1 ))
+    done
+    printf '%s' "$n"
+}
+
+#[pub]
+# Every key, one per line, in the order they were first set.
+# Usage: map_keys counts
+map_keys() {
+    [[ -n "${1:-}" ]] || return 1
+    # `|| [[ -n "$k" ]]` for the last field, which has no newline after it.
+    local k
+    while IFS= read -r k || [[ -n "$k" ]]; do
+        [[ -n "$k" ]] && printf '%s\n' "$k"
+    done < <(printf '%s' "${_NUT_MAP_ORDER[$1]:-}" | tr $'\037' '\n')
+}

--- a/lib/map.sh
+++ b/lib/map.sh
@@ -1,0 +1,220 @@
+#!/bin/sh
+# =============================================================================
+# nutshell/lib/map.sh - A keyed table, in POSIX sh
+# =============================================================================
+# Part of nutshell - Everything you need, in a nutshell.
+# https://github.com/orgrinrt/nutshell
+#
+# The floor. `lib/map.bash.sh` is the same surface over `declare -A` and is
+# what bash 4 gets; this is what a POSIX shell gets, and POSIX has no
+# associative array at all.
+#
+# A map is a name the caller holds. `map_new counts` and then `map_set counts
+# hits 1`, the way `declare -A counts` would.
+#
+# **The key becomes part of a variable name**, which is the only keyed storage
+# a POSIX shell has, so it has to be encoded: nutshell's own keys look like
+# `lib/some-module.sh:412` and none of `/`, `-`, `.` or `:` may appear in a
+# name. Encoded here rather than by the caller, because a caller that forgets
+# gets a variable it did not mean to set.
+#
+# The encoding is a loop rather than `${k//[^A-Za-z0-9_]/_}`, which is bash,
+# and rather than `tr`, which is a fork per key and would cost more than the
+# whole operation. `benches/maps` prices what that costs against `declare -A`.
+#
+# It is one-to-one, not lossy: a substitution mapping every unsafe character to
+# `_` collides `a.b` with `a_b`, and a map whose keys collide is worse than no
+# map. Each unsafe character becomes `_xx` with its hex code, and `_` itself
+# becomes `_5f` so nothing else can produce it.
+#
+# Usage:
+#   use map
+#
+#   map_new counts
+#   map_set counts "lib/x.sh:1" hello
+#   map_get counts "lib/x.sh:1"      -> hello
+#   map_has counts "nope"            -> returns 1
+#   map_keys counts                  -> one key per line
+# =============================================================================
+
+[ -n "${_NUTSHELL_MAP_SH:-}" ] && return 0
+_NUTSHELL_MAP_SH=1
+
+# A key as the tail of a variable name. One-to-one.
+#
+# Walks the string a character at a time with parameter expansion only. There
+# is no global substitution in POSIX and no way to iterate a string without
+# either this or a fork, and a fork per key is not a map, it is a syscall
+# storm.
+_map_encode() {
+    _me_in="$1"; _me_out=""
+    while [ -n "$_me_in" ]; do
+        # The whole leading run of safe characters in one expansion, rather
+        # than a loop iteration per character. `lib/some-module.sh:412` has
+        # five unsafe characters in twenty-two, so this is six passes instead
+        # of twenty-two, and a key that needs no encoding at all leaves on the
+        # first one.
+        _me_run="${_me_in%%[!A-Za-z0-9]*}"
+        if [ "$_me_run" = "$_me_in" ]; then
+            _me_out="${_me_out}${_me_in}"
+            break
+        fi
+        _me_out="${_me_out}${_me_run}"
+        _me_in="${_me_in#"$_me_run"}"
+        # `_` is encoded too, so `_` cannot be produced two ways and two
+        # different keys cannot land on one name.
+        _map_hex "${_me_in%"${_me_in#?}"}"
+        _me_out="${_me_out}_${_mh}"
+        _me_in="${_me_in#?}"
+    done
+    # No `printf` and no substitution at the call sites: the answer is left in
+    # `_me_out` and read from there. A fork per operation is what `benches/maps`
+    # measured as costing more than the substitution technique itself does.
+}
+
+
+# One character as two hex digits, without a fork.
+#
+# `printf '%d' "'c"` is POSIX: a leading quote makes printf take the character's
+# value. The table below is the low half of ASCII, which is every character a
+# key here can hold; anything above it falls back to the arithmetic form.
+_map_hex() {
+    case "$1" in
+        '_') _mh=5f ;;  '/') _mh=2f ;;  '.') _mh=2e ;;
+        '-') _mh=2d ;;  ':') _mh=3a ;;  ' ') _mh=20 ;;
+        '=') _mh=3d ;;  ',') _mh=2c ;;  '+') _mh=2b ;;
+        '@') _mh=40 ;;  '#') _mh=23 ;;  '%') _mh=25 ;;
+        *)   _mh="$(printf '%02x' "$(printf '%d' "'$1")")" ;;
+    esac
+}
+
+
+#[pub]
+# Start a map, or empty one that is already there.
+# Usage: map_new counts
+map_new() {
+    [ -n "${1:-}" ] || return 1
+    map_clear "$1"
+    eval "_map_keys_$1=''"
+}
+
+#[pub]
+# Forget every key in a map.
+# Usage: map_clear counts
+map_clear() {
+    [ -n "${1:-}" ] || return 1
+    _mc_k=""
+    eval "_mc_all=\"\${_map_keys_$1:-}\""
+    for _mc_k in $_mc_all; do
+        eval "unset _map_v_$1_$_mc_k"
+    done
+    eval "_map_keys_$1=''"
+}
+
+#[pub]
+# Put a value under a key.
+# Usage: map_set counts "lib/x.sh:1" hello
+map_set() {
+    [ -n "${1:-}" ] && [ $# -ge 2 ] || return 1
+    _ms_n="$1"; _map_encode "$2"; _ms_e="$_me_out"; _ms_v="${3:-}"
+    # The key list only grows when the key is new, so setting twice does not
+    # list it twice and `map_len` does not drift from what is there.
+    if ! eval "[ -n \"\${_map_set_${_ms_n}_${_ms_e}:-}\" ]"; then
+        eval "_map_keys_${_ms_n}=\"\${_map_keys_${_ms_n}:-} ${_ms_e}\""
+        eval "_map_set_${_ms_n}_${_ms_e}=1"
+    fi
+    eval "_map_v_${_ms_n}_${_ms_e}=\"\$_ms_v\""
+}
+
+#[pub]
+# What is under a key, or nothing.
+# Usage: map_get counts "lib/x.sh:1" -> hello
+map_get() {
+    [ -n "${1:-}" ] && [ $# -ge 2 ] || return 1
+    _map_encode "$2"; _mg_e="$_me_out"
+    eval "printf '%s' \"\${_map_v_$1_${_mg_e}:-}\""
+}
+
+#[pub]
+# What is under a key, into a variable of your naming.
+#
+# `map_get` prints, so reading one value costs the caller a fork, and
+# `benches/maps` measured a fork per operation as costing more than the whole
+# substitution technique does. This is the same read with the answer left in a
+# variable instead, and `benches/map-api` prices the difference.
+#
+# Usage: map_read v counts "lib/x.sh:1"; printf '%s' "$v"
+map_read() {
+    [ -n "${1:-}" ] && [ -n "${2:-}" ] && [ $# -ge 3 ] || return 1
+    _map_encode "$3"; _mr_e="$_me_out"
+    eval "$1=\"\${_map_v_$2_${_mr_e}:-}\""
+}
+
+#[pub]
+# Is the key there at all. Distinct from an empty value.
+# Usage: map_has counts "lib/x.sh:1" -> returns 0 when set
+map_has() {
+    [ -n "${1:-}" ] && [ $# -ge 2 ] || return 1
+    _map_encode "$2"; _mh_e="$_me_out"
+    eval "[ -n \"\${_map_set_$1_${_mh_e}:-}\" ]"
+}
+
+#[pub]
+# Forget one key.
+# Usage: map_del counts "lib/x.sh:1"
+map_del() {
+    [ -n "${1:-}" ] && [ $# -ge 2 ] || return 1
+    _md_n="$1"; _map_encode "$2"; _md_e="$_me_out"
+    eval "[ -n \"\${_map_set_${_md_n}_${_md_e}:-}\" ]" || return 0
+    eval "unset _map_v_${_md_n}_${_md_e} _map_set_${_md_n}_${_md_e}"
+    _md_new=""
+    eval "_md_all=\"\${_map_keys_${_md_n}:-}\""
+    for _md_k in $_md_all; do
+        [ "$_md_k" = "$_md_e" ] && continue
+        _md_new="${_md_new} ${_md_k}"
+    done
+    eval "_map_keys_${_md_n}=\"\$_md_new\""
+}
+
+#[pub]
+# How many keys are set.
+# Usage: map_len counts -> 3
+map_len() {
+    [ -n "${1:-}" ] || return 1
+    eval "_ml_all=\"\${_map_keys_$1:-}\""
+    _ml_n=0
+    for _ml_k in $_ml_all; do _ml_n=$(( _ml_n + 1 )); done
+    printf '%s' "$_ml_n"
+}
+
+#[pub]
+# Every key, one per line, in the order they were first set.
+#
+# Decoded back, because the caller put a key in and expects the same one out.
+# Usage: map_keys counts
+map_keys() {
+    [ -n "${1:-}" ] || return 1
+    eval "_mk_all=\"\${_map_keys_$1:-}\""
+    for _mk_k in $_mk_all; do
+        _map_decode "$_mk_k"
+        printf '\n'
+    done
+}
+
+# The encoding, backwards.
+_map_decode() {
+    _md2_in="$1"; _md2_out=""
+    while [ -n "$_md2_in" ]; do
+        _md2_c="${_md2_in%"${_md2_in#?}"}"
+        if [ "$_md2_c" = "_" ]; then
+            _md2_in="${_md2_in#?}"
+            _md2_h="${_md2_in%"${_md2_in#??}"}"
+            _md2_in="${_md2_in#??}"
+            _md2_out="${_md2_out}$(printf "\\$(printf '%03o' "0x${_md2_h}")")"
+        else
+            _md2_out="${_md2_out}${_md2_c}"
+            _md2_in="${_md2_in#?}"
+        fi
+    done
+    printf '%s' "$_md2_out"
+}

--- a/lib/map.sh
+++ b/lib/map.sh
@@ -40,6 +40,21 @@
 [ -n "${_NUTSHELL_MAP_SH:-}" ] && return 0
 _NUTSHELL_MAP_SH=1
 
+# A name safe to build a variable out of, and safe to assign through.
+#
+# Every function here puts its first argument into an `eval`, because that is
+# how a named container works without associative arrays. So a name that is not
+# a name is code, and `map_new "m=1; echo hi; :"` would run it. Refused rather
+# than encoded: a container name is written by the programmer, never taken from
+# data, so there is nothing here to escape and a refusal is the honest answer.
+_map_name_ok() {
+    case "${1:-}" in
+        "" | *[!A-Za-z0-9_]* ) return 1 ;;
+        [0-9]* ) return 1 ;;
+    esac
+    return 0
+}
+
 # A key as the tail of a variable name. One-to-one.
 #
 # Walks the string a character at a time with parameter expansion only. There
@@ -93,6 +108,7 @@ _map_hex() {
 # Start a map, or empty one that is already there.
 # Usage: map_new counts
 map_new() {
+    _map_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] || return 1
     map_clear "$1"
     eval "_map_keys_$1=''"
@@ -102,11 +118,17 @@ map_new() {
 # Forget every key in a map.
 # Usage: map_clear counts
 map_clear() {
+    _map_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] || return 1
     _mc_k=""
     eval "_mc_all=\"\${_map_keys_$1:-}\""
     for _mc_k in $_mc_all; do
-        eval "unset _map_v_$1_$_mc_k"
+        # Both, because the presence table is what `map_has` and `map_set`
+        # read. Unsetting only the value left the key present but unlisted: the
+        # order list was empty so `map_len` said zero, `map_set` saw the key as
+        # already there and did not re-add it, and `map_get` still answered.
+        # A key `map_get` returns and `map_len` cannot count.
+        eval "unset _map_v_$1_$_mc_k _map_set_$1_$_mc_k"
     done
     eval "_map_keys_$1=''"
 }
@@ -115,6 +137,7 @@ map_clear() {
 # Put a value under a key.
 # Usage: map_set counts "lib/x.sh:1" hello
 map_set() {
+    _map_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] && [ $# -ge 2 ] || return 1
     _ms_n="$1"; _map_encode "$2"; _ms_e="$_me_out"; _ms_v="${3:-}"
     # The key list only grows when the key is new, so setting twice does not
@@ -130,6 +153,7 @@ map_set() {
 # What is under a key, or nothing.
 # Usage: map_get counts "lib/x.sh:1" -> hello
 map_get() {
+    _map_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] && [ $# -ge 2 ] || return 1
     _map_encode "$2"; _mg_e="$_me_out"
     eval "printf '%s' \"\${_map_v_$1_${_mg_e}:-}\""
@@ -145,7 +169,8 @@ map_get() {
 #
 # Usage: map_read v counts "lib/x.sh:1"; printf '%s' "$v"
 map_read() {
-    [ -n "${1:-}" ] && [ -n "${2:-}" ] && [ $# -ge 3 ] || return 1
+    _map_name_ok "${1:-}" && _map_name_ok "${2:-}" || return 1
+    [ $# -ge 3 ] || return 1
     _map_encode "$3"; _mr_e="$_me_out"
     eval "$1=\"\${_map_v_$2_${_mr_e}:-}\""
 }
@@ -154,6 +179,7 @@ map_read() {
 # Is the key there at all. Distinct from an empty value.
 # Usage: map_has counts "lib/x.sh:1" -> returns 0 when set
 map_has() {
+    _map_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] && [ $# -ge 2 ] || return 1
     _map_encode "$2"; _mh_e="$_me_out"
     eval "[ -n \"\${_map_set_$1_${_mh_e}:-}\" ]"
@@ -163,6 +189,7 @@ map_has() {
 # Forget one key.
 # Usage: map_del counts "lib/x.sh:1"
 map_del() {
+    _map_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] && [ $# -ge 2 ] || return 1
     _md_n="$1"; _map_encode "$2"; _md_e="$_me_out"
     eval "[ -n \"\${_map_set_${_md_n}_${_md_e}:-}\" ]" || return 0
@@ -180,6 +207,7 @@ map_del() {
 # How many keys are set.
 # Usage: map_len counts -> 3
 map_len() {
+    _map_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] || return 1
     eval "_ml_all=\"\${_map_keys_$1:-}\""
     _ml_n=0
@@ -193,6 +221,7 @@ map_len() {
 # Decoded back, because the caller put a key in and expects the same one out.
 # Usage: map_keys counts
 map_keys() {
+    _map_name_ok "${1:-}" || return 1
     [ -n "${1:-}" ] || return 1
     eval "_mk_all=\"\${_map_keys_$1:-}\""
     for _mk_k in $_mk_all; do
@@ -202,6 +231,27 @@ map_keys() {
 }
 
 # The encoding, backwards.
+# The reverse of `_map_hex`, and it does not fork either.
+#
+# It ran two command substitutions per encoded character, which for keys of
+# nutshell's own `<path>:<line>` shape is about ten forks per key: `map_keys`
+# over two hundred of them took about a second under dash where plain keys took
+# none. This file's own header says the encoding must not fork, in those words,
+# and the decoder was doing it twice per character.
+#
+# The table covers what `_map_hex` produces by name. Anything else falls back
+# to the fork, which is correct for a key holding a character nobody listed and
+# is rare enough not to matter.
+_map_unhex() {
+    case "$1" in
+        5f) _mu='_' ;;  2f) _mu='/' ;;  2e) _mu='.' ;;
+        2d) _mu='-' ;;  3a) _mu=':' ;;  20) _mu=' ' ;;
+        3d) _mu='=' ;;  2c) _mu=',' ;;  2b) _mu='+' ;;
+        40) _mu='@' ;;  23) _mu='#' ;;  25) _mu='%' ;;
+        *)  _mu="$(printf "\\$(printf '%03o' "0x$1")")" ;;
+    esac
+}
+
 _map_decode() {
     _md2_in="$1"; _md2_out=""
     while [ -n "$_md2_in" ]; do
@@ -210,11 +260,21 @@ _map_decode() {
             _md2_in="${_md2_in#?}"
             _md2_h="${_md2_in%"${_md2_in#??}"}"
             _md2_in="${_md2_in#??}"
-            _md2_out="${_md2_out}$(printf "\\$(printf '%03o' "0x${_md2_h}")")"
+            _map_unhex "$_md2_h"
+            _md2_out="${_md2_out}${_mu}"
         else
-            _md2_out="${_md2_out}${_md2_c}"
-            _md2_in="${_md2_in#?}"
+            # The whole run up to the next escape in one expansion, rather than
+            # a character per iteration, the same way `_map_encode` takes its
+            # safe runs.
+            _md2_run="${_md2_in%%_*}"
+            if [ "$_md2_run" = "$_md2_in" ]; then
+                _md2_out="${_md2_out}${_md2_in}"
+                break
+            fi
+            _md2_out="${_md2_out}${_md2_run}"
+            _md2_in="${_md2_in#"$_md2_run"}"
         fi
     done
     printf '%s' "$_md2_out"
 }
+

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -115,6 +115,23 @@ assert_contains() {
 }
 
 #[pub]
+# The negation, which was missing and cost three tests.
+#
+# Without it, `assert_not_contains` is an unknown command: it prints to stderr,
+# it does not register an assertion, and the test around it passes on whatever
+# else it happened to check. Three tests in this repo carried a line that did
+# nothing, and two of them reported a pass. The harness's own
+# "asserted nothing" guard caught the third, which is the only reason any of
+# them were found.
+#
+# Usage: assert_not_contains "$output" "PWNED"
+assert_not_contains() {
+    _test_asserted
+    [[ "$1" != *"$2"* ]] && return 0
+    _test_failed "expected NOT to find [$2]" "                in [$1]" ${3:+"     $3"}
+}
+
+#[pub]
 # Usage: assert_empty "$value" ["about"] -> 0 or 1
 assert_empty() {
     _test_asserted

--- a/lib/text.sh
+++ b/lib/text.sh
@@ -106,9 +106,9 @@ text_line() {
     
     # Use sed if available, otherwise awk
     if deps_has "sed"; then
-        "${_TOOL_PATH[sed]}" -n "${num}p" "$file"
+        "${_TOOL_PATH_sed}" -n "${num}p" "$file"
     elif deps_has "awk"; then
-        "${_TOOL_PATH[awk]}" "NR==${num}" "$file"
+        "${_TOOL_PATH_awk}" "NR==${num}" "$file"
     else
         # Pure bash fallback (slow for large files)
         local i=0
@@ -134,15 +134,15 @@ text_lines() {
     
     if deps_has "sed"; then
         if [[ -n "$end" ]]; then
-            "${_TOOL_PATH[sed]}" -n "${start},${end}p" "$file"
+            "${_TOOL_PATH_sed}" -n "${start},${end}p" "$file"
         else
-            "${_TOOL_PATH[sed]}" -n "${start}p" "$file"
+            "${_TOOL_PATH_sed}" -n "${start}p" "$file"
         fi
     elif deps_has "awk"; then
         if [[ -n "$end" ]]; then
-            "${_TOOL_PATH[awk]}" "NR>=${start} && NR<=${end}" "$file"
+            "${_TOOL_PATH_awk}" "NR>=${start} && NR<=${end}" "$file"
         else
-            "${_TOOL_PATH[awk]}" "NR==${start}" "$file"
+            "${_TOOL_PATH_awk}" "NR==${start}" "$file"
         fi
     else
         return 1
@@ -327,11 +327,11 @@ text_extract_transform() {
             [[ ! -f "$file" ]] && return 1
             
             if deps_has "grep" && deps_has "sed"; then
-                "${_TOOL_PATH[grep]}" -E "$pattern" "$file" 2>/dev/null | \
-                    "${_TOOL_PATH[sed]}" "s/${search}/${replace}/g"
+                "${_TOOL_PATH_grep}" -E "$pattern" "$file" 2>/dev/null | \
+                    "${_TOOL_PATH_sed}" "s/${search}/${replace}/g"
             elif deps_has "perl"; then
-                "${_TOOL_PATH[perl]}" -ne "print if /${pattern}/" "$file" | \
-                    "${_TOOL_PATH[perl]}" -pe "s/${search}/${replace}/g"
+                "${_TOOL_PATH_perl}" -ne "print if /${pattern}/" "$file" | \
+                    "${_TOOL_PATH_perl}" -pe "s/${search}/${replace}/g"
             else
                 return 1
             fi
@@ -361,8 +361,8 @@ text_count_in_matches() {
             [[ ! -f "$file" ]] && { echo "0"; return 1; }
             
             if deps_has "grep"; then
-                "${_TOOL_PATH[grep]}" -E "$filter" "$file" 2>/dev/null | \
-                    "${_TOOL_PATH[grep]}" -c "$count_pattern" 2>/dev/null || echo "0"
+                "${_TOOL_PATH_grep}" -E "$filter" "$file" 2>/dev/null | \
+                    "${_TOOL_PATH_grep}" -c "$count_pattern" 2>/dev/null || echo "0"
             else
                 echo "0"
                 return 1
@@ -397,7 +397,7 @@ text_prepend() {
     
     local temp
     if deps_has "mktemp"; then
-        temp="$("${_TOOL_PATH[mktemp]}")"
+        temp="$("${_TOOL_PATH_mktemp}")"
     else
         temp="/tmp/text_prepend.$$"
     fi
@@ -417,11 +417,11 @@ text_between() {
     [[ ! -f "$file" || -z "$start" || -z "$end" ]] && return 1
     
     if deps_has "sed"; then
-        "${_TOOL_PATH[sed]}" -n "/${start}/,/${end}/p" "$file" | "${_TOOL_PATH[sed]}" '1d;$d'
+        "${_TOOL_PATH_sed}" -n "/${start}/,/${end}/p" "$file" | "${_TOOL_PATH_sed}" '1d;$d'
     elif deps_has "awk"; then
-        "${_TOOL_PATH[awk]}" "/${start}/,/${end}/" "$file" | "${_TOOL_PATH[awk]}" 'NR>1 { print prev } { prev=$0 }'
+        "${_TOOL_PATH_awk}" "/${start}/,/${end}/" "$file" | "${_TOOL_PATH_awk}" 'NR>1 { print prev } { prev=$0 }'
     elif deps_has "perl"; then
-        "${_TOOL_PATH[perl]}" -ne "print if /${start}/../${end}/" "$file" | "${_TOOL_PATH[perl]}" -ne 'print unless $. == 1 || eof'
+        "${_TOOL_PATH_perl}" -ne "print if /${start}/../${end}/" "$file" | "${_TOOL_PATH_perl}" -ne 'print unless $. == 1 || eof'
     else
         return 1
     fi
@@ -435,11 +435,11 @@ text_remove_blank() {
     [[ ! -f "$file" ]] && return 1
     
     if deps_has "grep"; then
-        "${_TOOL_PATH[grep]}" -v '^[[:space:]]*$' "$file" || true
+        "${_TOOL_PATH_grep}" -v '^[[:space:]]*$' "$file" || true
     elif deps_has "sed"; then
-        "${_TOOL_PATH[sed]}" '/^[[:space:]]*$/d' "$file"
+        "${_TOOL_PATH_sed}" '/^[[:space:]]*$/d' "$file"
     elif deps_has "awk"; then
-        "${_TOOL_PATH[awk]}" 'NF' "$file"
+        "${_TOOL_PATH_awk}" 'NF' "$file"
     else
         # Pure bash fallback
         while IFS= read -r line; do
@@ -456,11 +456,11 @@ text_remove_comments() {
     [[ ! -f "$file" ]] && return 1
     
     if deps_has "grep"; then
-        "${_TOOL_PATH[grep]}" -v '^[[:space:]]*#' "$file" | "${_TOOL_PATH[grep]}" -v '^[[:space:]]*$' || true
+        "${_TOOL_PATH_grep}" -v '^[[:space:]]*#' "$file" | "${_TOOL_PATH_grep}" -v '^[[:space:]]*$' || true
     elif deps_has "sed"; then
-        "${_TOOL_PATH[sed]}" -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' "$file"
+        "${_TOOL_PATH_sed}" -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' "$file"
     elif deps_has "awk"; then
-        "${_TOOL_PATH[awk]}" '!/^[[:space:]]*#/ && NF' "$file"
+        "${_TOOL_PATH_awk}" '!/^[[:space:]]*#/ && NF' "$file"
     else
         return 1
     fi

--- a/lib/text/impl/awk_replace.sh
+++ b/lib/text/impl/awk_replace.sh
@@ -22,8 +22,8 @@ _text_replace_awk_impl() {
     [[ -z "$pattern" ]] && return 1
     [[ ! -f "$file" ]] && return 1
     
-    local awk_path="${_TOOL_PATH[awk]:-awk}"
-    local mktemp_path="${_TOOL_PATH[mktemp]:-mktemp}"
+    local awk_path="${_TOOL_PATH_awk:-awk}"
+    local mktemp_path="${_TOOL_PATH_mktemp:-mktemp}"
     
     # awk doesn't have in-place editing; use temp file
     local temp

--- a/lib/text/impl/combo/grep_sed.sh
+++ b/lib/text/impl/combo/grep_sed.sh
@@ -34,14 +34,14 @@ _text_grep_sed_filtered_replace_impl() {
     [[ -z "$search" ]] && return 1
     [[ ! -f "$file" ]] && return 1
     
-    local grep_path="${_TOOL_PATH[grep]:-grep}"
-    local sed_path="${_TOOL_PATH[sed]:-sed}"
-    local variant="${_TOOL_VARIANT[sed]:-unknown}"
+    local grep_path="${_TOOL_PATH_grep:-grep}"
+    local sed_path="${_TOOL_PATH_sed:-sed}"
+    local variant="${_TOOL_VARIANT_sed:-unknown}"
     
     # Create temp file
     local temp
-    if [[ -n "${_TOOL_PATH[mktemp]:-}" ]]; then
-        temp="$("${_TOOL_PATH[mktemp]}")"
+    if [[ -n "${_TOOL_PATH_mktemp:-}" ]]; then
+        temp="$("${_TOOL_PATH_mktemp}")"
     else
         temp="/tmp/grep_sed.$$"
     fi
@@ -88,8 +88,8 @@ _text_grep_sed_extract_transform_impl() {
     [[ -z "$pattern" ]] && return 1
     [[ ! -f "$file" ]] && return 1
     
-    local grep_path="${_TOOL_PATH[grep]:-grep}"
-    local sed_path="${_TOOL_PATH[sed]:-sed}"
+    local grep_path="${_TOOL_PATH_grep:-grep}"
+    local sed_path="${_TOOL_PATH_sed:-sed}"
     
     # Grep first, pipe to sed
     "$grep_path" -E "$pattern" "$file" 2>/dev/null | "$sed_path" "s/${search}/${replace}/g"
@@ -106,8 +106,8 @@ _text_grep_sed_count_in_matches_impl() {
     [[ -z "$count_pattern" ]] && { echo "0"; return 1; }
     [[ ! -f "$file" ]] && { echo "0"; return 1; }
     
-    local grep_path="${_TOOL_PATH[grep]:-grep}"
-    local sed_path="${_TOOL_PATH[sed]:-sed}"
+    local grep_path="${_TOOL_PATH_grep:-grep}"
+    local sed_path="${_TOOL_PATH_sed:-sed}"
     
     # Grep lines matching filter, then count secondary pattern
     "$grep_path" -E "$filter" "$file" 2>/dev/null | "$grep_path" -c "$count_pattern" 2>/dev/null || echo "0"
@@ -124,9 +124,9 @@ _text_replace_grep_sed_impl() {
     [[ -z "$pattern" ]] && return 1
     [[ ! -f "$file" ]] && return 1
     
-    local grep_path="${_TOOL_PATH[grep]:-grep}"
-    local sed_path="${_TOOL_PATH[sed]:-sed}"
-    local variant="${_TOOL_VARIANT[sed]:-unknown}"
+    local grep_path="${_TOOL_PATH_grep:-grep}"
+    local sed_path="${_TOOL_PATH_sed:-sed}"
+    local variant="${_TOOL_VARIANT_sed:-unknown}"
     
     # Quick check: does the pattern even exist?
     if ! "$grep_path" -qE "$pattern" "$file" 2>/dev/null; then

--- a/lib/text/impl/grep_match.sh
+++ b/lib/text/impl/grep_match.sh
@@ -18,7 +18,7 @@ _text_grep_grep_impl() {
     [[ -z "$pattern" ]] && return 1
     [[ ! -f "$file" ]] && return 1
     
-    local grep_path="${_TOOL_PATH[grep]:-grep}"
+    local grep_path="${_TOOL_PATH_grep:-grep}"
     
     # Use -E for extended regex by default
     "$grep_path" -E "$pattern" "$file" 2>/dev/null || true
@@ -32,7 +32,7 @@ _text_contains_grep_impl() {
     [[ -z "$pattern" ]] && return 1
     [[ ! -f "$file" ]] && return 1
     
-    local grep_path="${_TOOL_PATH[grep]:-grep}"
+    local grep_path="${_TOOL_PATH_grep:-grep}"
     
     # -q for quiet mode; just return exit status
     "$grep_path" -qE "$pattern" "$file" 2>/dev/null
@@ -46,7 +46,7 @@ _text_count_matches_grep_impl() {
     [[ -z "$pattern" ]] && { echo "0"; return 1; }
     [[ ! -f "$file" ]] && { echo "0"; return 1; }
     
-    local grep_path="${_TOOL_PATH[grep]:-grep}"
+    local grep_path="${_TOOL_PATH_grep:-grep}"
     
     # -c counts matching lines
     "$grep_path" -cE "$pattern" "$file" 2>/dev/null || echo "0"

--- a/lib/text/impl/perl_match.sh
+++ b/lib/text/impl/perl_match.sh
@@ -21,7 +21,7 @@ _text_grep_perl_impl() {
     [[ -z "$pattern" ]] && return 1
     [[ ! -f "$file" ]] && return 1
     
-    local perl_path="${_TOOL_PATH[perl]:-perl}"
+    local perl_path="${_TOOL_PATH_perl:-perl}"
     
     # -n reads line by line; print only lines matching pattern
     "$perl_path" -ne "print if /${pattern}/" "$file" 2>/dev/null || true
@@ -35,7 +35,7 @@ _text_contains_perl_impl() {
     [[ -z "$pattern" ]] && return 1
     [[ ! -f "$file" ]] && return 1
     
-    local perl_path="${_TOOL_PATH[perl]:-perl}"
+    local perl_path="${_TOOL_PATH_perl:-perl}"
     
     # Exit 0 on first match, 1 if no match
     "$perl_path" -ne "exit 0 if /${pattern}/; END { exit 1 }" "$file" 2>/dev/null
@@ -49,7 +49,7 @@ _text_count_matches_perl_impl() {
     [[ -z "$pattern" ]] && { echo "0"; return 1; }
     [[ ! -f "$file" ]] && { echo "0"; return 1; }
     
-    local perl_path="${_TOOL_PATH[perl]:-perl}"
+    local perl_path="${_TOOL_PATH_perl:-perl}"
     
     # Count lines matching pattern
     "$perl_path" -ne '$c++ if /'"${pattern}"'/; END { print $c // 0 }' "$file" 2>/dev/null || echo "0"

--- a/lib/text/impl/perl_replace.sh
+++ b/lib/text/impl/perl_replace.sh
@@ -22,7 +22,7 @@ _text_replace_perl_impl() {
     [[ -z "$pattern" ]] && return 1
     [[ ! -f "$file" ]] && return 1
     
-    local perl_path="${_TOOL_PATH[perl]:-perl}"
+    local perl_path="${_TOOL_PATH_perl:-perl}"
     
     # perl -i does in-place editing consistently across platforms
     # -p reads input line by line and prints after each line

--- a/lib/text/impl/sed_replace.sh
+++ b/lib/text/impl/sed_replace.sh
@@ -19,8 +19,8 @@ _text_replace_sed_impl() {
     [[ -z "$pattern" ]] && return 1
     [[ ! -f "$file" ]] && return 1
     
-    local sed_path="${_TOOL_PATH[sed]:-sed}"
-    local variant="${_TOOL_VARIANT[sed]:-unknown}"
+    local sed_path="${_TOOL_PATH_sed:-sed}"
+    local variant="${_TOOL_VARIANT_sed:-unknown}"
     
     if [[ "$variant" == "gnu" ]]; then
         "$sed_path" -i "s/${pattern}/${replacement}/g" "$file"

--- a/tests/array_test.sh
+++ b/tests/array_test.sh
@@ -219,17 +219,32 @@ it_refuses_a_name_that_is_not_a_started_list() {
 }
 
 #[test]
-it_does_not_eat_a_list_named_like_its_own_scratch() {
-    # The scratch list was a hardcoded global, so a list actually called that
-    # was emptied and the function returned zero. It is derived from the
-    # caller's name now, and the one shape that would still collide is refused.
-    _l _arrtmp_x c a b
-    assert_fails arr_unique _arrtmp_x
-    assert_eq "$(_dump _arrtmp_x)" "c|a|b|"
+it_has_no_scratch_list_for_a_caller_to_collide_with() {
+    # The scratch was a hardcoded global, so a list called that was emptied and
+    # the call returned zero. Deriving it from the caller's name moved the
+    # collision rather than removing it: a caller holding `_arrtmp_x` was still
+    # emptied when somebody sorted `x`, and the test named for the defect
+    # picked a victim that could never collide, so it passed against it.
+    #
+    # There is no scratch list now. The answer is built in a local string, so
+    # there is no name for a caller to hold. This checks the property that
+    # replaced it: nothing outside the list under operation is touched, and the
+    # reserved space is not reachable as a name at all.
+    assert_fails list_new _arrtmp_anything
+    assert_fails list_new _arrtmp__t_l
+    assert_fails list_new _NUT_LIST_N_x
 
-    # And a normal list beside a scratch-shaped one is untouched.
+    # The shape that used to be eaten, as close as a caller can now get.
+    _l _t_l c a b a
+    _l arrtmp__t_l KEEP1 KEEP2
+    assert_ok arr_unique _t_l
+    assert_eq "$(_dump arrtmp__t_l)" "KEEP1|KEEP2|"
+    assert_eq "$(_dump _t_l)" "c|a|b|"
+
+    # And every other list in reach stays as it was, through all three.
     _l _t_l c a b
-    _l _arrtmp_other keep
-    arr_sort _t_l
-    assert_eq "$(_dump _arrtmp_other)" "keep|"
+    _l _t_other keep
+    arr_sort _t_l;    assert_eq "$(_dump _t_other)" "keep|"
+    arr_unique _t_l;  assert_eq "$(_dump _t_other)" "keep|"
+    arr_reverse _t_l; assert_eq "$(_dump _t_other)" "keep|"
 }

--- a/tests/array_test.sh
+++ b/tests/array_test.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Tests for `array.sh`, which had none.
+#
+# The module is a public surface with, at the time these were written, no
+# callers anywhere in the tree and no tests. Both halves of that are worth
+# knowing: untested is why the conversion to the POSIX floor could not be done
+# safely without writing these first, and uncalled is a question for whoever
+# decides what the library ships.
+
+use test
+use array
+
+_l() {
+    list_new "$1"; shift 2>/dev/null || return 0
+    local v; for v in "$@"; do list_push _t_l "$v"; done
+}
+_dump() { local s; list_ref s "$1"; printf '%s' "$s" | tr '\037' '|'; }
+
+#[test]
+it_finds_an_element_among_the_arguments() {
+    assert_ok    arr_contains b a b c
+    assert_ok    arr_contains a a b c
+    assert_ok    arr_contains c a b c
+    assert_fails arr_contains z a b c
+    assert_fails arr_contains "" a b c
+    assert_fails arr_contains b
+    # An element that is a prefix or a suffix of another is not that other one.
+    assert_fails arr_contains ab abc
+    assert_fails arr_contains bc abc
+    # Spaces and globs are compared literally, not matched.
+    assert_ok    arr_contains "a b" "a b" c
+    assert_fails arr_contains "*" a b
+    assert_ok    arr_contains "*" "*" b
+}
+
+#[test]
+it_reports_where_an_element_sits_and_255_when_it_is_absent() {
+    assert_eq "$(arr_index a a b c)" "0"
+    assert_eq "$(arr_index b a b c)" "1"
+    assert_eq "$(arr_index c a b c)" "2"
+    assert_eq "$(arr_index z a b c)" "255"
+    assert_fails arr_index z a b c
+    assert_ok    arr_index a a b c
+    # The first of a repeat, not the last.
+    assert_eq "$(arr_index b a b c b)" "1"
+}
+
+#[test]
+it_answers_the_trivial_questions_about_the_arguments() {
+    assert_eq "$(arr_length a b c)" "3"
+    assert_eq "$(arr_length)" "0"
+    assert_eq "$(arr_length "")" "1"
+    assert_ok    arr_is_empty
+    assert_fails arr_is_empty a
+    assert_fails arr_is_empty ""
+    assert_eq "$(arr_first a b c)" "a"
+    assert_eq "$(arr_last a b c)" "c"
+    assert_eq "$(arr_first only)" "only"
+    assert_eq "$(arr_last only)" "only"
+    assert_fails arr_last
+    # `arr_last` walks rather than using bash's `${!#}`, so a value with
+    # spaces has to survive the walk.
+    assert_eq "$(arr_last a "b c")" "b c"
+}
+
+#[test]
+it_filters_the_arguments_by_a_glob() {
+    assert_eq "$(arr_filter 'a*' apple bat avocado | tr '\n' ' ')" "apple avocado "
+    assert_eq "$(arr_filter '*t' apple bat | tr '\n' ' ')" "bat "
+    assert_eq "$(arr_filter 'z*' apple bat)" ""
+    assert_eq "$(arr_filter '*' a b | tr '\n' ' ')" "a b "
+    # The pattern is a glob and the elements are not: an element holding `*`
+    # is matched literally by a literal pattern.
+    assert_eq "$(arr_filter '?' a bb | tr '\n' ' ')" "a "
+}
+
+#[test]
+it_drops_repeats_and_keeps_the_first_of_each() {
+    _l _t_l b a b c a
+    arr_unique _t_l
+    assert_eq "$(_dump _t_l)" "b|a|c|"
+
+    _l _t_l
+    arr_unique _t_l
+    assert_eq "$(list_len _t_l)" "0"
+
+    _l _t_l only
+    arr_unique _t_l
+    assert_eq "$(_dump _t_l)" "only|"
+
+    _l _t_l same same same
+    arr_unique _t_l
+    assert_eq "$(_dump _t_l)" "same|"
+
+    # The seen-set is a string, so an element that is a substring of another
+    # must not count as already seen. This is the defect that shape invites.
+    _l _t_l ab a b
+    arr_unique _t_l
+    assert_eq "$(_dump _t_l)" "ab|a|b|"
+
+    _l _t_l "a b" a b
+    arr_unique _t_l
+    assert_eq "$(_dump _t_l)" "a b|a|b|"
+
+    # An empty element is an element, and there is only one of it.
+    _l _t_l "" a ""
+    arr_unique _t_l
+    assert_eq "$(_dump _t_l)" "|a|"
+}
+
+#[test]
+it_reverses_a_list() {
+    _l _t_l a b c
+    arr_reverse _t_l
+    assert_eq "$(_dump _t_l)" "c|b|a|"
+
+    _l _t_l a b
+    arr_reverse _t_l
+    assert_eq "$(_dump _t_l)" "b|a|"
+
+    _l _t_l only
+    arr_reverse _t_l
+    assert_eq "$(_dump _t_l)" "only|"
+
+    _l _t_l
+    arr_reverse _t_l
+    assert_eq "$(list_len _t_l)" "0"
+
+    # Twice is where it started.
+    _l _t_l a "b c" d
+    arr_reverse _t_l; arr_reverse _t_l
+    assert_eq "$(_dump _t_l)" "a|b c|d|"
+}
+
+#[test]
+it_sorts_a_list() {
+    _l _t_l c a b
+    assert_ok arr_sort _t_l
+    assert_eq "$(_dump _t_l)" "a|b|c|"
+
+    _l _t_l b a
+    arr_sort _t_l
+    assert_eq "$(_dump _t_l)" "a|b|"
+
+    _l _t_l only
+    assert_ok arr_sort _t_l
+    assert_eq "$(_dump _t_l)" "only|"
+
+    _l _t_l
+    assert_ok arr_sort _t_l
+    assert_eq "$(list_len _t_l)" "0"
+
+    # Lexicographic, which is what `sort` does and not what a number would.
+    _l _t_l 10 9 1
+    arr_sort _t_l
+    assert_eq "$(_dump _t_l)" "1|10|9|"
+
+    # An element with a space survives the trip through the file.
+    _l _t_l "b b" "a a"
+    arr_sort _t_l
+    assert_eq "$(_dump _t_l)" "a a|b b|"
+}
+
+#[test]
+it_refuses_to_sort_a_list_holding_a_newline_and_leaves_it_alone() {
+    # An element with a newline cannot go through `sort` at all: it would come
+    # back as two. Refusing beats losing one silently, and the list has to
+    # survive the refusal rather than being half-rewritten.
+    _l _t_l "one
+two" zzz
+    local before; before="$(_dump _t_l)"
+    arr_sort _t_l
+    assert_eq "$?" "2"
+    assert_eq "$(_dump _t_l)" "$before"
+}
+
+#[test]
+it_leaves_a_second_list_alone() {
+    # All three of these build their answer in a scratch list and copy it back.
+    # A scratch list that leaked, or a copy that wrote to the wrong name, shows
+    # up here and nowhere else.
+    _l _t_l c a b
+    list_new _t_other; list_push _t_other keep
+    arr_sort _t_l
+    assert_eq "$(_dump _t_other)" "keep|"
+    arr_unique _t_l
+    assert_eq "$(_dump _t_other)" "keep|"
+    arr_reverse _t_l
+    assert_eq "$(_dump _t_other)" "keep|"
+}

--- a/tests/array_test.sh
+++ b/tests/array_test.sh
@@ -10,9 +10,14 @@
 use test
 use array
 
+# Build a named list. It took a name and then pushed into a hardcoded one,
+# which worked only because every call passed that same name, and the test for
+# leaving a second list alone had to build its second list by hand to get round
+# it.
 _l() {
-    list_new "$1"; shift 2>/dev/null || return 0
-    local v; for v in "$@"; do list_push _t_l "$v"; done
+    local name="$1"; shift 2>/dev/null || true
+    list_new "$name"
+    local v; for v in "$@"; do list_push "$name" "$v"; done
 }
 _dump() { local s; list_ref s "$1"; printf '%s' "$s" | tr '\037' '|'; }
 
@@ -180,11 +185,51 @@ it_leaves_a_second_list_alone() {
     # A scratch list that leaked, or a copy that wrote to the wrong name, shows
     # up here and nowhere else.
     _l _t_l c a b
-    list_new _t_other; list_push _t_other keep
+    _l _t_other keep
     arr_sort _t_l
     assert_eq "$(_dump _t_other)" "keep|"
     arr_unique _t_l
     assert_eq "$(_dump _t_other)" "keep|"
     arr_reverse _t_l
     assert_eq "$(_dump _t_other)" "keep|"
+}
+
+#[test]
+it_refuses_a_name_that_is_not_a_started_list() {
+    # These three used to take a bash array through a nameref. That call shape
+    # now names a list that does not exist, and without a check it would report
+    # success and leave the array untouched, which is the worst outcome for a
+    # consumer upgrading: silent, and rc 0.
+    local fn
+    for fn in arr_unique arr_reverse arr_sort; do
+        assert_fails "$fn" never_started_list
+        assert_fails "$fn" ""
+    done
+
+    # A bash array by name, which is exactly the old call shape.
+    local -a fruits=(apple banana apple)
+    assert_fails arr_unique fruits
+    assert_eq "${fruits[*]}" "apple banana apple"
+
+    # An empty list is a started list and is accepted.
+    list_new _t_empty
+    assert_ok arr_sort _t_empty
+    assert_ok arr_unique _t_empty
+    assert_ok arr_reverse _t_empty
+}
+
+#[test]
+it_does_not_eat_a_list_named_like_its_own_scratch() {
+    # The scratch list was a hardcoded global, so a list actually called that
+    # was emptied and the function returned zero. It is derived from the
+    # caller's name now, and the one shape that would still collide is refused.
+    _l _arrtmp_x c a b
+    assert_fails arr_unique _arrtmp_x
+    assert_eq "$(_dump _arrtmp_x)" "c|a|b|"
+
+    # And a normal list beside a scratch-shaped one is untouched.
+    _l _t_l c a b
+    _l _arrtmp_other keep
+    arr_sort _t_l
+    assert_eq "$(_dump _arrtmp_other)" "keep|"
 }

--- a/tests/bench_test.sh
+++ b/tests/bench_test.sh
@@ -13,9 +13,12 @@
 use test
 use bench
 
+# The clearing half is `bench_reset`, which is the harness's own and is what a
+# bench file with two cases calls. This adds only what a test needs on top: a
+# lower repeat count and a results directory that gets thrown away.
 _bench_fresh() {
-    BENCH_TITLE=""; BENCH_VERIFY=""; BENCH_SIZE=0; BENCH_REPEATS=2
-    _BENCH_LABEL=(); _BENCH_FN=(); _BENCH_CEIL=(); _BENCH_NOTE=()
+    bench_reset
+    BENCH_REPEATS=2
     BENCH_RESULTS="$(mktemp -d "${TMPDIR:-/tmp}/nutshell-bench.XXXXXX")"
     export BENCH_RESULTS
 }
@@ -192,5 +195,72 @@ it_uses_the_note_an_arm_gave_for_why_it_did_not_run() {
     bench_arm "absent" _arm_b 10 "no memory filesystem here"
 
     assert_contains "$(bench_run 2>&1)" "no memory filesystem here"
+    _bench_done
+}
+
+# --- a second case in one file -----------------------------------------------
+
+#[test]
+it_clears_the_arms_so_a_second_case_can_run() {
+    # Two workloads are two questions. Without this a file asking both declares
+    # its second pair on top of its first, and the agreement control refuses
+    # the run because arms answering different strings are not competing.
+    _bench_fresh
+    bench_case "the first question"
+    bench_verify _answer_of
+    bench_arm "a" _arm_a
+    bench_arm "b" _arm_b
+    bench_run >/dev/null 2>&1
+
+    bench_reset
+    assert_eq "${#_BENCH_FN[@]}" "0"
+    assert_eq "$BENCH_TITLE" ""
+    assert_eq "$BENCH_VERIFY" ""
+    assert_eq "$BENCH_SIZE" "0"
+    _bench_done
+}
+
+#[test]
+it_refuses_a_second_case_that_does_not_name_itself() {
+    # The reset clears the title and the verify function too, so a second case
+    # cannot inherit them. A file that resets and then declares arms without
+    # naming the new question is refused rather than reported under the
+    # previous one's heading.
+    _bench_fresh
+    bench_case "the first question"
+    bench_verify _answer_of
+    bench_arm "a" _arm_a
+    bench_arm "b" _arm_b
+    bench_run >/dev/null 2>&1
+
+    bench_reset
+    bench_arm "a" _arm_a
+    bench_arm "b" _arm_b
+    local out; out="$(bench_run 2>&1)"; local rc=$?
+    assert_ne "$rc" "0"
+    assert_contains "$out" "no case named"
+    _bench_done
+}
+
+#[test]
+it_runs_a_second_case_after_a_reset() {
+    # The positive control for the two refusals above. A reset that cleared
+    # everything and left the harness unusable would pass both of them.
+    _bench_fresh
+    bench_case "the first question"
+    bench_verify _answer_of
+    bench_arm "a" _arm_a
+    bench_arm "b" _arm_b
+    bench_run >/dev/null 2>&1
+
+    bench_reset
+    bench_case "the second question"
+    bench_verify _answer_of
+    bench_arm "a" _arm_a
+    bench_arm "b" _arm_b
+    local out; out="$(bench_run 2>&1)"; local rc=$?
+    assert_eq "$rc" "0"
+    assert_contains "$out" "the second question"
+    assert_not_contains "$out" "the first question"
     _bench_done
 }

--- a/tests/bench_test.sh
+++ b/tests/bench_test.sh
@@ -213,7 +213,13 @@ it_clears_the_arms_so_a_second_case_can_run() {
     bench_run >/dev/null 2>&1
 
     bench_reset
+    # All four, not just the functions. They are parallel arrays read by index
+    # when the table is printed, so a reset clearing one and not another
+    # desynchronises them and a check on `_BENCH_FN` alone would not see it.
     assert_eq "${#_BENCH_FN[@]}" "0"
+    assert_eq "${#_BENCH_LABEL[@]}" "0"
+    assert_eq "${#_BENCH_CEIL[@]}" "0"
+    assert_eq "${#_BENCH_NOTE[@]}" "0"
     assert_eq "$BENCH_TITLE" ""
     assert_eq "$BENCH_VERIFY" ""
     assert_eq "$BENCH_SIZE" "0"

--- a/tests/deps_test.sh
+++ b/tests/deps_test.sh
@@ -66,3 +66,81 @@ it_refuses_an_absent_tool_through_every_door() {
     assert_fails deps_run "$absent" true
     assert_fails deps_path "$absent"
 }
+
+# --- the tables are variables now, not associative arrays --------------------
+
+#[test]
+it_refuses_a_name_that_is_not_a_name() {
+    # The tool tables are one variable per entry, so a name reaches `eval`.
+    # `deps_has` takes whatever a caller hands it, which makes this the one
+    # place where that matters, and the check is the whole defence.
+    assert_fails _deps_name_ok 'x; echo pwned'
+    assert_fails _deps_name_ok 'x$(echo pwned)'
+    assert_fails _deps_name_ok 'x`echo pwned`'
+    assert_fails _deps_name_ok 'a-b'
+    assert_fails _deps_name_ok 'a b'
+    assert_fails _deps_name_ok 'a.b'
+    assert_fails _deps_name_ok ''
+    assert_fails _deps_name_ok '1abc'
+    # And the shapes that are names, or the check would pass by refusing
+    # everything and the six above would prove nothing.
+    assert_ok _deps_name_ok 'sed'
+    assert_ok _deps_name_ok 'grep_pcre'
+    assert_ok _deps_name_ok '_x'
+    assert_ok _deps_name_ok 'a1'
+}
+
+#[test]
+it_does_not_execute_what_a_caller_puts_in_a_tool_name() {
+    # The negative control for the one above, driven through the public
+    # surface rather than the validator, because that is where a caller
+    # reaches it.
+    local out
+    out="$(deps_has 'x; echo PWNED' 2>&1; deps_path 'y$(echo PWNED)' 2>&1; deps_cap 'z`echo PWNED`' 2>&1)"
+    assert_not_contains "$out" "PWNED"
+}
+
+#[test]
+it_answers_the_same_through_the_accessor_and_the_variable() {
+    # A literal read outside this module expands `${_TOOL_PATH_sed}` directly
+    # and never calls the accessor. The two have to agree or every consumer
+    # sees something different from what `deps_path` reports.
+    deps_has sed || return 0
+    local viafn viavar
+    viafn="$(deps_path sed)"
+    viavar="${_TOOL_PATH_sed:-}"
+    assert_eq "$viavar" "$viafn"
+    assert_ne "$viavar" ""
+}
+
+#[test]
+it_lists_only_the_capabilities_that_were_set() {
+    # `deps_caps` used to walk the keys of an associative array, so a
+    # capability nobody set was absent rather than zero. Walking a fixed list
+    # of every known capability instead would report the unset ones as zero,
+    # which is a different answer, and this pins the one it gives.
+    local caps; caps="$(deps_caps)"
+    assert_ne "$caps" ""
+    local n; n="$(printf '%s\n' "$caps" | wc -l | tr -d ' ')"
+    local names; names="$(printf '%s' "$_TOOL_CAN_NAMES" | wc -w | tr -d ' ')"
+    assert_eq "$n" "$names"
+    # Every line is name=0 or name=1, never an empty value, which is what a
+    # read through a missing variable would have produced.
+    assert_not_contains "$caps" "="$'\n'
+    printf '%s\n' "$caps" | while IFS= read -r line; do
+        case "$line" in
+            *=0|*=1) : ;;
+            *) return 1 ;;
+        esac
+    done
+}
+
+#[test]
+it_remembers_a_tool_it_could_not_find() {
+    # A miss is paid for once. The table holding that is now a variable, so
+    # this checks the variable rather than trusting the second call was fast.
+    deps_has definitely_not_a_real_tool_xyzzy && return 1
+    assert_eq "${_TOOL_MISSING_definitely_not_a_real_tool_xyzzy:-}" "1"
+    deps_has definitely_not_a_real_tool_xyzzy && return 1
+    return 0
+}

--- a/tests/deps_test.sh
+++ b/tests/deps_test.sh
@@ -95,8 +95,65 @@ it_encodes_a_name_that_is_not_a_variable_name() {
     _deps_key pkg;        local b="$_dk"
     assert_ne "$a" "$b"
 
+    # Byte-wise, which is what makes the concatenation prefix-free. `printf
+    # '%d' "'c"` gives a codepoint and `%02x` is a minimum width, so a
+    # character above U+00FF produced four digits and one character could
+    # occupy the space of two: `€` and a space followed by `¬` both encoded to
+    # `20ac`, and the second name read the first's path.
+    local a b
+    _deps_key '€';  a="$_dk"
+    _deps_key ' ¬'; b="$_dk"
+    assert_ne "$a" "$b"
+    assert_eq "$a" "enc_e282ac"
+    assert_eq "$b" "enc_20c2ac"
+
+    # `é` is two bytes and the raw byte 0xe9 is one. They collided at `e9`.
+    _deps_key 'é'; assert_eq "$_dk" "enc_c3a9"
+
+    # Every encoded name is an even number of hex digits, which is the property
+    # the fixed width buys and the thing a variable width breaks.
+    local n v
+    for v in 'a-b' '7z' 'pkg-config' '€' 'é' 'a b' 'x.y'; do
+        _deps_key "$v"
+        n="${_dk#enc_}"
+        assert_eq "$(( ${#n} % 2 ))" "0"
+    done
+
     # And an empty name is not a name at all.
     assert_fails _deps_key ""
+}
+
+#[test]
+it_does_not_let_two_tool_names_reach_one_variable() {
+    # The property the whole scheme rests on, checked as a property rather than
+    # on the pair that motivated it. Every name here must reach its own
+    # variable; any two landing on one is a silent wrong-path bug in
+    # `deps_path` and `deps_run`, which are public.
+    local seen="" v k
+    for v in sed grep_pcre _x a1 pkg-config git-lfs 7z 'a b' 'x.y' 'a+b' \
+             '€' ' ¬' 'é' 'enc_706b67' pkg 'enc_' 'a' 'aa' 'a-' '-a'; do
+        _deps_key "$v" || continue
+        k="$_dk"
+        assert_not_contains "$seen" "|${k}|"
+        seen="${seen}|${k}|"
+    done
+}
+
+#[test]
+it_refuses_a_capability_name_that_is_not_a_variable_name() {
+    # Capabilities are internal literals and are refused rather than encoded,
+    # because `_TOOL_CAN_NAMES` is a space-separated list that `deps_caps`
+    # splits. An encoded name and a raw one in one list disagree the moment
+    # either holds a space, and `deps_caps` then emits two rows with empty
+    # values.
+    assert_fails _deps_can_set "a b" 1
+    assert_fails _deps_can_set "a-b" 1
+    assert_fails _deps_can_set "" 1
+    assert_ok    _deps_can_set nut_test_cap 1
+    assert_contains "$(deps_caps)" "nut_test_cap=1"
+    # Every row still has a value, which is what a raw name in an encoded
+    # table would have broken.
+    assert_not_contains "$(deps_caps)" "="$'\n'
 }
 
 #[test]

--- a/tests/deps_test.sh
+++ b/tests/deps_test.sh
@@ -70,24 +70,54 @@ it_refuses_an_absent_tool_through_every_door() {
 # --- the tables are variables now, not associative arrays --------------------
 
 #[test]
-it_refuses_a_name_that_is_not_a_name() {
-    # The tool tables are one variable per entry, so a name reaches `eval`.
-    # `deps_has` takes whatever a caller hands it, which makes this the one
-    # place where that matters, and the check is the whole defence.
-    assert_fails _deps_name_ok 'x; echo pwned'
-    assert_fails _deps_name_ok 'x$(echo pwned)'
-    assert_fails _deps_name_ok 'x`echo pwned`'
-    assert_fails _deps_name_ok 'a-b'
-    assert_fails _deps_name_ok 'a b'
-    assert_fails _deps_name_ok 'a.b'
-    assert_fails _deps_name_ok ''
-    assert_fails _deps_name_ok '1abc'
-    # And the shapes that are names, or the check would pass by refusing
-    # everything and the six above would prove nothing.
-    assert_ok _deps_name_ok 'sed'
-    assert_ok _deps_name_ok 'grep_pcre'
-    assert_ok _deps_name_ok '_x'
-    assert_ok _deps_name_ok 'a1'
+it_encodes_a_name_that_is_not_a_variable_name() {
+    # The tool tables are one variable per entry, so the name is part of a
+    # variable name. A name that already is one is used as itself, which is
+    # what keeps `${_TOOL_PATH_jq}` a plain expansion in the sixteen modules
+    # that read these literally.
+    _deps_key sed;        assert_eq "$_dk" "sed"
+    _deps_key grep_pcre;  assert_eq "$_dk" "grep_pcre"
+    _deps_key _x;         assert_eq "$_dk" "_x"
+    _deps_key a1;         assert_eq "$_dk" "a1"
+
+    # Anything else is encoded rather than refused. An earlier version refused,
+    # and `deps_has pkg-config` then answered yes with an empty path while
+    # growing the available-tools list on every call. Half the binaries worth
+    # asking about have a hyphen or a leading digit.
+    _deps_key pkg-config; assert_ne "$_dk" "pkg-config"
+    assert_eq "${_dk#enc_}" "706b672d636f6e666967"
+    _deps_key 7z;         assert_eq "${_dk%${_dk#enc_}}" "enc_"
+
+    # One to one, which is the property the whole scheme rests on. A safe name
+    # beginning `enc_` takes the encoded path too, or it would collide with
+    # whatever hex-encodes to it.
+    _deps_key enc_706b67; local a="$_dk"
+    _deps_key pkg;        local b="$_dk"
+    assert_ne "$a" "$b"
+
+    # And an empty name is not a name at all.
+    assert_fails _deps_key ""
+}
+
+#[test]
+it_resolves_a_tool_whose_name_is_not_a_variable_name() {
+    # The regression this replaced a refusal to fix. Answering yes with an
+    # empty path is worse than either answering no or answering correctly.
+    command -v pkg-config >/dev/null 2>&1 || return 0
+
+    assert_ok deps_has pkg-config
+    local p; p="$(deps_path pkg-config)"
+    assert_ne "$p" ""
+    assert_ok test -x "$p"
+
+    # And the miss is remembered, so the lookup does not re-fork forever. The
+    # available list grew by one word per call when the write was silently
+    # failing.
+    local before after
+    before="$(printf '%s' "$_TOOLS_AVAILABLE" | wc -w | tr -d ' ')"
+    deps_has pkg-config; deps_has pkg-config; deps_has pkg-config
+    after="$(printf '%s' "$_TOOLS_AVAILABLE" | wc -w | tr -d ' ')"
+    assert_eq "$after" "$before"
 }
 
 #[test]
@@ -95,9 +125,14 @@ it_does_not_execute_what_a_caller_puts_in_a_tool_name() {
     # The negative control for the one above, driven through the public
     # surface rather than the validator, because that is where a caller
     # reaches it.
+    # Encoded rather than refused now, so the defence is that the name never
+    # reaches `eval` as text: it is hex by the time it gets there.
     local out
     out="$(deps_has 'x; echo PWNED' 2>&1; deps_path 'y$(echo PWNED)' 2>&1; deps_cap 'z`echo PWNED`' 2>&1)"
     assert_not_contains "$out" "PWNED"
+    # And a name built to look like an assignment does not become one.
+    deps_has 'q=1; echo PWNED2; :' >/dev/null 2>&1
+    assert_eq "${q:-unset}" "unset"
 }
 
 #[test]
@@ -126,13 +161,14 @@ it_lists_only_the_capabilities_that_were_set() {
     assert_eq "$n" "$names"
     # Every line is name=0 or name=1, never an empty value, which is what a
     # read through a missing variable would have produced.
+    #
+    # The `assert_not_contains` is the whole check. A `while | case ... return 1`
+    # loop stood here and could not fail: the pipeline puts the loop in a
+    # subshell, its status becomes the function's return value, and the harness
+    # discards that in favour of the tally. Inverting the arm so every line took
+    # the failing branch still reported a pass. It was four lines below the
+    # commit that exists to fix exactly that class.
     assert_not_contains "$caps" "="$'\n'
-    printf '%s\n' "$caps" | while IFS= read -r line; do
-        case "$line" in
-            *=0|*=1) : ;;
-            *) return 1 ;;
-        esac
-    done
 }
 
 #[test]

--- a/tests/fixtures/asserts_nothing_test.sh
+++ b/tests/fixtures/asserts_nothing_test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# A fixture for `test_test.sh`. Its one test deliberately checks nothing, so
+# the harness's "asserted nothing" guard has something to catch. It is not part
+# of the suite and is run by name.
+use test
+
+#[test]
+it_checks_nothing_at_all() {
+    local x=1
+    [[ "$x" == 1 ]]
+}

--- a/tests/json_test.sh
+++ b/tests/json_test.sh
@@ -203,3 +203,49 @@ it_returns_the_same_text_from_every_backend() {
     _agrees json_set '{"a":{"b":1}}' a.b 9
     _agrees json_delete '{"a":{"b":1,"c":2}}' a.b
 }
+
+# --- the jq backend's own classifiers ----------------------------------------
+
+#[test]
+it_tells_a_json_literal_from_a_string() {
+    # This replaced `[[ "$v" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]` and three `==`
+    # comparisons, because `[[ ]]` is bash and this file is on the POSIX
+    # floor. A `case` recognising the same shape is easy to get subtly wrong
+    # in either direction: too loose and a string gets injected into the jq
+    # program unquoted, too tight and a number arrives quoted.
+    deps_has jq || return 0
+
+    for v in 1 -1 0 1.5 -1.5 10 -0.25 true false null '[1]' '[]' '{}' '{"a":1}'; do
+        assert_ok _jq_is_json_literal "$v"
+    done
+
+    # The near misses. Each of these was accepted by neither the old regex nor
+    # the new case, and each is a shape somebody would expect to work.
+    for v in .5 5. 1.2.3 - -- --1 1a a1 abc '' ' ' 'true ' ' null' 0x10 1e5 +1; do
+        assert_fails _jq_is_json_literal "$v"
+    done
+}
+
+#[test]
+it_builds_a_path_that_tells_an_index_from_a_name() {
+    # A numeric segment is an array index and a name is a key, and putting a
+    # dot in front of the whole path gets the first wrong: `.1` is the number
+    # 0.1, not the second element. Bracket form for both, and a name quoted so
+    # a key holding a dash or a space stays one segment.
+    deps_has jq || return 0
+
+    assert_eq "$(_jq_path '')" "."
+    assert_eq "$(_jq_path '.')" "."
+    assert_eq "$(_jq_path 'a')" '.["a"]'
+    assert_eq "$(_jq_path '.a')" '.["a"]'
+    assert_eq "$(_jq_path 'a.b')" '.["a"]["b"]'
+    assert_eq "$(_jq_path '1')" '.[1]'
+    assert_eq "$(_jq_path 'a.1')" '.["a"][1]'
+    assert_eq "$(_jq_path '1.a')" '.[1]["a"]'
+    assert_eq "$(_jq_path 'a-b')" '.["a-b"]'
+    assert_eq "$(_jq_path 'a..b')" '.["a"]["b"]'
+    # A segment holding a glob character must not be expanded by the split,
+    # which is what `set -f` inside the loop is for.
+    assert_eq "$(_jq_path 'a*b')" '.["a*b"]'
+    assert_eq "$(_jq_path '*')" '.["*"]'
+}

--- a/tests/list_parity_test.sh
+++ b/tests/list_parity_test.sh
@@ -154,6 +154,11 @@ it_refuses_a_container_name_that_would_be_code() {
     _both "$sh" 'list_new l; list_read "v; echo PWNED" l 0 2>/dev/null; printf "%s" "$?"'
     _both "$sh" 'list_new l; list_ref "v; echo PWNED" l 2>/dev/null; printf "%s" "$?"'
     _both "$sh" 'list_new "a-b" 2>/dev/null; printf "%s" "$?"'
+    # The storage namespace and `array.sh`'s scratch space are reserved on both
+    # halves. Reserving them is what makes the scratch collision structural
+    # rather than a convention two files have to keep agreeing about.
+    _both "$sh" 'list_new _NUT_LIST_N_x 2>/dev/null; printf "%s" "$?"'
+    _both "$sh" 'list_new _arrtmp_x 2>/dev/null; printf "%s" "$?"'
     _both "$sh" 'list_new ok; list_push ok v; list_get ok 0'
 }
 

--- a/tests/list_parity_test.sh
+++ b/tests/list_parity_test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Tests that the POSIX list answers what the bash one answers.
+#
+# One keeps a string and lets the shell field-split it; the other keeps an
+# associative array with the index in the key. They look nothing alike, so
+# reading them side by side establishes nothing and this drives both over the
+# same operations instead, the floor under a real POSIX shell rather than under
+# bash, which forgives too much to be a test.
+#
+# The awkward elements are the point. A value with spaces, one with a newline,
+# and one holding `*` and `?` all break a naive split: `IFS` left at its
+# default splits the first two, and `set -f` left off turns the third into a
+# directory listing. Every case below carries at least one of them.
+
+use test
+
+ROOT="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+POSIXFILE="$ROOT/lib/list.sh"
+BASHFILE="$ROOT/lib/list.bash.sh"
+
+_lp_shell() {
+    local cand probe; probe="$(mktemp)"
+    for cand in dash ash yash posh sh; do
+        command -v "$cand" >/dev/null 2>&1 || continue
+        printf 'a=(1 2)\n' > "$probe"
+        "$cand" -n "$probe" >/dev/null 2>&1 && continue
+        printf 'x=1\necho "${x:-}"\n' > "$probe"
+        "$cand" -n "$probe" >/dev/null 2>&1 && { rm -f "$probe"; printf '%s' "$cand"; return 0; }
+    done
+    rm -f "$probe"; return 1
+}
+
+_both() {
+    local sh="$1" body="$2" b p
+    b="$(bash -c 'nut_once() { return 0; }; . "$1" || exit 1; shift; eval "$1"' _ "$BASHFILE" "$body" 2>&1)"
+    p="$("$sh" -c 'nut_once() { return 0; }; . "$1" || exit 1; shift; eval "$1"' _ "$POSIXFILE" "$body" 2>&1)"
+    assert_eq "$p" "$b" "$body"
+}
+
+#[test]
+it_has_a_posix_shell_to_compare_under() {
+    # The positive control. Every case below returns early without a POSIX
+    # shell, and a skip that reports a pass is how a parity suite comes to mean
+    # nothing.
+    local sh; sh="$(_lp_shell)"
+    assert_ne "$sh" ""
+    assert_ne "$sh" "bash"
+}
+
+#[test]
+it_reads_the_floor_under_a_posix_shell_and_the_other_does_not() {
+    local sh; sh="$(_lp_shell)" || return 0
+    assert_ok "$sh" -n "$POSIXFILE"
+    assert_fails "$sh" -n "$BASHFILE"
+}
+
+#[test]
+it_answers_the_same_for_push_and_length() {
+    local sh; sh="$(_lp_shell)" || return 0
+    _both "$sh" 'list_new a; list_len a'
+    _both "$sh" 'list_new a; list_push a x; list_push a y; list_len a'
+    _both "$sh" 'list_new a; list_push a ""; list_len a'
+    _both "$sh" 'list_new a; list_push a x; list_new a; list_len a'
+}
+
+#[test]
+it_answers_the_same_for_elements_that_break_a_naive_split() {
+    # Spaces need IFS pinned to the separator, `*` and `?` need set -f, and a
+    # newline needs both. An implementation getting any of them wrong reports a
+    # different length or a different element and the case fails on that.
+    local sh; sh="$(_lp_shell)" || return 0
+    _both "$sh" 'list_new a; list_push a "a value with spaces"; printf "%s|%s" "$(list_len a)" "$(list_get a 0)"'
+    _both "$sh" 'list_new a; list_push a "star * and ? here"; printf "%s|%s" "$(list_len a)" "$(list_get a 0)"'
+    _both "$sh" 'list_new a; list_push a "one
+two"; printf "%s|%s" "$(list_len a)" "$(list_get a 0)"'
+    _both "$sh" 'list_new a; list_push a "tab	here"; printf "%s|%s" "$(list_len a)" "$(list_get a 0)"'
+    _both "$sh" 'list_new a; list_push a "*"; list_push a "?"; list_push a "[a-z]"; printf "%s|%s|%s|%s" "$(list_len a)" "$(list_get a 0)" "$(list_get a 1)" "$(list_get a 2)"'
+}
+
+#[test]
+it_answers_the_same_for_get_and_read_and_the_edges() {
+    local sh; sh="$(_lp_shell)" || return 0
+    _both "$sh" 'list_new a; list_push a x; list_push a y; list_push a z; printf "%s|%s|%s" "$(list_get a 0)" "$(list_get a 1)" "$(list_get a 2)"'
+    _both "$sh" 'list_new a; list_push a x; list_get a 5; printf "|%s" "$?"'
+    _both "$sh" 'list_new a; list_push a x; list_read v a 5; printf "%s|%s" "$?" "$v"'
+    _both "$sh" 'list_new a; list_push a x; list_read v a 0; printf "%s|%s" "$?" "$v"'
+    _both "$sh" 'list_new a; list_get a 0; printf "|%s" "$?"'
+}
+
+#[test]
+it_refuses_a_value_holding_the_separator_on_both() {
+    # A value one half takes and the other rejects is worse than a limit both
+    # hold to, so the bash half refuses it too even though nothing there would
+    # mangle on it.
+    local sh; sh="$(_lp_shell)" || return 0
+    _both "$sh" 'list_new a; list_push a "bad${LIST_SEP}x"; printf "%s|%s" "$?" "$(list_len a)"'
+    _both "$sh" 'list_new a; list_push a ok; list_push a "bad${LIST_SEP}x"; printf "%s|%s|%s" "$?" "$(list_len a)" "$(list_get a 0)"'
+}
+
+#[test]
+it_walks_in_order_on_both() {
+    local sh; sh="$(_lp_shell)" || return 0
+    _both "$sh" 'show() { printf "[%s]" "$1"; }; list_new a; list_push a x; list_push a "a b"; list_push a "*"; list_each a show'
+    _both "$sh" 'show() { printf "[%s]" "$1"; }; list_new a; list_each a show; printf "|%s" "$?"'
+    _both "$sh" 'stop() { [ "$1" = y ] && return 3; printf "[%s]" "$1"; }; list_new a; list_push a x; list_push a y; list_push a z; list_each a stop; printf "|%s" "$?"'
+}
+
+#[test]
+it_gives_the_callee_the_shell_as_it_found_it() {
+    # `list_each` sets IFS and `set -f` to walk, and has to put both back
+    # before calling. A callee that word-splits an unquoted expansion would
+    # otherwise split on the separator, and a callee that globs would not.
+    # That defect only shows for callers who happen to do those things, which
+    # is why it is pinned here rather than left to notice.
+    local sh; sh="$(_lp_shell)" || return 0
+    _both "$sh" 'splitty() { set -- $1; printf "<%s>" "$#"; }; list_new a; list_push a "a b c d"; list_each a splitty'
+    _both "$sh" 'globby() { set -- $1; printf "<%s>" "$#"; }; list_new a; list_push a "a b"; list_each a globby'
+}
+
+#[test]
+it_gives_the_same_raw_string_from_both() {
+    # A caller that walks `list_str` itself must get the same bytes whichever
+    # half is loaded, or it has to ask which one it got.
+    local sh; sh="$(_lp_shell)" || return 0
+    _both "$sh" 'list_new a; list_push a x; list_push a "a b"; list_str a | od -An -c | tr -s " "'
+    _both "$sh" 'list_new a; list_str a | od -An -c | tr -s " "'
+}
+
+#[test]
+it_keeps_two_lists_apart() {
+    local sh; sh="$(_lp_shell)" || return 0
+    _both "$sh" 'list_new one; list_new two; list_push one a; list_push two b; printf "%s|%s|%s|%s" "$(list_len one)" "$(list_len two)" "$(list_get one 0)" "$(list_get two 0)"'
+    _both "$sh" 'list_new one; list_new two; list_push one a; list_new two; printf "%s|%s" "$(list_len one)" "$(list_get one 0)"'
+}

--- a/tests/list_parity_test.sh
+++ b/tests/list_parity_test.sh
@@ -107,11 +107,12 @@ it_walks_in_order_on_both() {
 
 #[test]
 it_gives_the_callee_the_shell_as_it_found_it() {
-    # `list_each` sets IFS and `set -f` to walk, and has to put both back
-    # before calling. A callee that word-splits an unquoted expansion would
-    # otherwise split on the separator, and a callee that globs would not.
-    # That defect only shows for callers who happen to do those things, which
-    # is why it is pinned here rather than left to notice.
+    # Neither half touches `IFS` or `set -f` any more: both walk their storage
+    # directly and build no string to split. This stays because that is a
+    # property worth keeping rather than an accident, and a future
+    # implementation that walked a string would have to restore both to pass
+    # it. The comment used to describe a mechanism that had been removed, which
+    # is worse than no comment: it says the test guards something it does not.
     local sh; sh="$(_lp_shell)" || return 0
     _both "$sh" 'splitty() { set -- $1; printf "<%s>" "$#"; }; list_new a; list_push a "a b c d"; list_each a splitty'
     _both "$sh" 'globby() { set -- $1; printf "<%s>" "$#"; }; list_new a; list_push a "a b"; list_each a globby'
@@ -131,4 +132,40 @@ it_keeps_two_lists_apart() {
     local sh; sh="$(_lp_shell)" || return 0
     _both "$sh" 'list_new one; list_new two; list_push one a; list_push two b; printf "%s|%s|%s|%s" "$(list_len one)" "$(list_len two)" "$(list_get one 0)" "$(list_get two 0)"'
     _both "$sh" 'list_new one; list_new two; list_push one a; list_new two; printf "%s|%s" "$(list_len one)" "$(list_get one 0)"'
+}
+
+#[test]
+it_knows_a_started_list_from_one_that_was_never_started() {
+    # `list_len` answers zero for both, so nothing could tell an empty list
+    # from a name that is not a list. `array.sh` needs that difference: its
+    # rewrites used to take a bash array, and without this that old call shape
+    # would be treated as an empty list and report success having done nothing.
+    local sh; sh="$(_lp_shell)" || return 0
+    _both "$sh" 'list_new a; list_exists a && printf yes || printf no'
+    _both "$sh" 'list_new a; list_push a x; list_exists a && printf yes || printf no'
+    _both "$sh" 'list_exists never_started && printf yes || printf no'
+    _both "$sh" 'list_exists "" 2>/dev/null && printf yes || printf no'
+}
+
+#[test]
+it_refuses_a_container_name_that_would_be_code() {
+    local sh; sh="$(_lp_shell)" || return 0
+    _both "$sh" 'list_new "l=1; echo PWNED; :" 2>/dev/null; printf "%s" "${l:-clean}"'
+    _both "$sh" 'list_new l; list_read "v; echo PWNED" l 0 2>/dev/null; printf "%s" "$?"'
+    _both "$sh" 'list_new l; list_ref "v; echo PWNED" l 2>/dev/null; printf "%s" "$?"'
+    _both "$sh" 'list_new "a-b" 2>/dev/null; printf "%s" "$?"'
+    _both "$sh" 'list_new ok; list_push ok v; list_get ok 0'
+}
+
+#[test]
+it_refuses_a_non_numeric_index_on_both() {
+    # Arithmetic context turns `abc` into 0 under bash and into a fatal error
+    # under dash, so this was the halves disagreeing in the place a caller is
+    # most likely to pass something it never checked.
+    local sh; sh="$(_lp_shell)" || return 0
+    _both "$sh" 'list_new l; list_push l x; list_read v l abc 2>/dev/null; printf "%s|%s" "$?" "$v"'
+    _both "$sh" 'list_new l; list_push l x; list_read v l "" 2>/dev/null; printf "%s|%s" "$?" "$v"'
+    _both "$sh" 'list_new l; list_push l x; list_read v l "1x" 2>/dev/null; printf "%s|%s" "$?" "$v"'
+    _both "$sh" 'list_new l; list_push l x; list_read v l -1 2>/dev/null; printf "%s|%s" "$?" "$v"'
+    _both "$sh" 'list_new l; list_push l x; list_read v l 0 2>/dev/null; printf "%s|%s" "$?" "$v"'
 }

--- a/tests/map_parity_test.sh
+++ b/tests/map_parity_test.sh
@@ -132,3 +132,32 @@ it_survives_a_value_full_of_the_characters_that_break_things() {
     _both "$sh" 'map_new m; map_set m k "100% of \$it"; map_get m k'
     _both "$sh" 'map_new m; map_set m k "a*b?c[d]"; map_get m k'
 }
+
+#[test]
+it_forgets_the_key_as_well_as_the_value_when_cleared() {
+    # `map_clear` unset the value and left the presence table, so a cleared map
+    # kept a key that `map_get` answered and `map_len` could not count, and
+    # `map_set` on that key never re-listed it. `map_new` is `map_clear` plus a
+    # line, so reusing a map under its own documented contract corrupted it.
+    local sh; sh="$(_mp_shell)" || return 0
+    _both "$sh" 'map_new c; map_set c hits 1; map_new c; map_set c hits 2; printf "%s|%s|%s" "$(map_len c)" "$(map_keys c | tr "\n" ",")" "$(map_get c hits)"'
+    _both "$sh" 'map_new d; map_set d a 1; map_clear d; map_has d a && printf present || printf absent'
+    _both "$sh" 'map_new d; map_set d a 1; map_clear d; map_set d a 2; printf "%s|%s" "$(map_len d)" "$(map_keys d | tr "\n" ",")"'
+}
+
+#[test]
+it_refuses_a_container_name_that_would_be_code() {
+    # Every function puts its first argument into an `eval`, so a name that is
+    # not a name is code. A container name is written by the programmer and
+    # never taken from data, so refusing is the honest answer and there is
+    # nothing to escape.
+    local sh; sh="$(_mp_shell)" || return 0
+    _both "$sh" 'map_new "m=1; echo PWNED; :" 2>/dev/null; printf "%s" "${m:-clean}"'
+    _both "$sh" 'map_new m; map_set "m; echo PWNED" k v 2>/dev/null; printf "%s" "$?"'
+    _both "$sh" 'map_new m; map_read "v; echo PWNED" m k 2>/dev/null; printf "%s" "$?"'
+    _both "$sh" 'map_new "a-b" 2>/dev/null; printf "%s" "$?"'
+    _both "$sh" 'map_new "" 2>/dev/null; printf "%s" "$?"'
+    # And a name that is a name still works, or the refusals above would pass
+    # against a function that refuses everything.
+    _both "$sh" 'map_new ok; map_set ok k v; map_get ok k'
+}

--- a/tests/map_parity_test.sh
+++ b/tests/map_parity_test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Tests that the POSIX map answers what the bash one answers.
+#
+# One is a hash table and the other is a string of encoded variable names, so
+# nothing about them looks alike and reading them side by side establishes
+# nothing. Both are driven over the same operations and the answers compared,
+# the POSIX one under a real POSIX shell rather than under bash: running it
+# under bash tests nothing bash does not already cover, and the interesting
+# failures are the ones bash forgives.
+#
+# The keys here are nutshell's own shape, `<path>:<line>`, because that is what
+# forced the encoding: `/`, `.`, `-` and `:` cannot appear in a variable name.
+#
+# `a.b` against `a_b` is the case that matters most. A substitution mapping
+# every unsafe character to `_` collides them, and a map whose keys collide is
+# worse than no map at all.
+
+use test
+
+ROOT="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+POSIXFILE="$ROOT/lib/map.sh"
+BASHFILE="$ROOT/lib/map.bash.sh"
+
+_mp_shell() {
+    local cand probe; probe="$(mktemp)"
+    for cand in dash ash yash posh sh; do
+        command -v "$cand" >/dev/null 2>&1 || continue
+        printf 'a=(1 2)\n' > "$probe"
+        "$cand" -n "$probe" >/dev/null 2>&1 && continue
+        printf 'x=1\necho "${x:-}"\n' > "$probe"
+        "$cand" -n "$probe" >/dev/null 2>&1 && { rm -f "$probe"; printf '%s' "$cand"; return 0; }
+    done
+    rm -f "$probe"; return 1
+}
+
+# A script run against both files, and its output compared.
+_both() {
+    local sh="$1" body="$2" b p
+    b="$(bash -c 'nut_once() { return 0; }; . "$1" || exit 1; shift; eval "$1"' _ "$BASHFILE" "$body" 2>&1)"
+    p="$("$sh" -c 'nut_once() { return 0; }; . "$1" || exit 1; shift; eval "$1"' _ "$POSIXFILE" "$body" 2>&1)"
+    assert_eq "$p" "$b" "$body"
+}
+
+#[test]
+it_has_a_posix_shell_to_compare_under() {
+    # The control for every test below. Without it they all skip, and a skip
+    # that reports a pass is how a parity suite comes to mean nothing.
+    local sh; sh="$(_mp_shell)"
+    assert_ne "$sh" ""
+    assert_ne "$sh" "bash"
+}
+
+#[test]
+it_reads_the_floor_under_a_posix_shell_and_the_other_does_not() {
+    local sh; sh="$(_mp_shell)" || return 0
+    assert_ok "$sh" -n "$POSIXFILE"
+    assert_fails "$sh" -n "$BASHFILE"
+}
+
+#[test]
+it_answers_the_same_for_set_and_get() {
+    local sh; sh="$(_mp_shell)" || return 0
+    _both "$sh" 'map_new m; map_set m hello world; map_get m hello'
+    _both "$sh" 'map_new m; map_set m hello world; map_set m hello again; map_get m hello'
+    _both "$sh" 'map_new m; map_get m missing; printf "|%s" "$?"'
+    _both "$sh" 'map_new m; map_set m k ""; map_get m k; printf "|empty"'
+}
+
+#[test]
+it_answers_the_same_for_keys_that_are_not_variable_names() {
+    # The whole reason the floor has to encode anything.
+    local sh; sh="$(_mp_shell)" || return 0
+    _both "$sh" 'map_new m; map_set m "lib/some-module.sh:412" v; map_get m "lib/some-module.sh:412"'
+    _both "$sh" 'map_new m; map_set m "a-b" v; map_get m "a-b"'
+    _both "$sh" 'map_new m; map_set m "a b" v; map_get m "a b"'
+    _both "$sh" 'map_new m; map_set m "a=b,c+d@e" v; map_get m "a=b,c+d@e"'
+    _both "$sh" 'map_new m; map_set m "" v; map_get m ""'
+}
+
+#[test]
+it_does_not_collide_two_keys_that_differ_only_in_punctuation() {
+    # `a.b` and `a_b` land on one name under any encoding that maps every
+    # unsafe character to `_`. A map whose keys collide is worse than none.
+    local sh; sh="$(_mp_shell)" || return 0
+    _both "$sh" 'map_new m; map_set m "a.b" one; map_set m "a_b" two; printf "%s|%s" "$(map_get m "a.b")" "$(map_get m "a_b")"'
+    _both "$sh" 'map_new m; map_set m "a.b" one; map_set m "a_b" two; map_len m'
+    _both "$sh" 'map_new m; map_set m "a/b" one; map_set m "a:b" two; printf "%s|%s" "$(map_get m "a/b")" "$(map_get m "a:b")"'
+}
+
+#[test]
+it_answers_the_same_for_has_and_an_empty_value() {
+    # A key set to nothing is present. Anything reading only the value cannot
+    # tell that from absent, which is the distinction `map_has` exists for.
+    local sh; sh="$(_mp_shell)" || return 0
+    _both "$sh" 'map_new m; map_set m k ""; map_has m k && printf present || printf absent'
+    _both "$sh" 'map_new m; map_has m k && printf present || printf absent'
+    _both "$sh" 'map_new m; map_set m k v; map_has m k && printf present || printf absent'
+}
+
+#[test]
+it_answers_the_same_for_len_keys_and_delete() {
+    local sh; sh="$(_mp_shell)" || return 0
+    _both "$sh" 'map_new m; map_len m'
+    _both "$sh" 'map_new m; map_set m a 1; map_set m b 2; map_set m c 3; map_len m'
+    _both "$sh" 'map_new m; map_set m a 1; map_set m a 2; map_len m'
+    _both "$sh" 'map_new m; map_set m a 1; map_set m b 2; map_set m c 3; map_keys m | tr "\n" " "'
+    _both "$sh" 'map_new m; map_set m a 1; map_set m b 2; map_del m a; printf "%s|%s" "$(map_len m)" "$(map_keys m | tr "\n" " ")"'
+    _both "$sh" 'map_new m; map_set m a 1; map_del m nope; map_len m'
+    _both "$sh" 'map_new m; map_set m a 1; map_del m a; map_has m a && printf present || printf absent'
+}
+
+#[test]
+it_answers_the_same_after_clearing() {
+    local sh; sh="$(_mp_shell)" || return 0
+    _both "$sh" 'map_new m; map_set m a 1; map_clear m; printf "%s|%s" "$(map_len m)" "$(map_get m a)"'
+    _both "$sh" 'map_new m; map_set m a 1; map_new m; map_len m'
+}
+
+#[test]
+it_keeps_two_maps_apart() {
+    local sh; sh="$(_mp_shell)" || return 0
+    _both "$sh" 'map_new one; map_new two; map_set one k a; map_set two k b; printf "%s|%s" "$(map_get one k)" "$(map_get two k)"'
+    _both "$sh" 'map_new one; map_new two; map_set one k a; map_clear two; map_get one k'
+    _both "$sh" 'map_new one; map_new two; map_set one a 1; map_set two b 2; printf "%s|%s" "$(map_len one)" "$(map_len two)"'
+}
+
+#[test]
+it_survives_a_value_full_of_the_characters_that_break_things() {
+    local sh; sh="$(_mp_shell)" || return 0
+    _both "$sh" 'map_new m; map_set m k "a b  c"; map_get m k'
+    _both "$sh" 'map_new m; map_set m k "with '"'"'quotes'"'"' and \"more\""; map_get m k'
+    _both "$sh" 'map_new m; map_set m k "100% of \$it"; map_get m k'
+    _both "$sh" 'map_new m; map_set m k "a*b?c[d]"; map_get m k'
+}

--- a/tests/test_test.sh
+++ b/tests/test_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Tests for the test harness itself, which had none.
+#
+# An assertion that cannot fail is worth nothing, and the way to find out is to
+# make it fail on purpose. `_try` runs one in a subshell so its failure marks
+# nothing in the enclosing run, and hands back the message and the status.
+
+use test
+
+# Run an assertion in isolation. Its output comes back on stdout and its status
+# as the exit code, and neither the assert counter nor the failure counter of
+# the test calling this is touched, because the subshell keeps them.
+_try() {
+    ( _test_mark() { :; }; "$@" ) 2>&1
+}
+_try_rc() {
+    ( _test_mark() { :; }; "$@" ) >/dev/null 2>&1
+}
+
+#[test]
+it_has_the_negation_of_contains() {
+    # `assert_not_contains` was missing while `assert_contains` existed, so
+    # three tests in this repo carried a line that was an unknown command: it
+    # registered no assertion and each test passed on whatever else it checked.
+    # Two of them reported a pass. The harness's own "asserted nothing" guard
+    # caught the third, which is the only reason any were found.
+    assert_not_contains "hello world" "PWNED"
+    assert_contains "hello world" "world"
+}
+
+#[test]
+it_fails_both_directions_of_contains_when_it_should() {
+    # The negative control. Without it the two above pass against an assertion
+    # that returns zero unconditionally, which is exactly the defect being
+    # repaired.
+    assert_fails _try_rc assert_not_contains "hello world" "world"
+    assert_fails _try_rc assert_contains "hello world" "PWNED"
+    assert_contains "$(_try assert_not_contains "hello world" "world")" "expected NOT to find"
+    assert_contains "$(_try assert_contains "hello world" "PWNED")" "expected to find"
+}
+
+#[test]
+it_fails_every_other_assertion_when_it_should() {
+    # The same control over the rest of the surface, because an assertion that
+    # cannot fail is the one defect none of the suites using it would notice.
+    assert_fails _try_rc assert_eq "a" "b"
+    assert_fails _try_rc assert_ne "a" "a"
+    assert_fails _try_rc assert_empty "not empty"
+    assert_fails _try_rc assert_ok false
+    assert_fails _try_rc assert_fails true
+}
+
+#[test]
+it_passes_every_assertion_when_it_should() {
+    # And the positive half, so the block above is not passing because
+    # everything refuses.
+    assert_ok _try_rc assert_eq "a" "a"
+    assert_ok _try_rc assert_ne "a" "b"
+    assert_ok _try_rc assert_empty ""
+    assert_ok _try_rc assert_ok true
+    assert_ok _try_rc assert_fails false
+    assert_ok _try_rc assert_contains "hello" "ell"
+    assert_ok _try_rc assert_not_contains "hello" "xyz"
+}
+
+#[test]
+it_says_when_a_test_asserted_nothing() {
+    # The guard that caught the missing assertion. A test body that checks
+    # nothing is a test that cannot fail, and reporting it as a pass is how a
+    # suite comes to mean nothing.
+    local out
+    out="$(cd "$NUTSHELL_ROOT" 2>/dev/null || cd .; ./test tests/fixtures/asserts_nothing_test.sh 2>&1)"
+    assert_contains "$out" "asserted nothing"
+}


### PR DESCRIPTION
POSIX sh has neither associative arrays nor indexed ones, and that is what keeps most of this library off its own floor. This builds both containers, then puts the first files on it.

The floor count goes from 19 of 39 to **18 of 41**, and the two files added are the new containers' own POSIX halves.

## The containers

`map` keeps one shell variable per entry with the key encoded into the name. The encoding is one to one, so `a.b` and `a_b` cannot collide; anything mapping every unsafe character to `_` does, and a map whose keys collide is worse than no map. 208% of bash fill-heavy, 188% read-heavy, down from 360%.

`list` keeps one variable per position and builds the separated string on demand. 128% of bash at four hundred elements, 141% at two thousand.

Both bash halves are picked by a `#[shell(bash4)]` gate on their row in `lib.nut`.

## What the benches overturned

Twice, and both are the interesting part.

**The map started at 360%** and three changes took it to 208%. Every one was a finding `benches/maps` had already written down: a fork per unsafe character, a fork per operation, and a character-at-a-time scan where one expansion takes the whole safe run. That bench says the encoding must not fork, in those words, and the code written against it forked twice per character anyway.

**The array bench's own first answer was wrong.** Four arms said slots by index at 137%. Widened to seventeen arms across four families, at both four hundred elements and four thousand, in two cases (one that indexes, one that only walks), the string family won at 117%. Its first conclusion had the right number and the wrong answer: the string family had been represented by its worst member, a shell-loop scan losing by four orders of magnitude, and that took the family down with it. One bad member is enough to retire a family.

**Then building the list that way measured 165% at four hundred and 468% at two thousand**, superlinear on a technique that had measured flat. The cause is the one thing that bench could not see: it measured a list in a *local* variable, where appending is `s+=` and bash extends in place. A list with a *name* cannot use `+=`, the assignment goes through `eval`, and that rebuilds the whole string every push. Inverted to one variable per position, the same code measures flat.

So a technique measured on a local does not transfer to the same technique on a named thing. The name is what forces the `eval`, and the `eval` is what changes the complexity.

Also settled: batching the `eval` calls is worse not better, positional parameters append quadratically (433% at four hundred, 5420% at four thousand), a rope is slots with extra steps, and `declare -a`'s `+=` is not a special fast path.

## Onto the floor

`deps.sh` owned four associative arrays and fifteen other modules read them. Every one of those reads names the tool literally, so a variable per entry costs the readers nothing: `${_TOOL_PATH_jq}` is a plain expansion. That removed array syntax from sixteen files and **moved the count by nothing**, which is the honest result and worth stating: `dash` reports the first error it hits, and every one of those files still had others.

`jq.sh` and `array.sh` are the two taken all the way, 20 to 19 to 18.

`array.sh`'s three in-place functions took a bash nameref and take a `list` name now, written against the public API so one implementation serves both halves.

## Sanity

Both parity suites drive both implementations under their own shells over the same operations and compare answers. Reading them side by side proves nothing, one is a hash table and the other is a string, so the tests are the only thing saying they agree. Each has a control that refuses to run at all if no real POSIX shell is present, because a skip reporting a pass is how a parity suite comes to mean nothing.

Mutation-checked: four ways of breaking the list (`set -f` dropped, `IFS` left at default, neither restored before a `list_each` callee, the separator refusal removed) and two of breaking `bench_reset` each kill their own named test and nothing else.

`array.sh` had no tests. Writing them first found two defects that were mine from the conversion: `arr_sort` refused every list, because `$(printf '\n')` is the empty string and the guard's pattern matched everything, and `arr_unique` dropped the first empty element it saw, because fencing both ends of an empty seen-set makes the two adjacent separators an empty element searches for.

663 tests pass. `./check` is green with the warnings it already had.

## Two things worth someone else's eyes

**`assert_not_contains` did not exist** while `assert_contains` did, so three tests here carried a line that was an unknown command: it registered no assertion and each test passed on whatever else it checked. Two reported a pass. The harness's own "asserted nothing" guard caught the third, which is the only reason any were found. It exists now, and the harness has self-tests, which it did not before: every assertion driven both to pass and to fail.

**`array.sh` has no callers.** Nine of its ten functions are referenced nowhere in the tree and the tenth only in two comments. That is why its contract was free to change here. Whether a public surface nobody calls should ship at all is a different question and not mine to answer.

## What I did not do

Seventeen files still cannot be read, and `[[` is in every one of them, between 5 and 86 times. `lib/toml.sh` alone has 86. Nothing here is one change away.

Three files fail on bash-only redirection rather than arrays: process substitution in `log.sh`, a here-string and `&>` in `validate.sh`. Process substitution has no POSIX equivalent that keeps the parent's variables, so that one is a design change rather than a rewrite.

`list_ref` builds its string by concatenating and is quadratic doing it. Measured under `dash`, a plain variable append is 7ms at 500 elements and 123 at 4000. POSIX has no `+=`, so `list_each` is the walk and the surface says so.

A value holding the separator is refused rather than escaped, on both halves of both containers. Escaping costs a pass over every element in each direction to carry a character nothing here has held.