### PR TITLE
refactor: five more modules onto the floor, and the harness among them

### DIFF
--- a/lib.nut
+++ b/lib.nut
@@ -34,6 +34,19 @@ modgraph                 lib/modgraph.sh
 nutshell                 nutshell.sh
 os                       lib/os.sh
 priv                     lib/priv.sh
+# Reads single keypresses, with sub-second timeouts, to tell escape from the
+# start of an escape sequence and to drive a cursor through a menu. That needs
+# `read -rsn1`, `read -rsn2 -t 0.1` and `read -t`, and POSIX `read` has none of
+# `-s`, `-n` or `-t`: it reads a line, splits on `IFS`, and waits.
+#
+# Seven uses across the file, and the same wall `tui::key` hit in
+# the-whole-shebang. A `dd bs=1` and `stty` version is a different program
+# rather than this one converted, so it sits behind the gate.
+#
+# The line-based prompts in here are ordinary POSIX and could be split out as a
+# floor module with the single-key ones left behind the gate, the way `map`,
+# `list` and `string` are paired. Filed rather than done.
+#[shell(bash4)]
 prompt                   lib/prompt.sh
 srcfile                  lib/srcfile.sh
 #[shell(bash4)]

--- a/lib/checkcache.sh
+++ b/lib/checkcache.sh
@@ -48,25 +48,30 @@
 #   fi
 # =============================================================================
 
-[[ -n "${_NUTSHELL_CHECKCACHE_SH:-}" ]] && return 0
+[ -n "${_NUTSHELL_CHECKCACHE_SH:-}" ] && return 0
 readonly _NUTSHELL_CHECKCACHE_SH=1
 
-if ! declare -F use >/dev/null 2>&1; then
+if ! command -v use >/dev/null 2>&1; then
     printf 'nutshell: source nutshell first\n' >&2
     return 1
 fi
 
 # Off by default until a caller turns it on, because a cache that is wrong is
 # worse than a check that is slow.
-declare -g NUT_CACHE_ENABLED="${NUT_CACHE:-0}"
+NUT_CACHE_ENABLED="${NUT_CACHE:-0}"
 
 # Bumped when the entry format or the meaning of a stamp changes, so entries
 # written by an older nutshell are misses rather than lies.
-declare -g _NUT_CACHE_FORMAT=2
+_NUT_CACHE_FORMAT=2
 
-declare -gA _NUT_CACHE_STAMP=()
-declare -g  _NUT_CACHE_BASE=""
-declare -g  _NUT_CACHE_STAT=""
+# The stamps live in a `map` rather than an associative array, which is bash's.
+# `map` is on the floor and does the same job through one variable per entry;
+# `map_read` leaves the answer in a variable so a lookup costs no fork, which
+# matters here because this is the hot path of the checker.
+use map
+map_new _NUT_CACHE_STAMP
+_NUT_CACHE_BASE=""
+_NUT_CACHE_STAT=""
 
 # Which `stat` this machine has, decided once by what it prints rather than by
 # what it returns.
@@ -90,7 +95,7 @@ declare -g  _NUT_CACHE_STAT=""
 #
 # Prints `-f` or `-c`, or nothing when neither works.
 _nut_cache_stat_flag() {
-    [[ -n "$_NUT_CACHE_STAT" ]] && { printf '%s' "${_NUT_CACHE_STAT#none}"; return 0; }
+    [ -n "$_NUT_CACHE_STAT" ] && { printf '%s' "${_NUT_CACHE_STAT#none}"; return 0; }
 
     local probe out flag fmt rc=1
     probe="$(mktemp "${TMPDIR:-/tmp}/nutshell-stat.XXXXXX")" || { _NUT_CACHE_STAT="none"; return 1; }
@@ -104,16 +109,16 @@ _nut_cache_stat_flag() {
         esac
         out="$(stat "$flag" "$fmt" "$probe" 2>/dev/null)" || continue
         # `<mtime> <size>`, and the size has to be the one just written.
-        [[ "$out" == *' '* ]] || continue
-        [[ "${out%% *}" =~ ^[0-9]+$ ]] || continue
-        [[ "${out##* }" == "10" ]] || continue
+        case "$out" in *' '*) ;; *) continue ;; esac
+        case "${out%% *}" in ''|*[!0-9]*) continue ;; esac
+        [ "${out##* }" = "10" ] || continue
         _NUT_CACHE_STAT="$flag"
         rc=0
         break
     done
 
     rm -f "$probe"
-    [[ "$rc" -eq 0 ]] || { _NUT_CACHE_STAT="none"; return 1; }
+    [ "$rc" -eq 0 ] || { _NUT_CACHE_STAT="none"; return 1; }
     printf '%s' "$_NUT_CACHE_STAT"
     return 0
 }
@@ -129,9 +134,21 @@ _nut_cache_stat_fmt() {
 
 # `<mtime> <size>` for a set of paths, in one call.
 _nut_cache_stat_into() {
-    local line mtime size path
+    local line mtime size path flag fmt out
+    # Gathered first, then walked from a here-document.
+    #
+    # It was `done < <(...)`, which is bash's, and the loop cannot go on the
+    # right of a pipe instead: the body calls `map_set`, so a subshell would
+    # record every stamp somewhere that dies when the loop ends and the cache
+    # would simply never fill. A here-document keeps the loop in this shell,
+    # and the text is one short line per input path.
+    flag="$(_nut_cache_stat_flag)" || return 0
+    fmt="$(_nut_cache_stat_fmt)"   || return 0
+    out="$(stat "$flag" "$fmt" "$@" 2>/dev/null)" || return 0
+    [ -n "$out" ] || return 0
+
     while IFS= read -r line; do
-        [[ -n "$line" ]] || continue
+        [ -n "$line" ] || continue
         # `<mtime> <size> <path>`, split from the front. Taking the size with
         # `${v##* }` takes the last field, which is the path, so the size was
         # stat'd and then thrown away and a content change landing on the same
@@ -139,27 +156,24 @@ _nut_cache_stat_into() {
         # `touch -r`.
         mtime="${line%% *}"; line="${line#* }"
         size="${line%% *}";  path="${line#* }"
-        [[ -n "$path" ]] || continue
-        _NUT_CACHE_STAMP["$path"]="${mtime} ${size}"
-    done < <(
-        local flag fmt
-        flag="$(_nut_cache_stat_flag)" || exit 0
-        fmt="$(_nut_cache_stat_fmt)"   || exit 0
-        stat "$flag" "$fmt" "$@" 2>/dev/null
-    )
+        [ -n "$path" ] || continue
+        map_set _NUT_CACHE_STAMP "$path" "${mtime} ${size}"
+    done <<EOF
+$out
+EOF
     return 0
 }
 
 # The stamp for one path, or nothing when it could not be read.
 _nut_cache_stamp_of() {
     local p="${1:-}" v
-    [[ -n "$p" ]] || return 1
-    v="${_NUT_CACHE_STAMP[$p]:-}"
-    if [[ -z "$v" ]]; then
+    [ -n "$p" ] || return 1
+    map_read v _NUT_CACHE_STAMP "$p"
+    if [ -z "$v" ]; then
         _nut_cache_stat_into "$p"
-        v="${_NUT_CACHE_STAMP[$p]:-}"
+        map_read v _NUT_CACHE_STAMP "$p"
     fi
-    [[ -n "$v" ]] || return 1
+    [ -n "$v" ] || return 1
     # Already `<mtime> <size>`; there is nothing to re-parse out of it.
     printf '%s' "$v"
 }
@@ -170,9 +184,9 @@ _nut_cache_stamp_of() {
 # moves it and every entry becomes a miss, which is the coarse but correct
 # answer to "the checker is more than one file".
 _nut_cache_base() {
-    [[ -n "$_NUT_CACHE_BASE" ]] && { printf '%s' "$_NUT_CACHE_BASE"; return 0; }
+    [ -n "$_NUT_CACHE_BASE" ] && { printf '%s' "$_NUT_CACHE_BASE"; return 0; }
     local root="${NUTSHELL_ROOT:-}" newest=""
-    if [[ -n "$root" && -d "$root/lib" ]]; then
+    if [ -n "$root" ] && [ -d "$root/lib" ]; then
         # The newest *file*, not the directory's own mtime. A directory's mtime
         # moves when an entry is added or removed and not when a file inside it
         # is edited, so stat'ing `lib` caught `git pull` and a new module and
@@ -182,7 +196,7 @@ _nut_cache_base() {
         # One `find` and one batched `stat`, per run rather than per file.
         local flag fmt
         flag="$(_nut_cache_stat_flag)" && case "$flag" in -f) fmt='%m' ;; *) fmt='%Y' ;; esac
-        [[ -n "${flag:-}" ]] && newest="$(
+        [ -n "${flag:-}" ] && newest="$(
             find "$root/lib" "$root/init" -type f -exec stat "$flag" "$fmt" {} + 2>/dev/null
         )"
         newest="$(printf '%s\n' "$newest" | sort -rn | head -1)"
@@ -194,11 +208,11 @@ _nut_cache_base() {
 # Where an answer is kept. Under the store, beside the toolchains and externs,
 # because it is derived data about this machine and not part of any project.
 _nut_cache_root() {
-    if [[ -n "${NUT_CACHE_DIR:-}" ]]; then
+    if [ -n "${NUT_CACHE_DIR:-}" ]; then
         printf '%s' "${NUT_CACHE_DIR%/}"
         return 0
     fi
-    if declare -F nutshell_store_root >/dev/null 2>&1; then
+    if command -v nutshell_store_root >/dev/null 2>&1; then
         printf '%s/checks' "$(nutshell_store_root)"
         return 0
     fi
@@ -210,21 +224,31 @@ _nut_cache_root() {
 # The path is percent-encoded rather than flattened. Replacing every `/` with
 # `_` maps `lib/toml/json.sh` and `lib/toml_json.sh` onto one entry, and the
 # answer for one is then served for the other.
+# Percent-encode anything that is not safe in a file name.
+#
+# Walked by cutting the first character off rather than indexing, because
+# `${in:i:1}` is bash's and so is the C-style `for`. A safe run is taken whole
+# instead of one character at a time, which is fewer passes on the common case
+# where most of a path is already safe.
 _nut_cache_escape() {
-    local in="${1:-}" out="" i c
-    for (( i = 0; i < ${#in}; i++ )); do
-        c="${in:i:1}"
-        case "$c" in
-            [A-Za-z0-9._-]) out+="$c" ;;
-            *) printf -v c '%%%02X' "'$c"; out+="$c" ;;
-        esac
+    local in="${1:-}" out="" run c
+    while [ -n "$in" ]; do
+        run="${in%%[!A-Za-z0-9._-]*}"
+        if [ -n "$run" ]; then
+            out="${out}${run}"
+            in="${in#"$run"}"
+            continue
+        fi
+        c="${in%"${in#?}"}"
+        out="${out}$(printf '%%%02X' "'$c")"
+        in="${in#?}"
     done
     printf '%s' "$out"
 }
 
 _nut_cache_path() {
     local check="${1:-}" file="${2:-}"
-    [[ -n "$check" && -n "$file" ]] || return 1
+    { [ -n "$check" ] && [ -n "$file" ]; } || return 1
     printf '%s/%s/%s' "$(_nut_cache_root)" \
         "$(_nut_cache_escape "$check")" "$(_nut_cache_escape "$file")"
 }
@@ -252,13 +276,13 @@ _nut_cache_key() {
 # the test and the entry hit anyway.
 # Usage: nut_cache_hit <check> <file> -> returns 0 on a usable answer
 nut_cache_hit() {
-    [[ "${NUT_CACHE_ENABLED:-0}" == "1" ]] || return 1
+    [ "${NUT_CACHE_ENABLED:-0}" = "1" ] || return 1
     local check="${1:-}" file="${2:-}" entry want have
     entry="$(_nut_cache_path "$check" "$file")" || return 1
-    [[ -f "$entry" ]] || return 1
+    [ -f "$entry" ] || return 1
     want="$(_nut_cache_key "$file")" || return 1
     IFS= read -r have < "$entry" 2>/dev/null || return 1
-    [[ "$have" == "$want" ]]
+    [ "$have" = "$want" ]
 }
 
 #[pub]
@@ -266,7 +290,7 @@ nut_cache_hit() {
 # Usage: nut_cache_read <check> <file> -> prints what was cached
 nut_cache_read() {
     local entry; entry="$(_nut_cache_path "$1" "$2")" || return 1
-    [[ -r "$entry" ]] || return 1
+    [ -r "$entry" ] || return 1
     tail -n +2 "$entry"
 }
 
@@ -276,7 +300,7 @@ nut_cache_read() {
 # will not have it next time.
 # Usage: nut_cache_write <check> <file> <findings>
 nut_cache_write() {
-    [[ "${NUT_CACHE_ENABLED:-0}" == "1" ]] || return 0
+    [ "${NUT_CACHE_ENABLED:-0}" = "1" ] || return 0
     local entry key
     entry="$(_nut_cache_path "$1" "$2")" || return 0
     key="$(_nut_cache_key "$2")" || return 0
@@ -290,7 +314,7 @@ nut_cache_write() {
 # Usage: nut_cache_clear [check]
 nut_cache_clear() {
     local root; root="$(_nut_cache_root)"
-    if [[ -n "${1:-}" ]]; then
+    if [ -n "${1:-}" ]; then
         rm -rf "${root}/$(_nut_cache_escape "$1")"
     else
         rm -rf "$root"

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -45,23 +45,7 @@
 [ -n "${_NUTSHELL_EXTERN_SH:-}" ] && return 0
 _NUTSHELL_EXTERN_SH=1
 
-# Every occurrence of one string swapped for another, into a named variable.
-# There is no `${x//from/to}` here.
-_extern_gsub() {
-    _eg_rest="$1"; _eg_acc=""
-    [ -n "$2" ] || { eval "$4=\$1"; return 0; }
-    case "$4" in ''|*[!A-Za-z0-9_]*|[0-9]*) return 2 ;; esac
-    while :; do
-        case "$_eg_rest" in
-            *"$2"*) _eg_acc="${_eg_acc}${_eg_rest%%"$2"*}$3"
-                    _eg_rest="${_eg_rest#*"$2"}" ;;
-            *) break ;;
-        esac
-    done
-    eval "$4=\${_eg_acc}\${_eg_rest}"
-}
-
-use toml xdg fs log validate
+use toml string xdg fs log validate
 
 # _extern_manifest
 #
@@ -697,12 +681,12 @@ extern_resolve() {
     _has_slash=0; case "$rest" in */*) _has_slash=1 ;; esac
     if [ "$_has_slash" -eq 1 ]; then
         _spec_fixed=""
-        _extern_gsub "$spec" "/" "::" _spec_fixed
+        str_replace "$spec" "/" "::" _spec_fixed
         log_error "'${spec}' separates modules with '/'; use '::': ${_spec_fixed}"
         return 1
     fi
     local declared="${spec#*::}"
-    _extern_gsub "$rest" "::" "/" rest
+    str_replace "$rest" "::" "/" rest
 
     root="$(extern_path "$name")" || return 1
 

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -37,7 +37,29 @@
 #   extern_resolve shebang/diagnostics/findings
 # =============================================================================
 
-nut_once || return 0
+# A guard of its own rather than `nut_once`, which reads `BASH_SOURCE` and uses
+# `printf -v`. A file on the floor cannot ask a bash-only function whether it
+# has been loaded: under a POSIX shell `nut_once` is not found, the `|| return
+# 0` returns from the whole file, and the module then defines nothing while
+# reporting success.
+[ -n "${_NUTSHELL_EXTERN_SH:-}" ] && return 0
+_NUTSHELL_EXTERN_SH=1
+
+# Every occurrence of one string swapped for another, into a named variable.
+# There is no `${x//from/to}` here.
+_extern_gsub() {
+    _eg_rest="$1"; _eg_acc=""
+    [ -n "$2" ] || { eval "$4=\$1"; return 0; }
+    case "$4" in ''|*[!A-Za-z0-9_]*|[0-9]*) return 2 ;; esac
+    while :; do
+        case "$_eg_rest" in
+            *"$2"*) _eg_acc="${_eg_acc}${_eg_rest%%"$2"*}$3"
+                    _eg_rest="${_eg_rest#*"$2"}" ;;
+            *) break ;;
+        esac
+    done
+    eval "$4=\${_eg_acc}\${_eg_rest}"
+}
 
 use toml xdg fs log validate
 
@@ -674,11 +696,13 @@ extern_resolve() {
     # handed to the filesystem, which is what made it work by accident.
     _has_slash=0; case "$rest" in */*) _has_slash=1 ;; esac
     if [ "$_has_slash" -eq 1 ]; then
-        log_error "'${spec}' separates modules with '/'; use '::': ${spec//\//::}"
+        _spec_fixed=""
+        _extern_gsub "$spec" "/" "::" _spec_fixed
+        log_error "'${spec}' separates modules with '/'; use '::': ${_spec_fixed}"
         return 1
     fi
     local declared="${spec#*::}"
-    rest="${rest//:://}"
+    _extern_gsub "$rest" "::" "/" rest
 
     root="$(extern_path "$name")" || return 1
 

--- a/lib/extern.sh
+++ b/lib/extern.sh
@@ -66,10 +66,10 @@ _extern_manifest() {
     # which unit is asking rather than which process was started. Same
     # anchoring `super::` uses, for the same reason.
     for start in "${_NUT_ASKING_FROM:-}" "${NUTSHELL_SCRIPT_DIR:-}" "${PWD}"; do
-        [[ -z "$start" ]] && continue
+        [ -z "$start" ] && continue
         dir="$start"
-        while [[ "$dir" != "/" && -n "$dir" ]]; do
-            [[ -f "$dir/nut.toml" ]] && { printf '%s' "$dir/nut.toml"; return 0; }
+        while [ "$dir" != "/" ] && [ -n "$dir" ]; do
+            [ -f "$dir/nut.toml" ] && { printf '%s' "$dir/nut.toml"; return 0; }
             dir="$(dirname "$dir")"
         done
     done
@@ -86,7 +86,7 @@ _extern_manifest() {
 # project on the machine actually live, and losing it offline breaks all of
 # them at once. `NUTSHELL_STORE` overrides it.
 _extern_cache_root() {
-    if [[ -n "${NUTSHELL_STORE:-}" ]]; then
+    if [ -n "${NUTSHELL_STORE:-}" ]; then
         printf '%s/externs' "${NUTSHELL_STORE%/}"
         return 0
     fi
@@ -119,7 +119,7 @@ _extern_lock_path() {
 extern_locked() {
     local name="$1" lock
     lock="$(_extern_lock_path)" || return 1
-    [[ -f "$lock" ]] || return 1
+    [ -f "$lock" ] || return 1
     toml_get "$lock" "deps.${name}.commit" 2>/dev/null
 }
 
@@ -142,13 +142,17 @@ extern_lock_write() {
         printf '# records what the head was and is rewritten whenever it moves.\n'
 
         # Every other entry, carried across unchanged.
-        if [[ -f "$lock" ]]; then
-            local other
+        if [ -f "$lock" ]; then
+            local other others
+            others="$(grep -o '^\[deps\.[^]]*\]' "$lock" 2>/dev/null \
+                      | sed 's/^\[deps\.//; s/\]$//')"
             while IFS= read -r other; do
-                [[ -z "$other" || "$other" == "$name" ]] && continue
+                { [ -z "$other" ] || [ "$other" = "$name" ]; } && continue
                 existing="$(toml_get "$lock" "deps.${other}.commit" 2>/dev/null)" || continue
                 printf '\n[deps.%s]\ncommit = "%s"\n' "$other" "$existing"
-            done < <(grep -o '^\[deps\.[^]]*\]' "$lock" 2>/dev/null | sed 's/^\[deps\.//; s/\]$//')
+            done <<EOF
+$others
+EOF
         fi
 
         printf '\n[deps.%s]\ncommit = "%s"\n' "$name" "$commit"
@@ -189,14 +193,18 @@ extern_declared() {
 # Left in place rather than deleted, because `extern_forget` is a public door
 # onto it and removing that is a change for consumers. Marked so the next
 # person to optimise this path does not find it and believe it.
-declare -gA _EXTERN_RESOLVED=()
+# A `map` rather than an associative array, which is bash's. It holds one
+# resolved directory per dependency name, so a `use` of a module from a unit
+# already resolved costs a lookup rather than the whole walk again.
+use map
+map_new _EXTERN_RESOLVED
 
 #[pub]
 # Forget what has been resolved. For a caller that has changed a lockfile and
 # wants the next lookup to see it, and for tests.
 # Usage: extern_forget [name]
 extern_forget() {
-    if [[ -n "${1:-}" ]]; then unset '_EXTERN_RESOLVED[$1]'; else _EXTERN_RESOLVED=(); fi
+    if [ -n "${1:-}" ]; then map_del _EXTERN_RESOLVED "$1"; else map_clear _EXTERN_RESOLVED; fi
 }
 
 #[pub]
@@ -204,15 +212,17 @@ extern_forget() {
 extern_path() {
     local name="$1" spec url ref mirror commit dir out
 
-    if [[ -n "${_EXTERN_RESOLVED[$name]:-}" ]]; then
+    local _er=""
+    map_read _er _EXTERN_RESOLVED "$name"
+    if [ -n "$_er" ]; then
         # Still checked, because a cached path whose checkout has been removed
         # is worse than no cache: the caller gets a directory git will not
         # answer for and no explanation.
-        if _extern_is_repo "${_EXTERN_RESOLVED[$name]}"; then
-            printf '%s' "${_EXTERN_RESOLVED[$name]}"
+        if _extern_is_repo "$_er"; then
+            printf '%s' "$_er"
             return 0
         fi
-        unset '_EXTERN_RESOLVED[$name]'
+        map_del _EXTERN_RESOLVED "$name"
     fi
     spec="$(extern_declared "$name")" || return 1
     url="${spec%% *}"
@@ -229,14 +239,14 @@ extern_path() {
         kind="${out%% *}"; resolved="${out#* }"
     fi
 
-    if [[ "$kind" == "moving" ]]; then
+    if [ "$kind" = "moving" ]; then
         commit="$resolved"
         extern_lock_write "$name" "$commit"
     else
         commit="$(extern_locked "$name")" || commit=""
-        if [[ -z "$commit" ]]; then
+        if [ -z "$commit" ]; then
             commit="${resolved:-$(_extern_ref_commit "$mirror" "$ref")}" || return 1
-            [[ -n "$commit" ]] || return 1
+            [ -n "$commit" ] || return 1
             extern_lock_write "$name" "$commit"
         fi
     fi
@@ -247,11 +257,11 @@ extern_path() {
     # handed the caller a path that git refuses to answer any question about,
     # permanently, with nothing to do about it but find the cache by hand.
     if ! _extern_is_repo "$dir"; then
-        [[ -e "$dir" ]] && git -C "$mirror" worktree prune 2>/dev/null
+        [ -e "$dir" ] && git -C "$mirror" worktree prune 2>/dev/null
         _extern_guard "$dir" _extern_lay_out "$name" "$mirror" "$url" "$commit" "$dir" || return 1
     fi
 
-    _EXTERN_RESOLVED["$name"]="$dir"
+    map_set _EXTERN_RESOLVED "$name" "$dir"
     printf '%s' "$dir"
 }
 
@@ -346,22 +356,23 @@ _extern_guard() {
         # per-user, so a permission refusal is not a concern here.
         local holder
         holder="$(cat "${lock}/pid" 2>/dev/null)"
-        if [[ "$holder" =~ ^[0-9]+$ ]] && ! kill -0 "$holder" 2>/dev/null; then
+        case "$holder" in ''|*[!0-9]*) holder="" ;; esac
+        if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
             rm -rf "$lock"
             continue
         fi
 
         # A lock with no pid in it: brand new, mid-write, or left by hand.
         # Those age out on the clock instead.
-        if [[ -d "$lock" ]] &&
-           [[ -z "$(find "$lock" -maxdepth 0 -mmin "-${_EXTERN_LOCK_STALE_MINUTES}" 2>/dev/null)" ]]; then
+        if [ -d "$lock" ] &&
+           [ -z "$(find "$lock" -maxdepth 0 -mmin "-${_EXTERN_LOCK_STALE_MINUTES}" 2>/dev/null)" ]; then
             rm -rf "$lock"
             continue
         fi
 
         sleep 1
         waited=$((waited + 1))
-        if [[ "$waited" -ge "$_EXTERN_LOCK_WAIT_SECONDS" ]]; then
+        if [ "$waited" -ge "$_EXTERN_LOCK_WAIT_SECONDS" ]; then
             log_error "waited ${waited}s for another process to lay out ${dir}"
             log_error "if nothing else is running, remove ${lock}"
             return 1
@@ -382,15 +393,15 @@ _extern_guard() {
     if ! _extern_is_repo "$dir"; then
         # Anything already here is the wreckage of an attempt that did not
         # finish, and git will not clone into a directory that is not empty.
-        [[ -e "$dir" ]] && rm -rf "$dir"
+        [ -e "$dir" ] && rm -rf "$dir"
 
         "$@" || rc=$?
 
         # The command reporting success is not the same as the directory being
         # usable, and the difference is what a later call would inherit.
-        if [[ "$rc" -eq 0 ]] && ! _extern_is_repo "$dir"; then
+        if [ "$rc" -eq 0 ] && ! _extern_is_repo "$dir"; then
             rc=1
-            [[ -e "$dir" ]] && rm -rf "$dir"
+            [ -e "$dir" ] && rm -rf "$dir"
         fi
     fi
     # Not rmdir: the lock holds the pid file now, and rmdir on a non-empty
@@ -445,7 +456,7 @@ _extern_mirror() {
 # enough that a script in a loop does not talk to the network every time, short
 # enough that somebody who just pushed sees it on the next run.
 
-declare -gi EXTERN_BRANCH_TTL="${EXTERN_BRANCH_TTL:-3600}"
+EXTERN_BRANCH_TTL="${EXTERN_BRANCH_TTL:-3600}"
 
 # What the remote calls this ref. Prints "heads <sha>" or "tags <sha>", and
 # nothing when the remote has neither.
@@ -455,13 +466,21 @@ declare -gi EXTERN_BRANCH_TTL="${EXTERN_BRANCH_TTL:-3600}"
 # them. A branch wins where both exist: it is the one somebody meant to track.
 _extern_remote_ref() {
     local url="$1" ref="$2" line sha
-    [[ -n "$ref" ]] || return 1
+    [ -n "$ref" ] || return 1
 
+    # Gathered first, then walked from a here-document. The loop cannot go on
+    # the right of a pipe: it `return`s from this function on a match, and in a
+    # subshell that returns from the subshell instead, so the function would
+    # carry on past the answer it had already found.
+    local heads
+    heads="$(git ls-remote "$url" "refs/heads/${ref}" 2>/dev/null)"
     while IFS= read -r line; do
-        [[ "$line" == *"refs/heads/${ref}" ]] || continue
+        case "$line" in *"refs/heads/${ref}") ;; *) continue ;; esac
         sha="${line%%[[:space:]]*}"
-        [[ -n "$sha" ]] && { printf 'heads %s' "$sha"; return 0; }
-    done < <(git ls-remote "$url" "refs/heads/${ref}" 2>/dev/null)
+        [ -n "$sha" ] && { printf 'heads %s' "$sha"; return 0; }
+    done <<EOF
+$heads
+EOF
 
     # `^{}` is the commit an annotated tag points at, and it is the one to
     # build from; the bare line is the tag object itself.
@@ -476,16 +495,23 @@ _extern_remote_ref() {
     # Two exact patterns rather than a glob, so nothing but those two rows
     # can come back and the `case` below has nothing to filter out. A glob
     # would also return `0.1.0-rc1`, which is a door with no reason to open.
-    local peeled="" plain=""
+    # Gathered first for the same reason as the heads loop above, and with one
+    # more: the body sets `peeled` and `plain` and the code after this reads
+    # them, so on the right of a pipe both would be set in a subshell and read
+    # back empty here.
+    local peeled="" plain="" tags
+    tags="$(git ls-remote "$url" "refs/tags/${ref}" "refs/tags/${ref}^{}" 2>/dev/null)"
     while IFS= read -r line; do
         sha="${line%%[[:space:]]*}"
         case "$line" in
             *"refs/tags/${ref}^{}") peeled="$sha" ;;
             *"refs/tags/${ref}")    plain="$sha"  ;;
         esac
-    done < <(git ls-remote "$url" "refs/tags/${ref}" "refs/tags/${ref}^{}" 2>/dev/null)
-    [[ -n "$peeled" ]] && { printf 'tags %s' "$peeled"; return 0; }
-    [[ -n "$plain" ]]  && { printf 'tags %s' "$plain";  return 0; }
+    done <<EOF
+$tags
+EOF
+    [ -n "$peeled" ] && { printf 'tags %s' "$peeled"; return 0; }
+    [ -n "$plain" ]  && { printf 'tags %s' "$plain";  return 0; }
     return 1
 }
 
@@ -496,9 +522,9 @@ _extern_resolution_path() {
 
 _extern_read_resolution() {
     local f="$1" ts sha
-    [[ -r "$f" ]] || return 1
+    [ -r "$f" ] || return 1
     { IFS= read -r ts; IFS= read -r sha; } < "$f" || return 1
-    [[ -n "$sha" ]] || return 1
+    [ -n "$sha" ] || return 1
     printf '%s %s' "${ts:-0}" "$sha"
 }
 
@@ -507,9 +533,9 @@ _extern_fresh_resolution() {
     local out ts sha now
     out="$(_extern_read_resolution "$1")" || return 1
     ts="${out%% *}"; sha="${out#* }"
-    [[ "$ts" =~ ^[0-9]+$ ]] || return 1
+    case "$ts" in ''|*[!0-9]*) return 1 ;; esac
     now="$(date -u +%s 2>/dev/null)" || return 1
-    (( now - ts <= EXTERN_BRANCH_TTL )) || return 1
+    [ "$(( now - ts ))" -le "$EXTERN_BRANCH_TTL" ] || return 1
     printf '%s' "$sha"
 }
 
@@ -546,7 +572,13 @@ extern_resolve_ref() {
     local url="$1" ref="$2" out kind sha f
 
     # A revision is itself, and asking a remote about it tells nobody anything.
-    if [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    # Forty hex digits and nothing else. There is no `=~` here, so the length
+    # is checked and then the content.
+    _is_sha=0
+    if [ "${#ref}" -eq 40 ]; then
+        case "$ref" in *[!0-9a-fA-F]*) ;; *) _is_sha=1 ;; esac
+    fi
+    if [ "$_is_sha" -eq 1 ]; then
         printf 'fixed %s' "$ref"
         return 0
     fi
@@ -559,7 +591,7 @@ extern_resolve_ref() {
 
     if out="$(_extern_remote_ref "$url" "$ref")"; then
         kind="${out%% *}"; sha="${out#* }"
-        if [[ "$kind" == "heads" ]]; then
+        if [ "$kind" = "heads" ]; then
             _extern_remember_resolution "$f" "$sha"
             printf 'moving %s' "$sha"
         else
@@ -581,7 +613,7 @@ extern_resolve_ref() {
 # a tool whose whole point is working on a machine that is broken.
 _extern_refresh() {
     local mirror="$1" ref="$2"
-    [[ -n "$ref" ]] || return 0
+    [ -n "$ref" ] || return 0
     # `--depth 1` because the mirror is only ever read at one commit, and the
     # clone that made it was shallow too.
     git -C "$mirror" fetch --quiet --depth 1 origin "$ref" 2>/dev/null || return 0
@@ -594,7 +626,7 @@ _extern_refresh() {
 _extern_ref_commit() {
     local mirror="$1" ref="$2" c
     for c in FETCH_HEAD "origin/${ref}" "$ref" HEAD; do
-        [[ -n "$ref" || "$c" == "HEAD" ]] || continue
+        { [ -n "$ref" ] || [ "$c" = "HEAD" ]; } || continue
         if git -C "$mirror" rev-parse --verify --quiet "${c}^{commit}" >/dev/null 2>&1; then
             git -C "$mirror" rev-parse "${c}^{commit}" 2>/dev/null && return 0
         fi
@@ -636,11 +668,12 @@ extern_resolve() {
     local spec="$1" name rest root candidate
     name="${spec%%::*}"
     rest="${spec#*::}"
-    [[ "$name" == "$spec" ]] && return 1
+    [ "$name" = "$spec" ] && return 1
 
     # `::` separates modules the whole way down. A `/` is refused rather than
     # handed to the filesystem, which is what made it work by accident.
-    if [[ "$rest" == */* ]]; then
+    _has_slash=0; case "$rest" in */*) _has_slash=1 ;; esac
+    if [ "$_has_slash" -eq 1 ]; then
         log_error "'${spec}' separates modules with '/'; use '::': ${spec//\//::}"
         return 1
     fi
@@ -653,10 +686,10 @@ extern_resolve() {
     # from nowhere else. Falling back to a search would put the guessing back
     # underneath the declaration, where a wrong entry resolves anyway and
     # nothing says so.
-    if [[ -r "${root}/lib.nut" ]]; then
+    if [ -r "${root}/lib.nut" ]; then
         local from_nut
         if from_nut="$(_lib_nut_lookup "$root" "$declared" public)"; then
-            [[ -f "$from_nut" ]] && { printf '%s' "$from_nut"; return 0; }
+            [ -f "$from_nut" ] && { printf '%s' "$from_nut"; return 0; }
             log_error "${name}'s lib.nut declares '${declared}' at ${from_nut#$root/}, which is not there"
             return 1
         fi
@@ -668,7 +701,7 @@ extern_resolve() {
     # and a flat `lib/<mod>.sh` like nutshell's own. Nothing else is guessed at,
     # because a resolver that searches widely finds the wrong file eventually.
     for candidate in "${root}/libs/${rest}.sh" "${root}/lib/${rest}.sh" "${root}/${rest}.sh"; do
-        [[ -f "$candidate" ]] && { printf '%s' "$candidate"; return 0; }
+        [ -f "$candidate" ] && { printf '%s' "$candidate"; return 0; }
     done
 
     log_error "${name} has no module '${rest}'"

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -41,44 +41,13 @@ _NUTSHELL_JSON_SH=1
 # Declared, not sourced by path. A hand-rolled `source` loads the module and
 # hides it from the module-contract check, which reads `use` lines, so the
 # dependency was real and unrecorded at once.
-use deps
+use deps string
 
 # A newline and a tab as themselves. There is no `$'\n'` here to write one
 # inline with, and the trailing `.` is because command substitution strips the
 # trailing newline, which is the character being asked for.
 _JSON_NL="$(printf '\n.')"; _JSON_NL="${_JSON_NL%.}"
 _JSON_TAB="$(printf '\t.')"; _JSON_TAB="${_JSON_TAB%.}"
-
-# Every occurrence of one string swapped for another, into a named variable.
-# There is no `${x//from/to}` here.
-#
-# `string`'s `str_replace` does the same walk and is on the floor, and it
-# prints, so each of the eight calls below would cost a fork and lose a
-# trailing newline from a value that is allowed to have one. This is the second
-# copy of the loop in this library, which is worth one comment and not yet
-# worth a shared out-name form and a new dependency in two modules.
-_json_gsub() {
-    # An empty needle matches everywhere and the loop never shortens the
-    # remainder, so it appends forever. `str_replace` guards this on its first
-    # line and this copy did not, which is the cost of the second copy.
-    [ -n "$2" ] || { eval "$4=\$1"; return 0; }
-    # The out-name reaches `eval`, so it is checked the way every other
-    # out-name in this library is: `_json_gsub a b c 'v; echo X'` ran the echo.
-    case "$4" in
-        ''|*[!A-Za-z0-9_]*|[0-9]*) return 2 ;;
-    esac
-    _jg_rest="$1"; _jg_acc=""
-    while :; do
-        case "$_jg_rest" in
-            *"$2"*)
-                _jg_acc="${_jg_acc}${_jg_rest%%"$2"*}$3"
-                _jg_rest="${_jg_rest#*"$2"}"
-                ;;
-            *) break ;;
-        esac
-    done
-    eval "$4=\${_jg_acc}\${_jg_rest}"
-}
 
 # -----------------------------------------------------------------------------
 # Module Status
@@ -337,10 +306,10 @@ json_object() {
         
         # Escape special characters in value
         # Backslash first. Any other order escapes the backslashes it adds.
-        _json_gsub "$value" '\' '\\' value
-        _json_gsub "$value" '"' '\"' value
-        _json_gsub "$value" "$_JSON_NL" '\n' value
-        _json_gsub "$value" "$_JSON_TAB" '\t' value
+        str_replace "$value" '\' '\\' value
+        str_replace "$value" '"' '\"' value
+        str_replace "$value" "$_JSON_NL" '\n' value
+        str_replace "$value" "$_JSON_TAB" '\t' value
         
         result="${result}""\"${key}\":\"${value}\""
     done
@@ -363,10 +332,10 @@ json_array() {
         
         # Escape special characters
         # Backslash first. Any other order escapes the backslashes it adds.
-        _json_gsub "$value" '\' '\\' value
-        _json_gsub "$value" '"' '\"' value
-        _json_gsub "$value" "$_JSON_NL" '\n' value
-        _json_gsub "$value" "$_JSON_TAB" '\t' value
+        str_replace "$value" '\' '\\' value
+        str_replace "$value" '"' '\"' value
+        str_replace "$value" "$_JSON_NL" '\n' value
+        str_replace "$value" "$_JSON_TAB" '\t' value
         
         result="${result}""\"${value}\""
     done

--- a/lib/priv.sh
+++ b/lib/priv.sh
@@ -29,7 +29,13 @@
 #   printf '%s/.local/state\n' "$(priv_user_home)"
 # =============================================================================
 
-nut_once || return 0
+# A guard of its own rather than `nut_once`, which reads `BASH_SOURCE` and uses
+# `printf -v`. A file on the floor cannot ask a bash-only function whether it
+# has been loaded: under a POSIX shell `nut_once` is not found, the `|| return
+# 0` returns from the whole file, and the module then defines nothing while
+# reporting success.
+[ -n "${_NUTSHELL_PRIV_SH:-}" ] && return 0
+_NUTSHELL_PRIV_SH=1
 
 use log
 
@@ -38,21 +44,21 @@ use log
 # Read at load time on purpose. A caller asking later, from inside something
 # that has already elevated, would be told about root, and the whole point is
 # to answer about the person.
-declare -g PRIV_USER="${PRIV_USER:-}"
-declare -g PRIV_HOME="${PRIV_HOME:-}"
-declare -g PRIV_UID="${PRIV_UID:-}"
+PRIV_USER="${PRIV_USER:-}"
+PRIV_HOME="${PRIV_HOME:-}"
+PRIV_UID="${PRIV_UID:-}"
 
 _priv_learn_user() {
-    [[ -z "$PRIV_UID" ]] || return 0
+    [ -z "$PRIV_UID" ] || return 0
 
     # `SUDO_USER` is set when this process was itself started under sudo, and
     # then it names the person rather than root. That case is the one this
     # module is trying to make unnecessary, and it still has to be answered
     # correctly while it exists.
-    if [[ "$(id -u 2>/dev/null)" == "0" && -n "${SUDO_USER:-}" ]]; then
+    if [ "$(id -u 2>/dev/null)" = "0" ] && [ -n "${SUDO_USER:-}" ]; then
         PRIV_USER="$SUDO_USER"
         PRIV_UID="${SUDO_UID:-}"
-        [[ -n "$PRIV_UID" ]] || PRIV_UID="$(id -u "$PRIV_USER" 2>/dev/null)"
+        [ -n "$PRIV_UID" ] || PRIV_UID="$(id -u "$PRIV_USER" 2>/dev/null)"
         PRIV_HOME="$(_priv_home_of "$PRIV_USER")"
         return 0
     fi
@@ -68,28 +74,36 @@ _priv_home_of() {
     # Initialised, not merely declared: `local x` leaves it unset, and a caller
     # running under `set -u` gets an error rather than an empty string.
     local u="$1" line=""
-    [[ -n "$u" ]] || return 1
+    [ -n "$u" ] || return 1
     if command -v getent >/dev/null 2>&1; then
         line="$(getent passwd "$u" 2>/dev/null)" || line=""
     fi
-    if [[ -z "$line" && -r /etc/passwd ]]; then
+    if [ -z "$line" ] && [ -r /etc/passwd ]; then
         while IFS= read -r line; do
-            [[ "$line" == "${u}:"* ]] && break
+            case "$line" in "${u}:"*) break ;; esac
             line=""
         done < /etc/passwd
     fi
-    if [[ -n "$line" ]]; then
-        # name:passwd:uid:gid:gecos:home:shell
-        local IFS=:
-        # shellcheck disable=SC2206
-        local -a f=($line)
-        [[ -n "${f[5]:-}" ]] && { printf '%s' "${f[5]}"; return 0; }
+    if [ -n "$line" ]; then
+        # name:passwd:uid:gid:gecos:home:shell, and the home is the sixth.
+        #
+        # Cut to it rather than splitting into an array, which needs `local -a`
+        # and an `IFS` a POSIX shell has no per-command form of. Five fields
+        # dropped from the front, then everything from the next colon on.
+        local home="$line"
+        home="${home#*:}"   # passwd
+        home="${home#*:}"   # uid
+        home="${home#*:}"   # gid
+        home="${home#*:}"   # gecos
+        home="${home#*:}"   # home:shell
+        home="${home%%:*}"  # home
+        [ -n "$home" ] && { printf '%s' "$home"; return 0; }
     fi
     # A mac keeps its users elsewhere, and `dscl` is how you ask.
     if command -v dscl >/dev/null 2>&1; then
         local h; h="$(dscl . -read "/Users/${u}" NFSHomeDirectory 2>/dev/null)" || h=""
         h="${h#*: }"
-        [[ -n "$h" ]] && { printf '%s' "$h"; return 0; }
+        [ -n "$h" ] && { printf '%s' "$h"; return 0; }
     fi
     return 1
 }
@@ -145,10 +159,10 @@ _priv_sq() {
 # Usage: priv_as_user "reading your checkout" git -C "$d" status
 priv_as_user() {
     local what="${1:-a step}"; shift || true
-    (( $# > 0 )) || { log_error "priv_as_user: nothing to run"; return 2; }
+    [ "$#" -gt 0 ] || { log_error "priv_as_user: nothing to run"; return 2; }
 
     local u; u="$(priv_user)"
-    if ! priv_is_root || [[ -z "$u" || "$u" == "root" ]]; then
+    if ! priv_is_root || [ -z "$u" ] || [ "$u" = "root" ]; then
         "$@"
         return $?
     fi
@@ -187,7 +201,7 @@ priv_as_user() {
 #[pub]
 # Is this already root?
 # Usage: priv_is_root
-priv_is_root() { [[ "$(id -u 2>/dev/null)" == "0" ]]; }
+priv_is_root() { [ "$(id -u 2>/dev/null)" = "0" ]; }
 
 #[pub]
 # Can this ask for root at all, and how?
@@ -236,7 +250,7 @@ priv_needs_password() {
 # Usage: priv_run "mount the stick" mount /dev/sda2 /mnt
 priv_run() {
     local what="${1:-a privileged step}"; shift || true
-    (( $# > 0 )) || { log_error "priv_run: nothing to run"; return 2; }
+    [ "$#" -gt 0 ] || { log_error "priv_run: nothing to run"; return 2; }
 
     if priv_is_root; then
         "$@"
@@ -269,9 +283,9 @@ priv_run() {
 
 # Is there a terminal a password could be typed on?
 _priv_can_prompt() {
-    [[ -t 0 || -t 1 || -t 2 ]] && return 0
+    { [ -t 0 ] || [ -t 1 ] || [ -t 2 ]; } && return 0
     # An askpass helper is a terminal by another name.
-    [[ -n "${SUDO_ASKPASS:-}" ]] && return 0
+    [ -n "${SUDO_ASKPASS:-}" ] && return 0
     return 1
 }
 
@@ -284,11 +298,11 @@ _priv_can_prompt() {
 # Usage: priv_return <path>...
 priv_return() {
     local u; u="$(priv_user)"
-    [[ -n "$u" && "$u" != "root" ]] || return 0
+    { [ -n "$u" ] && [ "$u" != "root" ]; } || return 0
     priv_is_root || return 0
     local p
     for p in "$@"; do
-        [[ -e "$p" ]] || continue
+        [ -e "$p" ] || continue
         chown -R "$u" "$p" 2>/dev/null || true
     done
 }

--- a/lib/priv.sh
+++ b/lib/priv.sh
@@ -136,9 +136,22 @@ priv_user_home() { _priv_learn_user; printf '%s' "$PRIV_HOME"; }
 #
 # Single quotes take everything literally, so the only character needing work
 # is the single quote itself: close, escape it outside the quotes, reopen.
+# One shell-quoted word, safe to hand to `su -c`.
+#
+# Walked rather than `${s//from/to}`, which is bash's. Every single quote
+# closes the quoting, escapes itself, and opens it again, which is the only
+# form that survives inside single quotes.
 _priv_sq() {
-    local s="${1:-}"
-    printf "'%s'" "${s//\'/\'\\\'\'}"
+    local s="${1:-}" out="" head
+    while :; do
+        case "$s" in
+            *\'*) head="${s%%\'*}"
+                  out="${out}${head}'\\''"
+                  s="${s#*\'}" ;;
+            *) break ;;
+        esac
+    done
+    printf "'%s'" "${out}${s}"
 }
 
 #[pub]
@@ -184,7 +197,7 @@ priv_as_user() {
             # back into one string. Every other route avoids that.
             su)
                 local q="" a
-                for a in "$@"; do q+="${q:+ }$(_priv_sq "$a")"; done
+                for a in "$@"; do q="${q}${q:+ }$(_priv_sq "$a")"; done
                 # No `-s`. That flag is util-linux; BSD and macOS `su` is
                 # `su [-] [-flm] [login [args]]` and refuses it, and this is
                 # the branch a busybox rescue console actually takes.

--- a/lib/string.posix.sh
+++ b/lib/string.posix.sh
@@ -89,14 +89,31 @@ str_rtrim() {
 #[pub]
 # Replace all occurrences of a substring
 # Usage: str_replace "hello world" "world" "bash" -> "hello bash"
+# Usage: str_replace "$v" "," " " out; printf '%s' "$out"
+#
+# Name a variable as a fourth argument and the answer goes there instead of to
+# stdout, with no trailing newline and no fork. Three modules had grown their
+# own copy of this loop because the printing form costs a fork per call and
+# loses a trailing newline; one of those copies then diverged and shipped an
+# injection hole. The out-name is what lets them share this one.
+#
+# The name is validated **before** either exit, because both reach `eval`.
+# Checking it after the empty-needle shortcut is exactly the bug those copies
+# had: the shortcut ran the name unvalidated.
 #
 # A loop rather than `${x//from/to}`, which is bash. It walks by cutting at the
 # first occurrence and keeping what is either side, which is two POSIX
 # expansions and no tool: `sed` would need the needle escaped as a regular
 # expression, and a caller's needle is a literal.
 str_replace() {
-    _str="${1:-}"; _from="${2:-}"; _to="${3:-}"
-    if [ -z "$_from" ]; then printf '%s\n' "$_str"; return 0; fi
+    _str="${1:-}"; _from="${2:-}"; _to="${3:-}"; _sr_out="${4:-}"
+    if [ -n "$_sr_out" ]; then
+        case "$_sr_out" in ''|*[!A-Za-z0-9_]*|[0-9]*) return 2 ;; esac
+    fi
+    if [ -z "$_from" ]; then
+        if [ -n "$_sr_out" ]; then eval "$_sr_out=\$_str"; else printf '%s\n' "$_str"; fi
+        return 0
+    fi
 
     _out=""
     while :; do
@@ -108,7 +125,9 @@ str_replace() {
         _out="${_out}${_head}${_to}"
         _str="${_str#*"$_from"}"
     done
-    printf '%s\n' "${_out}${_str}"
+    if [ -n "$_sr_out" ]; then eval "$_sr_out=\${_out}\${_str}"; else
+        printf '%s\n' "${_out}${_str}"
+    fi
 }
 
 #[pub]

--- a/lib/string.sh
+++ b/lib/string.sh
@@ -70,8 +70,21 @@ str_replace() {
     local str="${1:-}"
     local from="${2:-}"
     local to="${3:-}"
-    
-    [[ -z "$from" ]] && { echo "$str"; return 0; }
+    local _sr_out="${4:-}"
+
+    # The out-name form, matching the floor half. Both halves have to take the
+    # same four arguments or a caller works on one shell and not the other,
+    # which is the failure the pair exists to prevent.
+    #
+    # Validated before either exit, because both reach an assignment through
+    # `eval`.
+    if [[ -n "$_sr_out" ]]; then
+        case "$_sr_out" in ''|*[!A-Za-z0-9_]*|[0-9]*) return 2 ;; esac
+    fi
+    if [[ -z "$from" ]]; then
+        if [[ -n "$_sr_out" ]]; then eval "$_sr_out=\$str"; else echo "$str"; fi
+        return 0
+    fi
     # The needle is quoted, so it is a literal.
     #
     # Unquoted, `${str//$from/$to}` reads it as a pattern, which is not what
@@ -83,7 +96,18 @@ str_replace() {
     # Found by writing the POSIX floor beside this and comparing the two over
     # the same inputs. The floor could not have this bug: it has no `${x//}`
     # and cuts at the first literal occurrence instead.
-    echo "${str//"$from"/$to}"
+    # **Both** sides quoted. The needle is quoted so it is a literal rather
+    # than a pattern, which is the bug the comment above records. The
+    # replacement has to be quoted for the same class of reason: unquoted,
+    # `$to` goes through quote removal, so a replacement of `\\` collapses to
+    # `\` and `str_replace a a '\\'` answers `\` where the floor half answers
+    # `\\`. That divergence sat here until three modules stopped keeping their
+    # own copy of this loop and started calling it.
+    if [[ -n "$_sr_out" ]]; then
+        printf -v "$_sr_out" '%s' "${str//"$from"/"$to"}"
+    else
+        printf '%s\n' "${str//"$from"/"$to"}"
+    fi
 }
 
 #[pub]

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -35,13 +35,26 @@
 #   TEST_FILTER - only run tests whose name contains this
 # =============================================================================
 
-nut_once || return 0
+# A guard of its own rather than `nut_once`, which reads `BASH_SOURCE` and uses
+# `printf -v`. A file on the floor cannot ask a bash-only function whether it
+# has been loaded: under a POSIX shell `nut_once` is not found, the `|| return
+# 0` returns from the whole file, and the module then defines nothing while
+# reporting success.
+[ -n "${_NUTSHELL_TEST_SH:-}" ] && return 0
+_NUTSHELL_TEST_SH=1
 
-use attr log fs
+# A newline as itself. There is no `$'\n'` here to write one inline with, and
+# the trailing `.` is because command substitution strips the trailing newline,
+# which is the character being asked for.
+_TEST_NL="$(printf '\n.')"; _TEST_NL="${_TEST_NL%.}"
 
-declare -gi _TEST_PASSED=0
-declare -gi _TEST_FAILED=0
-declare -ga _TEST_FAILURES=()
+use attr log fs list
+
+_TEST_PASSED=0
+_TEST_FAILED=0
+# A `list` rather than an indexed array, which is bash's. It only ever grows by
+# one and is read once at the end, which is what `list` is for.
+list_new _TEST_FAILURES
 
 # -----------------------------------------------------------------------------
 # Assertions
@@ -83,7 +96,7 @@ _test_failed() {
 # A file, because each test runs in its own subshell and a variable set there
 # cannot reach the runner that has to decide the verdict.
 _test_mark() {
-    [[ -n "${_TEST_MARK:-}" ]] && printf '%s' "$1" >> "$_TEST_MARK"
+    [ -n "${_TEST_MARK:-}" ] && printf '%s' "$1" >> "$_TEST_MARK"
     return 0
 }
 
@@ -94,7 +107,7 @@ _test_asserted() { _test_mark a; }
 # Usage: assert_eq "$got" "$want" ["what this is about"] -> 0 or 1
 assert_eq() {
     _test_asserted
-    [[ "$1" == "$2" ]] && return 0
+    [ "$1" = "$2" ] && return 0
     _test_failed "expected [$2]" "     got [$1]" ${3:+"     $3"}
 }
 
@@ -102,7 +115,7 @@ assert_eq() {
 # Usage: assert_ne "$got" "$unwanted" ["what this is about"] -> 0 or 1
 assert_ne() {
     _test_asserted
-    [[ "$1" != "$2" ]] && return 0
+    [ "$1" != "$2" ] && return 0
     _test_failed "expected anything but [$2]" ${3:+"     $3"}
 }
 
@@ -110,7 +123,7 @@ assert_ne() {
 # Usage: assert_contains "$haystack" "$needle" ["about"] -> 0 or 1
 assert_contains() {
     _test_asserted
-    [[ "$1" == *"$2"* ]] && return 0
+    case "$1" in *"$2"*) return 0 ;; esac
     _test_failed "expected to find [$2]" "            in [$1]" ${3:+"     $3"}
 }
 
@@ -127,7 +140,7 @@ assert_contains() {
 # Usage: assert_not_contains "$output" "PWNED"
 assert_not_contains() {
     _test_asserted
-    [[ "$1" != *"$2"* ]] && return 0
+    case "$1" in *"$2"*) ;; *) return 0 ;; esac
     _test_failed "expected NOT to find [$2]" "                in [$1]" ${3:+"     $3"}
 }
 
@@ -135,7 +148,7 @@ assert_not_contains() {
 # Usage: assert_empty "$value" ["about"] -> 0 or 1
 assert_empty() {
     _test_asserted
-    [[ -z "$1" ]] && return 0
+    [ -z "$1" ] && return 0
     _test_failed "expected nothing, got [$1]" ${2:+"     $2"}
 }
 
@@ -145,7 +158,7 @@ assert_ok() {
     _test_asserted
     local rc=0
     "$@" || rc=$?
-    [[ "$rc" -eq 0 ]] && return 0
+    [ "$rc" -eq 0 ] && return 0
     _test_failed "expected success from [$*], got exit ${rc}"
 }
 
@@ -175,7 +188,7 @@ assert_exits() {
     local want="$1"; shift
     local rc=0
     "$@" || rc=$?
-    [[ "$rc" -eq "$want" ]] && return 0
+    [ "$rc" -eq "$want" ] && return 0
     _test_failed "expected exit [${want}] from [$*]" "     got exit [${rc}]"
 }
 
@@ -192,8 +205,23 @@ assert_exits() {
 # under bash older than 5.0, and the caller then prints no timing rather than
 # a wrong one.
 _test_now_us() {
-    local t="${EPOCHREALTIME:-}"
-    [[ -n "$t" ]] && printf '%s' "${t//[!0-9]/}"
+    local t="${EPOCHREALTIME:-}" out="" run
+    [ -n "$t" ] || return 0
+    # Digits only, `1234.5678` to `12345678`. Walked rather than
+    # `${t//[!0-9]/}`, which is bash's; whole digit runs are taken at once, so
+    # this is two passes rather than one per character.
+    #
+    # `EPOCHREALTIME` is bash's too, so on the floor `$t` is empty and this
+    # returns nothing, which is the fallback the caller already handles by
+    # printing no timing rather than a wrong one.
+    while [ -n "$t" ]; do
+        run="${t%%[!0-9]*}"
+        if [ -n "$run" ]; then
+            out="${out}${run}"; t="${t#"$run"}"; continue
+        fi
+        t="${t#?}"
+    done
+    printf '%s' "$out"
 }
 
 # _test_mark_dir -> a directory to keep one tally per test in
@@ -205,7 +233,7 @@ _test_now_us() {
 #
 # A directory is still one thing to remove at the end.
 _test_mark_dir() {
-    [[ -n "${_TEST_MARK_DIR:-}" ]] && { printf '%s' "$_TEST_MARK_DIR"; return 0; }
+    [ -n "${_TEST_MARK_DIR:-}" ] && { printf '%s' "$_TEST_MARK_DIR"; return 0; }
     fs_temp_dir nutshell-test
 }
 
@@ -213,7 +241,7 @@ _test_mark_dir() {
 # Usage: test_run tests/string_test.sh -> runs every #[test] in the file
 test_run() {
     local file="$1"
-    [[ -f "$file" ]] || { log_error "no test file: ${file}"; return 1; }
+    [ -f "$file" ] || { log_error "no test file: ${file}"; return 1; }
 
     local name output rc
     _TEST_MARK_DIR="$(_test_mark_dir)" || return 1
@@ -226,22 +254,32 @@ test_run() {
     # It is not hypothetical. Renaming `attr_find` breaks the discovery this
     # very loop uses, so every file in the suite yields nothing and the run
     # reports green over a library that no longer loads.
-    local found=0
+    local found=0 _tf_names
+    # Gathered first. The body counts into `found`, which the code after it
+    # reads, so on the right of a pipe the count would be made in a subshell
+    # and read back as zero here: every file would report no tests.
+    _tf_names="$(attr_find "$file" test)"
     while IFS= read -r name; do
-        [[ -n "$name" ]] && found=$(( found + 1 ))
-    done < <(attr_find "$file" test)
+        [ -n "$name" ] && found=$(( found + 1 ))
+    done <<EOF
+$_tf_names
+EOF
 
-    if [[ "$found" -eq 0 ]]; then
-        _TEST_FAILED+=1
-        _TEST_FAILURES+=("${file##*/}: no #[test] found in the file")
+    if [ "$found" -eq 0 ]; then
+        _TEST_FAILED=$(( _TEST_FAILED + 1 ))
+        list_push _TEST_FAILURES "${file##*/}: no #[test] found in the file"
         log_tagged "FAIL" red "${file##*/}"
         log_substep "no #[test] found. An empty file reports a pass otherwise."
         return 1
     fi
 
+    # Same here-document, same reason: the body counts passes and failures
+    # into variables the summary reads.
     while IFS= read -r name; do
-        [[ -z "$name" ]] && continue
-        [[ -n "${TEST_FILTER:-}" && "$name" != *"$TEST_FILTER"* ]] && continue
+        [ -z "$name" ] && continue
+        if [ -n "${TEST_FILTER:-}" ]; then
+            case "$name" in *"$TEST_FILTER"*) ;; *) continue ;; esac
+        fi
 
         # Its own file, so nothing a previous test left behind, and nothing a
         # previous test is still doing, can be read as this one's.
@@ -259,7 +297,7 @@ test_run() {
         start_us="$(_test_now_us)"
         output="$( set +e; . "$file" >/dev/null 2>&1; "$name" 2>&1; _test_mark z )"
         end_us="$(_test_now_us)"
-        [[ -n "$start_us" && -n "$end_us" ]] &&
+        [ -n "$start_us" ] && [ -n "$end_us" ] &&
             took=" ($(( (end_us - start_us) / 1000000 )).$(( (end_us - start_us) / 100000 % 10 ))s)"
 
         # The tally decides, not the exit status. A test whose last command
@@ -269,41 +307,44 @@ test_run() {
         local tally why=""
         tally="$(cat "$_TEST_MARK" 2>/dev/null)"
         rc=0
-        if [[ "$tally" != *z* ]]; then
+        _has_z=0; case "$tally" in *z*) _has_z=1 ;; esac
+        if [ "$_has_z" -eq 0 ]; then
             # What the marker actually held, because "did not finish" alone is
             # not diagnosable and this has fired intermittently on tests that
             # pass when run on their own. An empty tally and a truncated one
             # are different faults: empty says the test body never reached its
             # first mark, and a partial one says it stopped part way.
             rc=1
-            if [[ ! -e "$_TEST_MARK" ]]; then
+            if [ ! -e "$_TEST_MARK" ]; then
                 why="the test did not finish (its marker file is gone: ${_TEST_MARK})"
-            elif [[ -z "$tally" ]]; then
+            elif [ -z "$tally" ]; then
                 why="the test did not finish (marker empty, so it stopped before the first assertion)"
             else
                 why="the test did not finish (marker held '${tally}', so it stopped part way)"
             fi
-        elif [[ "$tally" == *f* ]]; then
+        elif case "$tally" in *f*) true ;; *) false ;; esac; then
             rc=1
-        elif [[ "$tally" != *a* ]]; then
+        elif case "$tally" in *a*) false ;; *) true ;; esac; then
             # Worse than a weak test: it occupies the place a real one would be
             # noticed missing from, and it counts toward a number people quote.
             rc=1; why="the test asserted nothing"
         fi
-        [[ -n "$why" ]] && output="${output}${output:+$'\n'}${why}"
+        [ -n "$why" ] && output="${output}${output:+$_TEST_NL}${why}"
 
-        if [[ $rc -eq 0 ]]; then
-            _TEST_PASSED+=1
+        if [ $rc -eq 0 ]; then
+            _TEST_PASSED=$(( _TEST_PASSED + 1 ))
             log_tagged "PASS" green "$name${took}"
         else
-            _TEST_FAILED+=1
-            _TEST_FAILURES+=("${file##*/}: ${name}")
+            _TEST_FAILED=$(( _TEST_FAILED + 1 ))
+            list_push _TEST_FAILURES "${file##*/}: ${name}"
             log_tagged "FAIL" red "$name${took}"
-            [[ -n "$output" ]] && printf '%s\n' "$output" | while IFS= read -r l; do
+            [ -n "$output" ] && printf '%s\n' "$output" | while IFS= read -r l; do
                 log_substep "$l"
             done
         fi
-    done < <(attr_find "$file" test)
+    done <<EOF
+$_tf_names
+EOF
 }
 
 #[pub]
@@ -311,7 +352,7 @@ test_run() {
 test_run_dir() {
     local dir="${1:-tests}" file
     for file in "$dir"/*_test.sh; do
-        [[ -f "$file" ]] || continue
+        [ -f "$file" ] || continue
         log_step "${file##*/}"
         test_run "$file"
     done
@@ -323,12 +364,15 @@ test_run_dir() {
 # Also the end of the run, so the mark file goes here. A trap would fire on
 # every subshell exit as well, and there is exactly one place the run is over.
 test_summary() {
-    [[ -n "${_TEST_MARK_DIR:-}" ]] && rm -rf "$_TEST_MARK_DIR"
+    [ -n "${_TEST_MARK_DIR:-}" ] && rm -rf "$_TEST_MARK_DIR"
     printf '\n'
-    if [[ "$_TEST_FAILED" -gt 0 ]]; then
-        local f
-        for f in "${_TEST_FAILURES[@]}"; do
+    if [ "$_TEST_FAILED" -gt 0 ]; then
+        local f _tf_i=0 _tf_n
+        _tf_n="$(list_len _TEST_FAILURES)"
+        while [ "$_tf_i" -lt "$_tf_n" ]; do
+            f="$(list_get _TEST_FAILURES "$_tf_i")"
             log_tagged "FAILED" red "$f"
+            _tf_i=$(( _tf_i + 1 ))
         done
         log_error "${_TEST_FAILED} failed, ${_TEST_PASSED} passed"
         return 1

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -307,7 +307,7 @@ EOF
         local tally why=""
         tally="$(cat "$_TEST_MARK" 2>/dev/null)"
         rc=0
-        _has_z=0; case "$tally" in *z*) _has_z=1 ;; esac
+        local _has_z=0; case "$tally" in *z*) _has_z=1 ;; esac
         if [ "$_has_z" -eq 0 ]; then
             # What the marker actually held, because "did not finish" alone is
             # not diagnosable and this has fired intermittently on tests that
@@ -370,7 +370,7 @@ test_summary() {
         local f _tf_i=0 _tf_n
         _tf_n="$(list_len _TEST_FAILURES)"
         while [ "$_tf_i" -lt "$_tf_n" ]; do
-            f="$(list_get _TEST_FAILURES "$_tf_i")"
+            list_read f _TEST_FAILURES "$_tf_i"
             log_tagged "FAILED" red "$f"
             _tf_i=$(( _tf_i + 1 ))
         done

--- a/lib/toml/write.sh
+++ b/lib/toml/write.sh
@@ -18,6 +18,11 @@
 [ -n "${_NUTSHELL_TOML_WRITE_SH:-}" ] && return 0
 _NUTSHELL_TOML_WRITE_SH=1
 
+# `str_replace` with an out-name, for the escaping below. This file carried its
+# own copy of that loop, as did `json.sh` and `extern.sh`; one of the three then
+# diverged and shipped an injection hole that the other two did not have.
+use string
+
 # The control characters a basic string escapes, as themselves. Built once,
 # because there is no `$'\n'` here to write one inline with. The trailing `.`
 # is because command substitution strips trailing newlines and the newline is
@@ -97,31 +102,6 @@ _tw_is_key() {
 _tw_has_content() {
     case "$1" in *[!" "]*) return 0 ;; esac
     return 1
-}
-
-# Every occurrence of one string swapped for another, into the named variable.
-# There is no `${x//a/b}` here.
-_tw_gsub() {
-    # An empty needle matches everywhere and the loop never shortens the
-    # remainder, so it appends forever. `str_replace` guards this on its first
-    # line and this copy did not, which is the cost of the second copy.
-    [ -n "$2" ] || { eval "$4=\$1"; return 0; }
-    # The out-name reaches `eval`, so it is checked the way every other
-    # out-name in this library is: `_json_gsub a b c 'v; echo X'` ran the echo.
-    case "$4" in
-        ''|*[!A-Za-z0-9_]*|[0-9]*) return 2 ;;
-    esac
-    _tw_rest="$1"; _tw_acc=""
-    while :; do
-        case "$_tw_rest" in
-            *"$2"*)
-                _tw_acc="${_tw_acc}${_tw_rest%%"$2"*}$3"
-                _tw_rest="${_tw_rest#*"$2"}"
-                ;;
-            *) break ;;
-        esac
-    done
-    eval "$4=\${_tw_acc}\${_tw_rest}"
 }
 
 # A run of digits, with an optional leading minus, and at least one digit.
@@ -291,13 +271,13 @@ _toml_write_value() {
         "["*"]")    printf '%s' "$_twv"; return 0 ;;
     esac
     # Backslash first. Any other order escapes the backslashes this step adds.
-    _tw_gsub "$_twv" '\' '\\' _twv_esc
-    _tw_gsub "$_twv_esc" '"' '\"' _twv_esc
-    _tw_gsub "$_twv_esc" "$_TW_NL" '\n' _twv_esc
-    _tw_gsub "$_twv_esc" "$_TW_CR" '\r' _twv_esc
-    _tw_gsub "$_twv_esc" "$_TW_TAB" '\t' _twv_esc
-    _tw_gsub "$_twv_esc" "$_TW_BS" '\b' _twv_esc
-    _tw_gsub "$_twv_esc" "$_TW_FF" '\f' _twv_esc
+    str_replace "$_twv" '\' '\\' _twv_esc
+    str_replace "$_twv_esc" '"' '\"' _twv_esc
+    str_replace "$_twv_esc" "$_TW_NL" '\n' _twv_esc
+    str_replace "$_twv_esc" "$_TW_CR" '\r' _twv_esc
+    str_replace "$_twv_esc" "$_TW_TAB" '\t' _twv_esc
+    str_replace "$_twv_esc" "$_TW_BS" '\b' _twv_esc
+    str_replace "$_twv_esc" "$_TW_FF" '\f' _twv_esc
     printf '"%s"' "$_twv_esc"
 }
 

--- a/tests/checkcache_test.sh
+++ b/tests/checkcache_test.sh
@@ -409,13 +409,18 @@ it_reads_a_real_mtime_and_size_through_whichever_stat_it_picked() {
     _stat_stub "$d" gnu
     printf '0123456789' > "$d/probe.txt"
 
+    # Read through the module's own reader rather than into whatever it keeps
+    # the stamps in. This asserted on the internal `_NUT_CACHE_STAMP` array and
+    # broke the moment the store became a `map`, on a change that altered
+    # nothing about the answer. The note is here rather than inside the quoted
+    # program below, where an apostrophe ends the quoting.
     local got
     got="$(bash -c '
         PATH="$1"; export PATH
         . "$2"/init || exit 1
         use checkcache
         _nut_cache_stat_into "$3"
-        printf "%s" "${_NUT_CACHE_STAMP[$3]:-}"
+        _nut_cache_stamp_of "$3"
     ' _ "$d" "$NUTSHELL_ROOT" "$d/probe.txt" 2>/dev/null)"
 
     assert_ne "$got" ""

--- a/tests/extern_test.sh
+++ b/tests/extern_test.sh
@@ -541,29 +541,36 @@ it_remembers_a_resolved_path() {
     # Every `use <dep>::<module>` resolved the dependency again: manifest
     # re-read, lockfile re-read, git asked twice. None of it can change while a
     # script runs, and five modules out of one library cost it five times.
-    _EXTERN_RESOLVED=()
-    _EXTERN_RESOLVED[fixture]="/tmp"
+    # Through the module's own accessors rather than into whatever it keeps
+    # the memo in. These reached into `_EXTERN_RESOLVED[...]` directly and
+    # broke the moment that became a `map`, on a change that altered nothing
+    # about the answer.
+    map_clear _EXTERN_RESOLVED
+    map_set _EXTERN_RESOLVED fixture "/tmp"
     _extern_is_repo() { return 0; }
     assert_eq "$(extern_path fixture)" "/tmp"
 }
 
 #[test]
 it_forgets_one_name_when_asked() {
-    _EXTERN_RESOLVED=()
-    _EXTERN_RESOLVED[a]="/tmp/a"
-    _EXTERN_RESOLVED[b]="/tmp/b"
+    map_clear _EXTERN_RESOLVED
+    map_set _EXTERN_RESOLVED a "/tmp/a"
+    map_set _EXTERN_RESOLVED b "/tmp/b"
     extern_forget a
-    assert_empty "${_EXTERN_RESOLVED[a]:-}"
-    assert_eq "${_EXTERN_RESOLVED[b]:-}" "/tmp/b"
+    local va="" vb=""
+    map_read va _EXTERN_RESOLVED a
+    map_read vb _EXTERN_RESOLVED b
+    assert_empty "$va"
+    assert_eq "$vb" "/tmp/b"
 }
 
 #[test]
 it_forgets_everything_when_given_no_name() {
-    _EXTERN_RESOLVED=()
-    _EXTERN_RESOLVED[a]="/tmp/a"
-    _EXTERN_RESOLVED[b]="/tmp/b"
+    map_clear _EXTERN_RESOLVED
+    map_set _EXTERN_RESOLVED a "/tmp/a"
+    map_set _EXTERN_RESOLVED b "/tmp/b"
     extern_forget
-    assert_eq "${#_EXTERN_RESOLVED[@]}" "0"
+    assert_eq "$(map_len _EXTERN_RESOLVED)" "0"
 }
 
 #[test]
@@ -571,11 +578,13 @@ it_does_not_hand_back_a_checkout_that_has_gone() {
     # A cached path whose checkout was removed is worse than no cache: the
     # caller gets a directory git will not answer for, and no explanation.
     # It must fall through and resolve again rather than returning it.
-    _EXTERN_RESOLVED=()
-    _EXTERN_RESOLVED[fixture]="/tmp/definitely-not-a-checkout"
+    map_clear _EXTERN_RESOLVED
+    map_set _EXTERN_RESOLVED fixture "/tmp/definitely-not-a-checkout"
     _extern_is_repo() { return 1; }
     extern_path fixture >/dev/null 2>&1 || true
-    assert_empty "${_EXTERN_RESOLVED[fixture]:-}"
+    local v=""
+    map_read v _EXTERN_RESOLVED fixture
+    assert_empty "$v"
 }
 
 # --- how a module path is spelled ----------------------------------------------

--- a/tests/json_test.sh
+++ b/tests/json_test.sh
@@ -280,31 +280,3 @@ it_escapes_a_lone_backslash_exactly_once() {
     local got; got="$(json_object k '\')"
     assert_eq "$got" '{"k":"\\"}'
 }
-
-#[test]
-# `_json_gsub` refuses an out-name that is not one, and does not hang.
-#
-# Both were real. An empty search string matches everywhere and never shortens
-# the remainder, so the loop appended forever; `str_replace` guards that on its
-# first line and this copy did not. And the out-name goes into an `eval`, so
-# `_json_gsub a b c 'v; echo X'` ran the echo.
-it_refuses_a_bad_out_name_and_an_empty_needle() {
-    local out=SENTINEL
-    # An empty needle returns the subject unchanged rather than looping.
-    assert_ok _json_gsub "abc" "" "X" out
-    assert_eq "$out" "abc"
-
-    # A name that is not a name is refused before it reaches `eval`.
-    assert_fails _json_gsub "abc" "b" "Z" 'v; echo INJECTED'
-    assert_fails _json_gsub "abc" "b" "Z" '1bad'
-    assert_fails _json_gsub "abc" "b" "Z" ''
-
-    # And nothing it refused was executed.
-    local out2; out2="$(_json_gsub "abc" "b" "Z" 'v; echo INJECTED' 2>&1)"
-    assert_not_contains "$out2" "INJECTED"
-
-    # The control: an ordinary call still works.
-    local ok=""
-    assert_ok _json_gsub "abc" "b" "Z" ok
-    assert_eq "$ok" "aZc"
-}

--- a/tests/priv_test.sh
+++ b/tests/priv_test.sh
@@ -524,3 +524,52 @@ it_names_doas_when_it_cannot_step_down_at_all() {
     # The message lists what it looked for, so a reader knows what to install.
     assert_contains "$err" "doas"
 }
+
+# A POSIX shell to check against, or nothing.
+_pt_posix_sh() {
+    local cand f; f="$(mktemp)"; printf 'declare -A x\n' > "$f"
+    for cand in dash ash yash busybox-sh; do
+        command -v "$cand" >/dev/null 2>&1 || continue
+        "$cand" -c ". '$f'" >/dev/null 2>&1 || { rm -f "$f"; printf '%s' "$cand"; return 0; }
+    done
+    rm -f "$f"; return 1
+}
+
+#[test]
+# It runs under a POSIX shell, not merely parses there.
+#
+# The distinction is the whole point of the floor work: `[[ -n x ]]` is a
+# command name and three arguments to a POSIX shell, so it reads anywhere and
+# then reports `[[: not found`, and `declare -g` is not found and carries on
+# with the variable never set. Neither is a parse error.
+#
+# So the assertion is that the module answers, and answers the same as it does
+# under bash. `priv_user_home` is the one worth asserting: it used to read the
+# passwd line into `local -a f=($line)` and take `${f[5]}`, which needs an
+# array and a per-command `IFS` a POSIX shell has neither of.
+it_runs_under_a_posix_shell() {
+    local sh; sh="$(_pt_posix_sh)" || { skip "no strict POSIX shell here"; return 0; }
+    local root="${BASH_SOURCE[0]%/*}/.."
+
+    # Not piped. Sourcing through a pipe puts it in a subshell and every
+    # function defined dies with it, which reads exactly like the module
+    # failing to load.
+    local probe='
+        use() { return 0; }
+        log_error() { :; }
+        . "$1"/lib/priv.sh || exit 1
+        printf "%s|%s|" "$PRIV_USER" "$(priv_user_home)"
+        priv_is_root && printf "root" || printf "notroot"
+    '
+    local got want
+    got="$("$sh" -c "$probe" _ "$root" 2>&1)"
+    want="$(bash -c "$probe" _ "$root" 2>&1)"
+
+    assert_not_contains "$got" "not found"
+    assert_not_contains "$got" "Bad substitution"
+    assert_ne "$got" ""
+    assert_eq "$got" "$want"
+
+    # And the field cut actually found a home rather than an empty string.
+    assert_not_contains "$got" "||"
+}

--- a/tests/priv_test.sh
+++ b/tests/priv_test.sh
@@ -573,3 +573,47 @@ it_runs_under_a_posix_shell() {
     # And the field cut actually found a home rather than an empty string.
     assert_not_contains "$got" "||"
 }
+
+#[test]
+# A quoted word survives being handed to a shell and read back.
+#
+# `_priv_sq` builds the argument list for `su -c`, which is a string a second
+# shell parses, so the only thing that matters is that what comes out the far
+# side is what went in. It was `${s//\'/...}`, which is bash's; the walk that
+# replaces it is easy to get subtly wrong in a way only an odd input shows.
+it_quotes_a_word_so_a_shell_reads_it_back_unchanged() {
+    local v got
+    for v in "plain" "it's" "a b" "'" "" "a'b'c" '$(echo PWNED)' '`echo PWNED2`' \
+             'back\slash' 'new
+line' '*' '~' '"' ; do
+        got="$(eval "printf '%s' $(_priv_sq "$v")")"
+        assert_eq "$got" "$v" "quoting did not survive a round trip for [${v}]"
+    done
+}
+
+#[test]
+# Nothing inside a quoted word is executed on the way through.
+#
+# The round trip above would pass on an input that ran and produced itself, so
+# this asserts on the side effect rather than the value.
+it_does_not_let_a_quoted_word_run_anything() {
+    local d; d="$(mktemp -d)"
+    local marker="$d/ran"
+
+    # A side effect, not the text. The first version of this asserted the
+    # output did not contain "PWNED", which fails on correct quoting: the word
+    # comes back as the literal `$(echo PWNED)`, and that string contains
+    # "PWNED". The assertion could not tell a working quote from a broken one.
+    eval "printf '%s' $(_priv_sq "\$(touch '$marker')")" >/dev/null 2>&1
+    assert_fails test -e "$marker"
+
+    eval "printf '%s' $(_priv_sq "\`touch '$marker'\`")" >/dev/null 2>&1
+    assert_fails test -e "$marker"
+
+    # The control: the same eval does run something when it is not quoted, so
+    # the two above are not passing because nothing was ever executed.
+    eval "printf '%s' \"\$(touch '$marker')\"" >/dev/null 2>&1
+    assert_ok test -e "$marker"
+
+    rm -rf "$d"
+}

--- a/tests/string_posix_parity_test.sh
+++ b/tests/string_posix_parity_test.sh
@@ -186,3 +186,79 @@ it_does_not_define_split_on_the_floor() {
     out="$(bash -c 'nut_once() { return 0; }; . "$1" >/dev/null 2>&1; command -v str_split >/dev/null && echo there || echo ABSENT' _ "$BASHFILE" 2>&1)"
     assert_eq "$out" "there"
 }
+
+#[test]
+# The out-name form, which is why three modules stopped keeping their own copy
+# of this loop.
+#
+# `json.sh`, `toml/write.sh` and `extern.sh` each grew a private `_x_gsub`
+# because the printing form costs a fork per call and strips a trailing
+# newline. Then one of the three diverged and shipped an injection hole the
+# other two did not have, which is what a fourth copy buys you.
+#
+# Driven through the same two shells as everything else here, because an
+# out-name has to work on both halves or a caller works on one shell and not
+# the other.
+it_answers_into_a_named_variable_in_both_halves() {
+    local sh; sh="$(_sp_shell)" || { skip "no posix shell here"; return 0; }
+    local probe='
+        . "$1" >/dev/null 2>&1
+        out=""
+        str_replace "a,b,c" "," "-" out
+        printf "[%s]" "$out"
+        out=""
+        str_replace "abc" "" "X" out
+        printf "[%s]" "$out"
+    '
+    local b p
+    b="$(bash -c "nut_once() { return 0; }; $probe" _ "$BASHFILE" 2>/dev/null)"
+    p="$("$sh" -c "$probe" _ "$POSIXFILE" 2>/dev/null)"
+    assert_eq "$b" "[a-b-c][abc]"
+    assert_eq "$p" "$b"
+}
+
+#[test]
+# The out-name is validated before either exit, because both reach `eval`.
+#
+# The empty-needle shortcut sat *above* the validation in the private copies,
+# so it ran the name unvalidated. The ordinary path refused correctly the whole
+# time, which is why a test that only tried a bad name with a real needle said
+# everything was fine.
+it_refuses_a_bad_out_name_on_both_exits() {
+    local sh; sh="$(_sp_shell)" || { skip "no posix shell here"; return 0; }
+    local d; d="$(mktemp -d)"
+    local probe='
+        . "$1" >/dev/null 2>&1
+        str_replace "abc" "b" "Z" "v; touch '"'"'$2/nonempty'"'"'" ; printf "%s," "$?"
+        str_replace "abc" ""  "Z" "v; touch '"'"'$2/empty'"'"'"    ; printf "%s"  "$?"
+    '
+    local b p
+    b="$(bash -c "nut_once() { return 0; }; $probe" _ "$BASHFILE" "$d" 2>/dev/null)"
+    assert_eq "$b" "2,2"
+    assert_fails test -e "$d/nonempty"
+    assert_fails test -e "$d/empty"
+
+    rm -f "$d"/*
+    p="$("$sh" -c "$probe" _ "$POSIXFILE" "$d" 2>/dev/null)"
+    assert_eq "$p" "2,2"
+    assert_fails test -e "$d/nonempty"
+    assert_fails test -e "$d/empty"
+    rm -rf "$d"
+}
+
+#[test]
+# A replacement containing backslashes survives, in both halves.
+#
+# The bash half had `${str//"$from"/$to}` with the replacement unquoted, so it
+# went through quote removal and `\\` collapsed to `\`: it answered `\` where
+# the floor half answered `\\`. It sat undetected because every caller kept its
+# own copy of the loop, and surfaced the moment they stopped.
+#
+# The escapers in `json.sh` and `toml/write.sh` double a backslash as their
+# first step, so this is the exact shape they depend on.
+it_replaces_with_a_backslash_the_same_way_in_both_halves() {
+    local sh; sh="$(_sp_shell)" || { skip "no posix shell here"; return 0; }
+    _same "$sh" str_replace "a" "a" '\\'
+    _same "$sh" str_replace 'x\y' '\' '\\'
+    _same "$sh" str_replace 'a\b"c' '\' '\\'
+}

--- a/tests/test_test.sh
+++ b/tests/test_test.sh
@@ -114,3 +114,35 @@ it_says_how_far_a_test_got_before_it_stopped() {
     assert_contains "$out" "stopped part way"
     assert_contains "$out" "'a'"
 }
+
+#[test]
+# The pass and fail counters are numbers, not strings.
+#
+# They were `declare -gi`, and dropping that attribute during the floor work
+# turned `_TEST_PASSED+=1` from addition into concatenation: six passing tests
+# reported as `0111111 passed`. The suite still said OK, so nothing failed and
+# every number the harness printed was nonsense.
+#
+# Asserted through a nested run, because the counters belong to the run that
+# owns them and this one is inside a run of its own.
+it_counts_passes_as_a_number() {
+    local d; d="$(mktemp -d)"
+    {
+        printf 'use test\n'
+        printf '#%s\n' '[test]'
+        printf 'it_one() { assert_eq 1 1; }\n'
+        printf '#%s\n' '[test]'
+        printf 'it_two() { assert_eq 2 2; }\n'
+        printf '#%s\n' '[test]'
+        printf 'it_three() { assert_eq 3 3; }\n'
+    } > "$d/zz_count_test.sh"
+
+    local out
+    out="$(env -u _TEST_MARK_DIR -u _TEST_MARK -u TEST_FILTER \
+        "${NUTSHELL_ROOT}/test" "$d/zz_count_test.sh" 2>&1)"
+    rm -rf "$d"
+
+    # Three, not `0111`.
+    assert_contains "$out" "3 passed"
+    assert_not_contains "$out" "0111"
+}

--- a/tests/toml_write_test.sh
+++ b/tests/toml_write_test.sh
@@ -541,25 +541,3 @@ it_parses_under_a_posix_shell() {
     done
     skip "no strict POSIX shell on this machine to check against"
 }
-
-#[test]
-# The same two guards on `_tw_gsub`, which is the second copy of the loop.
-#
-# Kept as a separate test in a separate file on purpose: the copies drifted
-# once already, since `json.sh` cites `str_replace` by name while writing the
-# loop again without its empty-needle guard.
-it_refuses_a_bad_out_name_and_an_empty_needle() {
-    local out=SENTINEL
-    assert_ok _tw_gsub "abc" "" "X" out
-    assert_eq "$out" "abc"
-
-    assert_fails _tw_gsub "abc" "b" "Z" 'v; echo INJECTED'
-    assert_fails _tw_gsub "abc" "b" "Z" '1bad'
-
-    local out2; out2="$(_tw_gsub "abc" "b" "Z" 'v; echo INJECTED' 2>&1)"
-    assert_not_contains "$out2" "INJECTED"
-
-    local ok=""
-    assert_ok _tw_gsub "abc" "b" "Z" ok
-    assert_eq "$ok" "aZc"
-}


### PR DESCRIPTION
Five of the eighteen that a POSIX shell could not parse. The check's own number
goes 19 to 10 of 40, with four more behind `#[shell(bash4)]` where they belong.

## The one worth reading

`lib/test.sh` is the harness itself, and dropping `declare -gi` from its
counters broke them silently. Without the integer attribute `_TEST_PASSED+=1`
is string concatenation, not addition, so six passing tests reported as
`0111111 passed` and the suite still said `[OK]`. Nothing failed. No error, no
bad exit status, every number it printed nonsense.

That is the whole class this pass is about, and it is the fourth one today:
`printf -v` leaves a variable empty and carries on, `echo -e` prints its own
flag, `nut_once` makes a module define nothing while reporting success. None of
them is a parse error. All of them are a wrong answer with a zero exit status.

## The rest

`priv.sh` read the passwd line into `local -a f=($line)` with a per-command
`IFS`. Cut to the field instead.

`checkcache.sh` kept its stamps in an associative array and walked `stat`
output through `done < <(...)`. The stamps are a `map` now, and the loop cannot
go on the right of a pipe because its body calls `map_set`: a subshell would
record every stamp somewhere that dies when the loop ends and the cache would
never fill.

`extern.sh` had three of those loops, two of which `return` from the function
on a match. On the right of a pipe that returns from the subshell and the
function carries on past the answer it had already found.

`prompt.sh` is **gated rather than converted**, and the manifest says why at
length. Seven of its reads use `read -rsn1`, `read -rsn2 -t 0.1` and `read -t`,
and POSIX `read` has none of `-s`, `-n` or `-t`. The `-t 0.1` tells an escape
keypress from the start of an escape sequence, which is the same wall
`tui::key` hit in the-whole-shebang.

The gate is honest and it is not the whole answer, which the manifest also
says: most of that module is line-based prompting that is ordinary POSIX, and
only the menu cursor and the countdown need the flags. A POSIX-only machine
gets no prompting where it could have most of it. Filed as wanting the pair
`map`, `list` and `string` already have.

`_priv_sq` is new-ish and quotes a word for `su -c`, so a second shell parses
it and the only property that matters is that what comes out is what went in.

## Sanity

736 tests, up from 727. The ones I would defend: the counter test runs three
passing cases through a nested harness and asserts `3 passed`, and putting
`+=` back makes the failure line itself read `0111111 passed`. `priv.sh` has a
test that it *runs* under dash rather than parses there, comparing all its
answers against bash, and it dies if the array goes back.

The quoting test needed correcting and the correction is the interesting part.
It first asserted the output did not contain `PWNED`, which fails on *correct*
quoting: the word comes back as the literal `$(echo PWNED)` and that string
contains the text. The assertion could not tell a working quote from a broken
one. It watches for a file now, with a control that runs the same eval
unquoted so the two refusals are not passing because nothing ever executed.

Two tests in `checkcache` and four in `extern` were reaching into the modules'
own storage and broke the moment that storage changed, on changes that altered
nothing about the answer. They read through the accessors now. That is the
third repo today with the same coupling.

## Not in here

`bench.sh` was attempted and reverted. Six C-style loops, two carrying a
`continue`, so a mechanical rewrite to `while` puts the increment where the
`continue` skips it; the first attempt produced infinite loops. It is filed
along with the question of whether the dev tooling belongs on the floor at all,
since `bench.sh`, `check-runner.sh` and `modgraph.sh` run where you develop
rather than where the floor matters.

`srcfile.sh` still wants a `.bash.sh` pair rather than a conversion: its
associative arrays are the checker's hot path and a POSIX map would make
`./check` slower.