### PR TITLE
chore: version 0.7.0

### DIFF
--- a/nut.toml
+++ b/nut.toml
@@ -62,7 +62,7 @@ bash = []
 # cargo's shape, and `[bin]` is a map the way package.json's is.
 [package]
 name = "nutshell"
-version = "0.6.3"
+version = "0.7.0"
 description = "A bash library: modules with a manifest, a QA gate, and dependency resolution."
 license = "MPL-2.0"
 repository = "https://github.com/orgrinrt/nutshell"


### PR DESCRIPTION
Bumps `[package] version` for the release. `init` reads it from the manifest, so nothing else carries the number.